### PR TITLE
Suppression de logs inutiles dans le script de déploiement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,9 +115,6 @@ jobs:
       # Build client with Sapper
       - name: Build client
         run: |
-          ls -la generated
-          ls -la generated/data
-          ls -la generated/models
           npm install
           npm run export
         working-directory: ${{env.working-directory}}


### PR DESCRIPTION
## Description

Cette PR retire des logs avec des `ls -la` qui me servait pour debugger le CI. Ces logs ne servent plus et en plus, ils cassent le déploiement vu qu'on a déplacé le dossier `generated` à la racine du repo maintenant -_- : https://github.com/betagouv/territoires-en-transitions/runs/2720187988?check_suite_focus=true