### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## À venir
 
-Fonctionnalités :
--  Ajout de Matomo pour suivre les statistiques d'usage de l'application
+## Déploiement du 4 juin 2021
 
-Réparation de bugs :
--
+Fonctionnalités :
+- Activation de l'affichage des référentiels par leur structure en production
+- Ajout de Matomo pour suivre les statistiques d'usage de l'application
+- Ajout de 3 indicateurs ECI
 
 ## Déploiement du 1er juin 2021
 


### PR DESCRIPTION
## Description

Cette PR met à jour le CHANGELOG suite au déploiement du 4 juin 2021. On met le CHANGELOG à jour manuellement via une PR sur `main` pour l'instant, en attendant une meilleure solution.