### PR TITLE
Restriction de l'appel à Matomo uniquement pour la production

### DIFF
--- a/app.territoiresentransitions.fr/src/utils/logger.js
+++ b/app.territoiresentransitions.fr/src/utils/logger.js
@@ -1,0 +1,4 @@
+export const debug = (message) => {
+    const hostname = window ? window.location.hostname : ''
+    console.log('%c %s', 'color: grey', `>> DEBUG ${hostname}: ${message}`)
+}


### PR DESCRIPTION
## Description 

Cette PR restreint l'appel de Matomo à l'environnement de production. Au passage, j'en profite pour faire le retour de ce commentaire : https://github.com/betagouv/territoires-en-transitions/pull/132#discussion_r643056221 ainsi que pour ajouter un petit utilitaire de debug.