### PR TITLE
Réparation de la navigation avec Sapper

### DIFF
--- a/app.territoiresentransitions.fr/src/components/shared/ActionReferentiel/ActionReferentielCard.svelte
+++ b/app.territoiresentransitions.fr/src/components/shared/ActionReferentiel/ActionReferentielCard.svelte
@@ -4,6 +4,7 @@
      *
      * Display is customizable using props such as: ficheButton, link, emoji...
      */
+    import { goto } from '@sapper/app'
     import ActionStatus from "../ActionStatus.svelte";
     import {ActionReferentiel} from "../../../../../generated/models/action_referentiel";
     import {onMount} from "svelte";
@@ -116,7 +117,7 @@
                    rel="prefetch"
                    class="flex flex-grow">
                     <ActionReferentielTitle
-                            on:click={() => window.location.href = `/actions_referentiels/${mesureId}/?epci_id=${epciId}#${action.id}`}
+                            on:click={() => goto(`/actions_referentiels/${mesureId}/?epci_id=${epciId}#${action.id}`)}
                             action={action} emoji={emoji}/>
                 </a>
             {:else if expandButton && (action.actions.length || action.description.trim().length) }

--- a/app.territoiresentransitions.fr/src/components/shared/Nav/Nav.svelte
+++ b/app.territoiresentransitions.fr/src/components/shared/Nav/Nav.svelte
@@ -6,12 +6,21 @@
     import {testUIVisibility} from "../../../api/currentEnvironment";
     import NavSignedIn from "./NavSignedIn.svelte";
     import NavSignedOut from "./NavSignedOut.svelte";
+    import {getCurrentEpciId} from '../../../api/currentEpci'
 
     export let segment // Type string. Typing this variable makes sapper crash.
 
     let showTestNavigation = false
+    let epciId = ''
+
+    const isLogged = segment && segment !== 'connexion'
     onMount(async () => {
         showTestNavigation = testUIVisibility()
+        try {
+            epciId = getCurrentEpciId()
+        } catch (e) {
+            // not signed in, it's fine
+        }
     });
 </script>
 
@@ -21,9 +30,20 @@
     {/await}
 {/if}
 
-{#if segment && segment !== 'connexion'}
-    <NavSignedIn/>
-{:else }
-    <NavSignedOut/>
-{/if}
+<nav class="bg-seagreen-400">
+    <ul class="container mx-auto lg:px-20 px-4 p-4 flex text-xl">
+        <li class={ !isLogged ? 'mr-4 flex-grow' : 'mr-4' }>
+            <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
+               href="/?epci_id={epciId}">
+                Territoires en Transitions
+            </a>
+        </li>
+
+        {#if isLogged}
+            <NavSignedIn/>
+        {:else }
+            <NavSignedOut/>
+        {/if}
+    </ul>
+</nav>
 

--- a/app.territoiresentransitions.fr/src/components/shared/Nav/NavSignedIn.svelte
+++ b/app.territoiresentransitions.fr/src/components/shared/Nav/NavSignedIn.svelte
@@ -15,35 +15,25 @@
         }
     });
 </script>
-<nav class="bg-seagreen-400">
-    <ul class="container mx-auto lg:px-20 px-4 p-4 flex text-xl">
-        <li class="mr-4">
-            <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
-               href="/?epci_id={epciId}">
-                Territoires en Transitions
-            </a>
-        </li>
 
-        <li class="mr-4 flex-grow text-center">
-            <EpciNavDisplay/>
-        </li>
-        <li class="mr-4">
-            <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
-               href="fiches/?epci_id={epciId}">
-                Plan d'actions
-            </a>
-        </li>
-        <li class="mr-4">
-            <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
-               href="actions_referentiels/?epci_id={epciId}">
-                Référentiels
-            </a>
-        </li>
-        <li class="mr-4">
-            <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
-               href="indicateurs/?epci_id={epciId}">
-                Indicateurs
-            </a>
-        </li>
-    </ul>
-</nav>
+<li class="mr-4 flex-grow text-center">
+    <EpciNavDisplay/>
+</li>
+<li class="mr-4">
+    <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
+       href="fiches/?epci_id={epciId}">
+        Plan d'actions
+    </a>
+</li>
+<li class="mr-4">
+    <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
+       href="actions_referentiels/?epci_id={epciId}">
+        Référentiels
+    </a>
+</li>
+<li class="mr-4">
+    <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
+       href="indicateurs/?epci_id={epciId}">
+        Indicateurs
+    </a>
+</li>

--- a/app.territoiresentransitions.fr/src/components/shared/Nav/NavSignedOut.svelte
+++ b/app.territoiresentransitions.fr/src/components/shared/Nav/NavSignedOut.svelte
@@ -13,25 +13,12 @@
         }
     });
 </script>
-<nav class="bg-seagreen-400">
-    <ul class="container mx-auto lg:px-20 px-4 p-4 flex text-xl">
-        <li class="mr-4">
-            <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
-               href="/?epci_id={epciId}">
-                Territoires en Transitions
-            </a>
-        </li>
 
-        <li class="mr-4 flex-grow">
-        </li>
-
-        {#if !segment}
-            <li class="mr-4">
-                <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
-                   href="connexion/?epci_id={epciId}">
-                    Se connecter
-                </a>
-            </li>
-        {/if}
-    </ul>
-</nav>
+{#if !segment}
+    <li class="mr-4">
+        <a class="p-1 rounded hover:bg-gray-100 hover:text-gray-700 focus:bg-gray-100 focus:text-gray-700 active:text-gray-900 active:shadow-inner active:bg-white"
+           href="connexion/?epci_id={epciId}">
+            Se connecter
+        </a>
+    </li>
+{/if}


### PR DESCRIPTION
## Description

cf. #162

Après investigation, il semblerait que les éléments ne s'affichaient pas correctement au bon endroit car Sapper ne sait pas quoi rafraichir. C'est dû à : 
- un souci avec `window.location.href` qui doit interférer avec le state de Sapper,
- un souci avec des éléments de layouts qui ont un élément HTML dynamique pour racine.