### PR TITLE
Changement de la valeur par défaut d'une action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Réparations de bugs :
 - Restriction de l'appel à Matomo uniquement pour la production
+- Changement de la valeur par défaut d'une action (de `pas_faite` à non
+  renseignée)
 
 ## Déploiement du 4 juin 2021
 

--- a/app.territoiresentransitions.fr/src/components/shared/ActionStatus.svelte
+++ b/app.territoiresentransitions.fr/src/components/shared/ActionStatus.svelte
@@ -44,7 +44,7 @@
         'border-t border-r border-b rounded-r flex-1 block whitespace-nowrap px-2 py-1 cursor-pointer border-gray-400',
     ]
 
-    let actionAvancementKey = 'pas_faite';
+    let actionAvancementKey = '';
 
     let epci_id = ''
 


### PR DESCRIPTION
## Description

cf. #108 

Cette PR change la valeur par défaut d'une action, de `pas_faite` à non renseignée.