### PR TITLE
Ajout de la majuscule sur le nom des domaines CAE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Réparations de bugs :
 - Restriction de l'appel à Matomo uniquement pour la production
+- Ajout de la majuscule sur le nom des domaines CAE
 
 ## Déploiement du 4 juin 2021
 

--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionsClimatAirEnergie.svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionsClimatAirEnergie.svelte
@@ -49,7 +49,7 @@
 
 
 {#each [...displayedByDomaine] as [domaine, sous_domaines]}
-    <h2 class="text-2xl font-bold mt-10 mb-2">{domaine.nom.toLowerCase()}</h2>
+    <h2 class="text-2xl font-bold mt-10 mb-2">{domaine.nom}</h2>
     {#each [...sous_domaines] as [sous_domaine, actions]}
         <h3 class="text-2xl mt-10 mb-2">{sous_domaine.nom}</h3>
         {#each actions as action}


### PR DESCRIPTION
## Description

Cette PR est liée à #158 qui passe le nom des domaines en minuscules (au lieu des SCREAMING CAPS) et du coup, côté front, on retire le forcing sur le formattage en minuscule.