### PR TITLE
Ajout de l'identifiant pour les axes ECI, les domaines et sous-domaines CAE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## À venir
 
+Fonctionnalités :
+- Ajout de l'identifiant pour les axes ECI, les domaines et sous-domaines CAE
+
 Réparations de bugs :
 - Restriction de l'appel à Matomo uniquement pour la production
 

--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionsClimatAirEnergie.svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionsClimatAirEnergie.svelte
@@ -49,9 +49,9 @@
 
 
 {#each [...displayedByDomaine] as [domaine, sous_domaines]}
-    <h2 class="text-2xl font-bold mt-10 mb-2">{domaine.nom.toLowerCase()}</h2>
+    <h2 class="text-2xl font-bold mt-10 mb-2">{domaine.id_nomenclature}. {domaine.nom}</h2>
     {#each [...sous_domaines] as [sous_domaine, actions]}
-        <h3 class="text-2xl mt-10 mb-2">{sous_domaine.nom}</h3>
+        <h3 class="text-2xl mt-10 mb-2">{sous_domaine.id_nomenclature}. {sous_domaine.nom}</h3>
         {#each actions as action}
             {#if searching}
                 <ActionReferentielCard action={action} ficheButton emoji expandButton statusBar/>

--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionsEconomieCirculaire.svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionsEconomieCirculaire.svelte
@@ -38,7 +38,7 @@
 
 
 {#each [...displayedByAxe] as [parent, actions]}
-    <h2 class="text-2xl mt-10 mb-2">{parent.nom}</h2>
+    <h2 class="text-2xl mt-10 mb-2">{parent.id_nomenclature}. {parent.nom}</h2>
     {#each actions as action}
         {#if searching}
             <ActionReferentielCard action={action} ficheButton emoji expandButton statusBar/>


### PR DESCRIPTION
## Description 

cf. #142 

Cette PR ajoute les identifiants des axes ECI et des domaines et sous-domaines CAE dans les pages de référentiels.