### PR TITLE
Tri par identifiant des éléments du référentiel CAE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Réparations de bugs :
 - Restriction de l'appel à Matomo uniquement pour la production
+- Tri par identifiant des éléments du référentiel CAE
 
 ## Déploiement du 4 juin 2021
 

--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionsClimatAirEnergie.svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionsClimatAirEnergie.svelte
@@ -10,6 +10,11 @@
 
     let displayedByDomaine: Map<ActionReferentiel, Map<ActionReferentiel, ActionReferentiel[]>>
 
+    const sortById = (a: ActionReferentiel, b: ActionReferentiel) => {
+        if (a.id_nomenclature > b.id_nomenclature) return 1
+        if (a.id_nomenclature < b.id_nomenclature) return -1
+        return 0
+    }
     const refresh = () => {
         const map = new Map<ActionReferentiel, Map<ActionReferentiel, ActionReferentiel[]>>()
         const mesures: ActionReferentiel[] = []
@@ -26,7 +31,9 @@
                         mesures.push(mesure)
                     }
                 }
+                sousDomaines.sort(sortById)
             }
+            domaines.sort(sortById)
         }
 
         for (let domaine of domaines) {
@@ -37,6 +44,8 @@
                     (mesure) => mesure.id.startsWith(domaine.id)
                         && mesure.id.startsWith(sousDomaine.id)
                 )
+
+                actions.sort(sortById)
                 if (actions.length) domaineMap.set(sousDomaine, actions)
             }
             if (domaineMap.size) map.set(domaine, domaineMap)


### PR DESCRIPTION
## Description

cf. #156 

Cette PR ajoute un tri pour afficher les éléments du référentiel CAE dans l'ordre des domaines et sous-domaines.