### PR TITLE
Ajout de la possibilité de développer l'application client avec l'API de sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Tech :
 - Mise en place des tests end-to-end avec Cypress
+- Ajout de la possibilité de développer l'application client avec l'API de
+  sandbox
 
 ## Déploiement du 11 juin 2021
 

--- a/app.territoiresentransitions.fr/README.md
+++ b/app.territoiresentransitions.fr/README.md
@@ -15,8 +15,6 @@ Territoires en Transitions. Cette application est construite avec
 ## Pré-requis
 
 - Node v15.6.0
-- [API Territoires en Transitions](https://github.com/betagouv/api-label-transition-ecologique)
-  démarrée sur [localhost:8000](http://localhost:8000).
 - [Les fichiers générés par codegen](codegen#le-générateur-de-code)
 
 ## Pour commencer à développer
@@ -30,7 +28,7 @@ npm i
 ### Lancer l'application en local
 
 ```sh
-npm run dev
+npm run dev:sandbox
 ```
 
 L'application va alors se lancer sur [localhost:3000](http://localhost:3000).
@@ -40,8 +38,12 @@ L'application va alors se lancer sur [localhost:3000](http://localhost:3000).
 L'application client communique avec une API pour récupérer certaines données et les mettre à jour. Cette API est
 disponible sur https://github.com/betagouv/api-label-transition-ecologique.
 
-Pour que l'application client fonctionne correctement, on peut s'assurer que l'API est lancée correctement sur
-[localhost:8000](http://localhost:8000).
+On peut développer l'application cliente avec une API lancée en local sur
+[localhost:8000](http://localhost:8000). Pour cela, démarrer l'API, puis pour
+lancer le client :
+```
+npm run dev
+```
 
 ### Lancer la version de production en local
 

--- a/app.territoiresentransitions.fr/package.json
+++ b/app.territoiresentransitions.fr/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "sapper dev",
+    "dev:sandbox": "cross-env USE_SANDBOX_API=1 sapper dev",
     "build": "sapper build",
     "export": "cross-env NODE_ENV=production sapper export",
     "start": "node __sapper__/build",

--- a/app.territoiresentransitions.fr/src/api/currentAPI.ts
+++ b/app.territoiresentransitions.fr/src/api/currentAPI.ts
@@ -1,7 +1,11 @@
 export const getCurrentAPI = (): string => {
-    const hostname = window.location.hostname;
-    if (hostname.substring(0, 10) === 'localhost') return 'http://localhost:8000';
-    if (hostname === 'sandbox.territoiresentransitions.fr') return 'https://sandboxterritoires.osc-fr1.scalingo.io'
+    const sandboxApiUrl = 'https://sandboxterritoires.osc-fr1.scalingo.io'
+    if (process.env.USE_SANDBOX_API) return sandboxApiUrl
+
+    const hostname = window.location.hostname
+    if (hostname.substring(0, 10) === 'localhost') return 'http://localhost:8000'
+    if (hostname === 'sandbox.territoiresentransitions.fr') return sandboxApiUrl
     if (hostname === 'app.territoiresentransitions.fr') return 'https://territoiresentransitions.osc-fr1.scalingo.io'
+
     throw `no API host for ${hostname}`
 }

--- a/app.territoiresentransitions.fr/webpack.config.js
+++ b/app.territoiresentransitions.fr/webpack.config.js
@@ -63,7 +63,8 @@ module.exports = {
 			// dev && new webpack.HotModuleReplacementPlugin(),
 			new webpack.DefinePlugin({
 				'process.browser': true,
-				'process.env.NODE_ENV': JSON.stringify(mode)
+				'process.env.NODE_ENV': JSON.stringify(mode),
+				'process.env.USE_SANDBOX_API': JSON.stringify(process.env.USE_SANDBOX_API),
 			}),
 		].filter(Boolean),
 		devtool: dev && 'inline-source-map'
@@ -108,8 +109,11 @@ module.exports = {
 		},
 		mode,
 		plugins: [
-			new WebpackModules()
-		],
+			new WebpackModules(),
+			new webpack.DefinePlugin({
+				'process.env.USE_SANDBOX_API': JSON.stringify(process.env.USE_SANDBOX_API),
+			}),
+],
 		performance: {
 			hints: false // it doesn't matter if server.js is large
 		}


### PR DESCRIPTION
## Description

Cette PR permet d'utiliser l'API de sandbox lorsque l'on développe l'application cliente en local en passant une variable d'environnement `USE_SANDBOX_API` à la commande `npm run dev`.