### PR TITLE
Ajout des tests end-to-end dans le CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ jobs:
   # This job runs tests in codegen and generated files that are needed by the
   # client application.
   codegen-test-and-generate:
+    name: Tests and artifacts on Codegen
     runs-on: ubuntu-latest
     env:
       python-version: 3.9.1
@@ -95,7 +96,8 @@ jobs:
 
   # This job retrieves previously generated files and builds the client
   # application.
-  client-build:
+  client-build-and-test:
+    name: Build and end-to-end tests on client
     runs-on: ubuntu-latest
     needs: codegen-test-and-generate
     env:
@@ -118,6 +120,13 @@ jobs:
           npm install
           npm run export
         working-directory: ${{env.working-directory}}
+
+      # Use Cypress to run end-to-end tests
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          start: npx serve __sapper__/export -p 3000
+          working-directory: ${{env.working-directory}}
 
       # Upload built client app as an artefact.
       - name: Upload exported client app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,18 @@ jobs:
       - name: Run tests
         run: poetry run pytest
         working-directory: ${{env.working-directory}}
+  end-to-end:
+    runs-on: ubuntu-latest
+    env:
+      working-directory:  ./app.territoiresentransitions.fr
+
+    steps:
+      # cf. https://github.com/actions/checkout
+      - uses: actions/checkout@v2
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          build: npm run export
+          start: npx serve __sapper__/export
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,35 +6,95 @@ on:
       - production
 
 jobs:
-  test-codegen:
+  codegen-test-and-generate:
     runs-on: ubuntu-latest
     env:
+      python-version: 3.9.1
       working-directory: ./codegen
 
     steps:
+      # cf. https://github.com/actions/checkout
       - uses: actions/checkout@v2
-      - name: Set up Python 3.x
+
+      # Restore cache or create a new one for all dependencies installed with
+      # Python.
+      - name: Set up Python cache
+        uses: actions/cache@v2
+        env:
+          python-tools-cache-name: python-tools-cache
+        with:
+          path: /opt/hostedtoolcache/Python
+          key: ${{ runner.os }}-${{ env.python-tools-cache-name }}-${{ env.python-version }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.python-tools-cache-name }}
+            ${{ runner.os }}-
+
+      # Restore cache or create a new one for the binary for Poetry, as Poetry
+      # will check if it is already installed before installing itself.
+      - name: Set up poetry binary cache
+        uses: actions/cache@v2
+        env:
+          poetry-bin-cache-name: poetry-bin
+        with:
+          path: ~/poetry
+          key: ${{ runner.os }}-${{ env.poetry-bin-cache-name }}-${{ hashFiles('codegen/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.poetry-bin-cache-name }}
+            ${{ runner.os }}-
+
+      # Restore cache or create a new one for all dependecies installed by
+      # Poetry.
+      - name: Set up dependencies cache
+        uses: actions/cache@v2
+        env:
+          poetry-cache-name: poetry-dependencies-cache
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-${{ env.poetry-cache-name }}-${{ hashFiles('codegen/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.poetry-cache-name }}-
+            ${{ runner.os }}-
+
+      # cf. https://github.com/actions/setup-python
+      - name: Set up Python 3.9.1
         uses: actions/setup-python@v2
         with:
           python-version: '3.9.1'
 
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-
+      # Install the dependencies manager for codegen.
       - name: Install Poetry
         run: |
-          pip install --upgrade pip
-          pip --no-cache-dir install poetry
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=~/poetry python -
+          echo "$HOME/poetry/bin" >> $GITHUB_PATH
 
+      # Install the dependencies of codegen.
       - name: Install dependencies
         run: poetry install
         working-directory: ${{env.working-directory}}
 
+      # Run all the tests for codegen.
       - name: Run tests
         run: poetry run pytest
         working-directory: ${{env.working-directory}}
+
+      # Generate all JavaScript shared models and data with codegen. These files
+      # are mandatory for the client build.
+      - name: Generate shared models and data in JavaScript
+        run: |
+          poetry run generate all
+        working-directory: ${{env.working-directory}}
+
+      # Upload the generated files as an artefact so they can be download in the
+      # client build job.
+      - name: Upload generated files
+        uses: actions/upload-artifact@v2
+        with:
+          name: generated-client-files
+          path: ${{ github.workspace }}/generated
+
   end-to-end:
     runs-on: ubuntu-latest
+    needs: codegen-test-and-generate
     env:
       working-directory:  ./app.territoiresentransitions.fr
 
@@ -42,9 +102,24 @@ jobs:
       # cf. https://github.com/actions/checkout
       - uses: actions/checkout@v2
 
+      # Download JavaScript models and data generated previously by codegen.
+      - name: Download generated files
+        uses: actions/download-artifact@v2
+        with:
+          name: generated-client-files
+          path: generated
+
+      # Build client with Sapper
+      - name: Build client
+        run: |
+          npm install
+          npm run export
+        working-directory: ${{env.working-directory}}
+
+      # Use Cypress to run end-to-end tests
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          build: npm run export
-          start: npx serve __sapper__/export
-        working-directory: ${{env.working-directory}}
+          start: |
+            cd ${{env.working-directory}}
+            npx serve __sapper__/export

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   codegen-test-and-generate:
+    name: Tests and artifacts on Codegen
     runs-on: ubuntu-latest
     env:
       python-version: 3.9.1
@@ -93,6 +94,7 @@ jobs:
           path: ${{ github.workspace }}/generated
 
   end-to-end:
+    name: End-to-end tests on client
     runs-on: ubuntu-latest
     needs: codegen-test-and-generate
     env:
@@ -109,17 +111,10 @@ jobs:
           name: generated-client-files
           path: generated
 
-      # Build client with Sapper
-      - name: Build client
-        run: |
-          npm install
-          npm run export
-        working-directory: ${{env.working-directory}}
-
       # Use Cypress to run end-to-end tests
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          start: |
-            cd ${{env.working-directory}}
-            npx serve __sapper__/export
+          build: npm run export
+          start: npx serve __sapper__/export
+          working-directory: ${{env.working-directory}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,5 +116,5 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           build: npm run export
-          start: npx serve __sapper__/export
+          start: npx serve __sapper__/export -p 3000
           working-directory: ${{env.working-directory}}


### PR DESCRIPTION
## Description

Cette PR ajoute le lancement de Cypress dans le CI au push sur les branches. On peut voir dans les actions que ça se passe bien avec le test de base : 
https://github.com/betagouv/territoires-en-transitions/runs/2821166534?check_suite_focus=true

On pourra repasser plus tard sur la config et discuter de quand on déclenche ces tests. J'ai l'impression que c'est un peu "too much" de les lancer au push sur chaque branche.