### PR TITLE
Retrait du tagging de déploiement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,12 +134,7 @@ jobs:
 
     steps:
       # cf. https://github.com/actions/checkout
-      # This step uses a GitHub Personal Access Token. If the CI is broken
-      # because of that, you can login into your own GitHub account, generate
-      # a new Personal Access Token and set it in the project secrets.
       - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       # Download the previously built client app.
       - name: Download exported client app
@@ -169,10 +164,6 @@ jobs:
       # Use AWS CLI to upload the client app on Scaleway.
       - name: Deploy on Scaleway
         run: |
-          git config --global user.name 'Territoires en transition'
-          git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
-          git tag -a `date +%Y-%m-%d-%H-%M` -m "Déploiement du `date '+%d %B %Y %T'`"
-          git push origin `date +%Y-%m-%d-%H-%M`
           aws s3 cp ~/tmp/client s3://app.territoiresentransitions.fr --recursive --acl public-read
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}


### PR DESCRIPTION
## Description

Cette PR retire le fait de tagguer un déploiement directement dans la GitHub Action (ceci étant fait maintenant via l'[interface de release](https://github.com/betagouv/territoires-en-transitions/releases/new)).