### PR TITLE
Réparation de la gestion des indicateurs sur la fiche action

### DIFF
--- a/app.territoiresentransitions.fr/package-lock.json
+++ b/app.territoiresentransitions.fr/package-lock.json
@@ -5160,8 +5160,7 @@
     "ramda": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-      "dev": true
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/app.territoiresentransitions.fr/package.json
+++ b/app.territoiresentransitions.fr/package.json
@@ -14,6 +14,7 @@
     "compression": "^1.7.1",
     "cypress-plugin-snapshots": "^1.4.4",
     "polka": "next",
+    "ramda": "^0.27.1",
     "sirv": "^1.0.0"
   },
   "devDependencies": {

--- a/app.territoiresentransitions.fr/src/routes/fiches/_Form.svelte
+++ b/app.territoiresentransitions.fr/src/routes/fiches/_Form.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import find from 'ramda/src/find'
+    import prop from 'ramda/src/prop'
     import {FicheActionStorable} from "../../storables/FicheActionStorable"
     import Button from "../../components/shared/Button/Button.svelte"
     import MultiSelect from './_MultiSelect.svelte'
@@ -243,10 +245,13 @@
                 </MultiSelect>
 
                 {#each data.referentiel_indicateur_ids as indicateurId}
-                    <div class="shadow">
-                        <IndicateurReferentielCard
-                                indicateur={indicateursReferentiel.filter((i) => i.id === indicateurId)[0]}/>
-                    </div>
+                    {#if find(prop(indicateurId))(indicateursReferentiel) }
+                        <div class="shadow">
+                            <IndicateurReferentielCard
+                                indicateur={find(prop(indicateurId))(indicateursReferentiel)}
+                            />
+                        </div>
+                    {/if}
                 {/each}
             {/if}
         </div>


### PR DESCRIPTION
## Description

cf. #180 

La gestion des indicateurs était cassée sur certaines fiches action car depuis le changement de la nomenclature des ids, on a parfois des indicateurs enregistrés avec un ancien id (ex : `22` au lieu de `cae-22`) et notre code ne le gérait pas. J'ai ajouté une lib au passage : [Ramda](https://ramdajs.com) qui permet de travailler en fonctionnel avec des listes et des objets de données en JavaScript.