### PR TITLE
Réparation de l'affichage des référentiels après un refresh

### DIFF
--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionReferentielPage.svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionReferentielPage.svelte
@@ -8,12 +8,14 @@
     import ActionReferentielCard from "../../components/shared/ActionReferentiel/ActionReferentielCard.svelte";
 
     export let action: ActionReferentiel
+
     let displayed = action.actions
-
-
     let epciId = ''
+    let description = ''
+
     onMount(async () => {
         epciId = getCurrentEpciId()
+        description = action.description
     })
 </script>
 
@@ -29,7 +31,9 @@
 
 <ActionReferentielCard action={action} emoji ficheButton statusBar/>
 <div class="m-4">
-    {@html action.description}
+    {#if description}
+        {@html description}
+    {/if}
 </div>
 
 <h2 class="text-2xl font-semibold mt-8 mb-4 ">Les actions</h2>


### PR DESCRIPTION
## Description

Cette PR répare le bug de #181 qui couvrait à la fois des problèmes de navigation et des problèmes d'affichage.

## Explication

L'erreur remontée dans la console JS sur ces pages après un refresh : 
```
Uncaught (in promise) TypeError: t.parentNode is null
    Kt https://app.territoiresentransitions.fr/client/241f0cb948d0da2140d8/main.js:1
    Kt https://app.territoiresentransitions.fr/client/241f0cb948d0da2140d8/main.js:1
    it https://app.territoiresentransitions.fr/client/241f0cb948d0da2140d8/main.js:1
    Ft https://app.territoiresentransitions.fr/client/241f0cb948d0da2140d8/main.js:16
    c https://app.territoiresentransitions.fr/client/241f0cb948d0da2140d8/main.js:16
```

Cette erreur est remontée par la fonction de réhydratation de Sapper. Il se trouve que Sapper essayait de retirer des noeuds DOM qu'il n'avait pas lui-même ajouté. Ces noeuds correspondent à la description d'une action que l'on affiche avec la directive `@html`. 

**Pourquoi Sapper tente-t-il de réhydrater la page alors qu'on a chargé les données au préalable avec la fonction `preload` ?**

Dans les logs, Sapper nous dit pour les pages du référentiel : 
```
Failed to serialize preloaded data to transmit to the client at the /actions_referentiels/citergie__1.1.2 route: Cannot stringify arbitrary non-POJOs
The client will re-render over the server-rendered page fresh instead of continuing where it left off. See https://sapper.svelte.dev/docs#Return_value for more information
``` 
Effectivement, les données que l'on transmet ne sont pas des POJO (Plain Old JavaScript Object), ce sont des objets qui contiennent des objets typés (en l'occurrence `ActionReferentiel`). Du coup, le client tente de réhydrater les données de la page par-dessus ce qui a été généré côté serveur. Et en faisant cela, on se retrouve avec l'erreur JS mentionnée plus haut.

**Plusieurs solutions possibles**

- Charger les données uniquement côté client
- Serialiser nous-mêmes les données avant de transmettre aux composants 
- Charger la description uniquement au `onMount` (fix sale mais rapide que j'ai donc choisi pour l'instant) 
