### PR TITLE
Déploiement automatique des pages statiques au merge dans `main`

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           git config --global user.name 'Territoires en transition'
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
-          git tag -a release-static-`date +%Y-%m-%d-%H-%M` -m "Déploiement de territoiresentransitions.fr du `date '+%d %B %Y %T'`"
+          git tag -a `date +%Y-%m-%d-%H-%M` -m "Déploiement de territoiresentransitions.fr du `date '+%d %B %Y %T'`"
           git push origin release-static-`date +%Y-%m-%d-%H-%M`
           aws s3 cp ~/tmp/client s3://territoiresentransitions.fr --recursive --acl public-read
         env:

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -2,10 +2,8 @@ name: Deploy territoiresentransitions.fr
 
 on:
   push:
-    # TODO : change branch name to production-static
     branches:
-      - deploy-static-workflow
-      - deploy-homepage
+      - production-static
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - production
       - production-static
-      - trigger-deploy
+      - trigger-deploy-from-main
       - deploy-static-workflow
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - production
+      - production-static
+      - trigger-deploy
       - deploy-static-workflow
 
 jobs:

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -30,5 +30,5 @@ jobs:
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
           git fetch
           git checkout -b production-static origin/production-static
-          git merge origin main --squash -X theirs
+          git merge origin/main --squash -X theirs
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -22,11 +22,13 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       # Update `production-static` branch with `main` branch and push to origin
+      # Note: we use "git pull origin main --no-rebase -X theirs" to merge `main` without rebase and to
+      #       force the version of `main` instead of the one on `production-static` in case of conflicts.
       - name: Update `production-static` branch with `main`
         run: |
           git config --global user.name 'Territoires en transition'
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
           git fetch
           git checkout -b production-static origin/production-static
-          git pull origin main --no-rebase
+          git pull origin main --no-rebase -X theirs
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           git config --global user.name 'Territoires en transition'
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
-          git checkout -b production-static
-          git pull origin production-static --no-rebase
+          git checkout -b production-static origin/production-static
           git pull origin main --no-rebase
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           git config --global user.name 'Territoires en transition'
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
-          git checkout production-static
+          git checkout -b production-static
+          git pull origin production-static
           git pull origin main
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       # Update `production-static` branch with `main` branch and push to origin
-      # Note: we use "git merge origin main --no-rebase -X theirs" to merge `main` with rebase and to
+      # Note: we use "git merge origin main -X theirs" to merge `main` and to
       #       force the version of `main` instead of the one on `production-static` in case of conflicts.
       - name: Update `production-static` branch with `main`
         run: |
@@ -30,5 +30,5 @@ jobs:
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
           git fetch
           git checkout -b production-static origin/production-static
-          git merge origin/main --squash -X theirs
+          git merge origin/main -X theirs
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -27,6 +27,6 @@ jobs:
           git config --global user.name 'Territoires en transition'
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
           git checkout -b production-static
-          git pull origin production-static
-          git pull origin main
+          git pull origin production-static --no-rebase
+          git pull origin main --no-rebase
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -10,6 +10,7 @@ jobs:
   trigger-app-deploy:
     name: Trigger app deployment
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       # cf. https://github.com/actions/checkout

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       # Update `production-static` branch with `main` branch and push to origin
-      # Note: we use "git pull origin main --no-rebase -X theirs" to merge `main` without rebase and to
+      # Note: we use "git merge origin main --no-rebase -X theirs" to merge `main` with rebase and to
       #       force the version of `main` instead of the one on `production-static` in case of conflicts.
       - name: Update `production-static` branch with `main`
         run: |
@@ -30,5 +30,5 @@ jobs:
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
           git fetch
           git checkout -b production-static origin/production-static
-          git pull origin main --no-rebase -X theirs
+          git merge origin main --rebase -X theirs
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -26,6 +26,6 @@ jobs:
         run: |
           git config --global user.name 'Territoires en transition'
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
-          git co production-static
+          git checkout production-static
           git pull origin main
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           git config --global user.name 'Territoires en transition'
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
+          git fetch
           git checkout -b production-static origin/production-static
           git pull origin main --no-rebase
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -30,5 +30,5 @@ jobs:
           git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
           git fetch
           git checkout -b production-static origin/production-static
-          git merge origin main --rebase -X theirs
+          git merge origin main --squash -X theirs
           git push origin production-static

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -1,0 +1,30 @@
+name: Trigger deployments on merge on default branch
+
+on:
+  push:
+    branches:
+      - main
+      - trigger-deploy-from-main
+
+jobs:
+  trigger-app-deploy:
+    name: Trigger app deployment
+    runs-on: ubuntu-latest
+
+    steps:
+      # cf. https://github.com/actions/checkout
+      # This step uses a GitHub Personal Access Token. If the CI is broken
+      # because of that, you can login into your own GitHub account, generate
+      # a new Personal Access Token and set it in the project secrets.
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      # Update `production-static` branch with `main` branch and push to origin
+      - name: Update `production-static` branch with `main`
+        run: |
+          git config --global user.name 'Territoires en transition'
+          git config --global user.email 'territoires-en-transitions-deploy@users.noreply.github.com'
+          git co production-static
+          git pull origin main
+          git push origin production-static

--- a/app.territoiresentransitions.fr/README.md
+++ b/app.territoiresentransitions.fr/README.md
@@ -1,5 +1,6 @@
 # Application client pour Labels Transition Écologique
 
+
 - [Pré-requis](#pré-requis)
 - [Pour commencer à développer](#pour-commencer-à-développer)
     - [Installer les dépendances de


### PR DESCRIPTION
## Description

Cette PR propose de pusher automatiquement sur la branche `production-static` les modifications que l'on vient de merger sur `main`. Cela permettrait de : 
- s'éviter la tâche manuelle de déploiement de l'application avec les pages statiques au merge dans `main`,
- et en même temps s'autoriser la possibilité de déployer parfois à la main via la branche `production-static`