### PR TITLE
[TerritoiresEnTransitions] Site statique : configuration purge css

### DIFF
--- a/territoiresentransitions.fr/svelte.config.js
+++ b/territoiresentransitions.fr/svelte.config.js
@@ -14,7 +14,19 @@ const config = {
       plugins: [
         purgecss({
           content: ['src/**/*.svelte', 'src/app.html', '../components/**/*.svelte'],
-          safelist: ['body']
+          safelist: ['body'],
+          keyframes: true,
+          defaultExtractor(content) {
+            const contentWithoutStyleBlocks = content.replace(
+              /<style[^]+?<\/style>/gi,
+              ""
+            );
+            return (
+              contentWithoutStyleBlocks.match(
+                /[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g
+              ) || []
+            );
+          },
           // rejected: true,
         })
       ]


### PR DESCRIPTION
J'ai constaté que le css du site statique avait gonflé, il ne semble plus vraiment purgé.

Visiblement, au passage du `__layout.svelte`, purge css s'emmèle les pinceaux et ne purge pas totalement le fichier `node_modules/@gouvfr/dsfr/dist/css/dsfr.css`

Cette configuration est issue de cette solution : 
https://github.com/FullHuman/purgecss/issues/22#issuecomment-605052229

Elle permet de faire redescendre le poids du css de 160kb à 45kb.

Une solution à plus long terme sera (je pense) d'injecter les composants DesignSystem.svelte du dossier components.