### PR TITLE
Réparation de l'affichage de la page à la racine de l'app

### DIFF
--- a/app.territoiresentransitions.fr/src/components/shared/Button/ButtonBase.svelte
+++ b/app.territoiresentransitions.fr/src/components/shared/Button/ButtonBase.svelte
@@ -10,7 +10,7 @@
     export let asLink = false
     export let href = ''
 
-    let buttonClassNames = ''
+    let buttonClassNames = 'legacy-button'
 
     /**
      * Color variants
@@ -51,13 +51,13 @@
         border: 2px solid;
     }
 
-    :global(.juniper) {
+    .juniper {
         color: var(--w);
         background-color: var(--bf500);
         border-color: var(--bf500);
     }
 
-    :global(.blueberry) {
+    .blueberry {
         color: var(--bf500);
         border-color: var(--bf500);
     }

--- a/app.territoiresentransitions.fr/src/routes/index.svelte
+++ b/app.territoiresentransitions.fr/src/routes/index.svelte
@@ -21,7 +21,7 @@
     <title>Territoires en Transitions</title>
 </svelte:head>
 
-<div class="">
+<div class="introduction">
     {#if connected === null}
         <p>Chargement en cours...</p>
     {:else if connected}
@@ -57,5 +57,10 @@
 <style>
     .hidden {
         display: none;
+    }
+
+    .introduction {
+        margin-top: 2.25rem;
+        margin-bottom: 3.75rem;
     }
 </style>


### PR DESCRIPTION
## Description 

Je pense avoir une intuition de comment fonctionne le `:global` mais je n'en suis pas encore certaine. Du coup, on pourrait en discuter plus amplement plus tard si tu veux @derfurth sur le pourquoi du fonctionnement de ce fix. 

En attendant, j'ai testé avec un `npm run export` en local et la CSS est bien restée.

J'ai ajouté un mini style dans la PR aussi pour que cette page fasse plus propre avec un padding.