### PR TITLE
Répare bug de navigation

### DIFF
--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/[id].svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/[id].svelte
@@ -1,21 +1,14 @@
 <script context="module" lang="ts">
     import {actions} from "../../../../generated/data/actions_referentiels";
-    import {ActionReferentiel} from "../../../../generated/models/action_referentiel";
+    import {searchById} from "./utils";
 
-    const search = (actions: ActionReferentiel[], id: string): ActionReferentiel | void => {
-        for (let action of actions) {
-            if (action.id === id) return action;
-            const found = search(action.actions, id);
-            if (found) return found;
-        }
-    }
 
     export async function preload({params}) {
         const id = params.id;
-        const found = search(actions, id);
+        const found = searchById(actions, id);
 
         if (found) {
-            return {action: found};
+            return {actionId: found.id};
         } else {
             this.error(404, `Aucune action trouvée pour ${id}`);
         }
@@ -25,9 +18,14 @@
 <script lang="ts">
     import ActionReferentielPage from "./_ActionReferentielPage.svelte";
 
-    export let action: ActionReferentiel
+    export let actionId: string
+    $: action = searchById(actions, actionId)
 </script>
 
-<ActionReferentielPage action={action}/>
+<div>
+    {#if action}
+        <ActionReferentielPage action={action}/>
+    {/if}
+</div>
 
 

--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionReferentielPage.svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionReferentielPage.svelte
@@ -86,11 +86,11 @@
 
     <ProgressStat action={action}/>
 
-    {#if action.description}
+    {#if description}
         <ExpandPanel>
             <h2 slot="title">Description</h2>
             <div slot="content" class="pageIntro__description">
-                {@html action.description}
+                {@html description}
             </div>
         </ExpandPanel>
     {/if}

--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/utils.ts
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/utils.ts
@@ -1,0 +1,9 @@
+import type { ActionReferentiel } from "../../../../generated/models/action_referentiel";
+
+export const searchById = (actions: ActionReferentiel[], id: string): ActionReferentiel | void => {
+    for (let action of actions) {
+        if (action.id === id) return action;
+        const found = searchById(action.actions, id);
+        if (found) return found;
+    }
+}


### PR DESCRIPTION
Il y a deux choses dans cette PR le même fix que pour la description dans la Card de l'action mais au niveau de la page.

Et le fait d'utiliser l'id de l'action pour la page et pas un objet qui a priori fixe un bug lors du reload du changement de statut