### PR TITLE
[Site statique] Correction favicon mentions légales et image svg sur safari

### DIFF
--- a/territoiresentransitions.fr/src/app.html
+++ b/territoiresentransitions.fr/src/app.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <link rel="apple-touch-icon" href="favicons/apple-touch-icon.png" />
-    <link rel="icon" href="favicons/favicon.svg" type="image/svg+xml" />
-    <link rel="shortcut icon" href="favicons/favicon.ico" type="image/x-icon" />
-    <link rel="manifest" href="favicons/manifest.webmanifest" crossorigin="use-credentials" />
+    <link rel="apple-touch-icon" href="/favicons/apple-touch-icon.png" />
+    <link rel="icon" href="/favicons/favicon.svg" type="image/svg+xml" />
+    <link rel="shortcut icon" href="/favicons/favicon.ico" type="image/x-icon" />
+    <link rel="manifest" href="/favicons/manifest.webmanifest" crossorigin="use-credentials" />
     %svelte.head%
   </head>
   <body>

--- a/territoiresentransitions.fr/src/components/Markdown/Cards.svelte
+++ b/territoiresentransitions.fr/src/components/Markdown/Cards.svelte
@@ -33,7 +33,7 @@
 
 <style>
   .Cards :global(.fr-card__img img) {
-    object-fit: none;
+    object-fit: contain;
     top: 15%;
   }
 


### PR DESCRIPTION
Actuellement, lorsqu'on se rend sur https://territoiresentransitions.fr/mentions-legales/

Les appels au favicon et apple-touch-icon sont relatifs, et ils sont recherchés sur :
https://territoiresentransitions.fr/mentions-legales/favicons/favicon.svg

Cette PR change les liens pour qu'ils soient en absolu sur le domaine.

Carte liée : https://github.com/betagouv/territoires-en-transitions/projects/2#card-64048410

Autre modification, les icones de la page d'accueil étaient tronqués sur Safari. Modification du object-fit pour corriger le problème