### PR TITLE
Retrait de la description sur les cartes d'un référentiel

### DIFF
--- a/app.territoiresentransitions.fr/src/components/shared/ActionReferentiel/ActionReferentielCard.svelte
+++ b/app.territoiresentransitions.fr/src/components/shared/ActionReferentiel/ActionReferentielCard.svelte
@@ -42,6 +42,9 @@
     // Displays the comment part
     export let commentBlock: boolean = false
 
+    // Displays the description part
+    export let descriptionBlock: boolean = false
+
     // Displays children of the card
     export let recursive: boolean = false
 
@@ -233,7 +236,9 @@
         </div>
     {/if}
 
-    <ActionReferentielDescription action={action}/>
+    {#if descriptionBlock }
+        <ActionReferentielDescription action={action}/>
+    {/if}
 
     {#if commentBlock}
         <ActionReferentielCommentaire action={action}/>

--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionReferentielPage.svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionReferentielPage.svelte
@@ -98,7 +98,16 @@
 
 <h2>Les actions</h2>
 {#each displayed as action}
-    <ActionReferentielCard action={action} ficheButton statusBar expandButton borderedCard commentBlock recursive/>
+    <ActionReferentielCard
+      action={action}
+      ficheButton
+      statusBar
+      expandButton
+      borderedCard
+      commentBlock
+      descriptionBlock
+      recursive
+    />
 {/each}
 
 <h2>Les indicateurs</h2>


### PR DESCRIPTION
## Description

Closes #356.

Dans cette PR, on retire la description sur les cartes d'un référentiel. 

Avant : 
![Screenshot 2021-07-12 at 17-21-15 Screenshot](https://user-images.githubusercontent.com/548778/125313550-a111c400-e335-11eb-9b88-1c002d3db9fe.png)

Après : 
![Screenshot 2021-07-12 at 17-20-30 Screenshot](https://user-images.githubusercontent.com/548778/125313585-a707a500-e335-11eb-8c42-74ee4abfe829.png)
