### PR TITLE
Ajout d'une information lorsqu'il n'y a pas d'indicateur pour des actions

### DIFF
--- a/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionReferentielPage.svelte
+++ b/app.territoiresentransitions.fr/src/routes/actions_referentiels/_ActionReferentielPage.svelte
@@ -16,6 +16,10 @@
     let epciId = ''
     let description = ''
 
+    const isIndicateurRelatedToAction = (indicateur) => indicateur.action_ids.includes(action.id)
+    const actionIndicateurs = indicateurs.filter(isIndicateurRelatedToAction)
+    const hasIndicateurs = actionIndicateurs.length > 0
+
     onMount(async () => {
         epciId = getCurrentEpciId()
         description = action.description
@@ -62,6 +66,10 @@
     .pageIntro > :global(details) {
         width: 70% !important;
     }
+
+    .listActions {
+        margin-bottom: 3.75rem;
+    }
 </style>
 
 <div class="pageIntro">
@@ -97,11 +105,17 @@
 </div>
 
 <h2>Les actions</h2>
-{#each displayed as action}
-    <ActionReferentielCard action={action} ficheButton statusBar expandButton borderedCard commentBlock recursive/>
-{/each}
+<div class="listActions">
+    {#each displayed as action}
+        <ActionReferentielCard action={action} ficheButton statusBar expandButton borderedCard commentBlock recursive/>
+    {/each}
+</div>
 
 <h2>Les indicateurs</h2>
-{#each indicateurs.filter((indicateur) => indicateur.action_ids.includes(action.id)) as indicateur (indicateur.id)}
-    <IndicateurReferentielCard indicateur={indicateur}/>
-{/each}
+{#if hasIndicateurs }
+    {#each actionIndicateurs as indicateur (indicateur.id)}
+        <IndicateurReferentielCard indicateur={indicateur}/>
+    {/each}
+{:else }
+    Il n'existe pas d'indicateur dans le référentiel pour ces actions.
+{/if}


### PR DESCRIPTION
## Description

Closes #151.

Dans cette PR, on ajoute une petite phrase d'information lorsqu'il n'y a pas d'indicateurs associés à l'action du référentiel. J'en ai profité pour ajouter une marge également pour mieux séparer visuellement la partie `Actions` et la partie `Indicateurs` sur la page. 

Screenshot : 

![Screenshot 2021-07-12 at 17-37-23 Screenshot](https://user-images.githubusercontent.com/548778/125316102-141c3a00-e338-11eb-8f0b-0d3677e19185.png)
