### PR TITLE
Mise à jour du déploiement continu

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: client-app
-          path: app.territoiresentransitions.fr/build
+          path: app.territoiresentransitions.fr/.svelte-kit/static/build
 
   # This job retrieves the exported client app and upload it to Scaleway.
   deploy-on-scaleway:

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: client-app
-          path: app.territoiresentransitions.fr/build
+          path: app.territoiresentransitions.fr/.svelte-kit/static/build
 
   # This job retrieves the exported client app and upload it to Scaleway.
   deploy-on-scaleway:


### PR DESCRIPTION
Apparement l'output du build de svelte kit est passé de `build` à `.svelte-kit/static/build`