### PR TITLE
Répare les indicateurs personnalisés dans le formulaire

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/IndicateursPersonnalisesField.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/IndicateursPersonnalisesField.tsx
@@ -34,10 +34,12 @@ export const IndicateursPersonnalisesField: FC<
     .map(entry => entry[0]);
 
   const renderIndicateurOption = (id: string) => {
-    const indicateur = indicateurs.get(id)!;
-    return `${indicateur.custom_id ? '(' + indicateur.custom_id + ') ' : ''} ${
-      indicateur.nom
-    }`;
+    const indicateur = indicateurs.get(id);
+    return indicateur
+      ? `${indicateur.custom_id ? '(' + indicateur.custom_id + ') ' : ''} ${
+          indicateur.nom
+        }`
+      : '...';
   };
   const htmlId = props.id ?? uuid();
   const errorMessage = errors[field.name];


### PR DESCRIPTION
fixes #740

Lorsque les indicateurs personnalisés ne sont pas chargés alors on affiche ... comme label.