### PR TITLE
[Tech Task] Test auth avec un faux token

### DIFF
--- a/api/tests/api/test_routers_auth.py
+++ b/api/tests/api/test_routers_auth.py
@@ -40,7 +40,8 @@ def test_user_infos_is_saved_on_token_call(
     token_route_dummy_params = dict(code="some_code", redirect_uri="redirect_uri")
 
     # Fred connects
-    connection_api.set_user_name(nom="Fred")  # type: ignore
+    dummy_ademe_user_id = connection_api.user.ademe_user_id
+    connection_api.set_user_name(prenom="Fred")  # type: ignore
     response = client.get(
         token_path,
         params=token_route_dummy_params,
@@ -51,19 +52,19 @@ def test_user_infos_is_saved_on_token_call(
 
     query = event_loop.run_until_complete(
         AdemeUtilisateur.filter(
-            ademe_user_id="dummy",
+            ademe_user_id=dummy_ademe_user_id,
         )
     )
-    assert query[0].nom == "Fred"
+    assert query[0].prenom == "Fred"
 
     # Fred connects with new name Frederic
-    connection_api.set_user_name(nom="Frederic")  # type: ignore
+    connection_api.set_user_name(prenom="Frederic")  # type: ignore
     response = client.get(
         token_path, params=token_route_dummy_params, headers=auth_headers()
     )
     query = event_loop.run_until_complete(
         AdemeUtilisateur.filter(
-            ademe_user_id="dummy",
+            ademe_user_id=dummy_ademe_user_id,
         )
     )
-    assert query[0].nom == "Frederic"
+    assert query[0].prenom == "Frederic"

--- a/api/tests/api/test_routers_utilisateur_droits.py
+++ b/api/tests/api/test_routers_utilisateur_droits.py
@@ -19,8 +19,6 @@ def test_add_item(client: TestClient, event_loop: asyncio.AbstractEventLoop):
     assert AUTH_DISABLED_DUMMY_USER
 
     # POST /v2/utilisateur_droits
-    response = add_ecriture_droit(
-        client, droits["ademe_user_id"], droits["epci_id"], droits["ecriture"]
-    )
+    response = add_ecriture_droit(client, droits["epci_id"], droits["ecriture"])
     assert response.status_code == 200
     assert response.json()["epci_id"] == droits["epci_id"]

--- a/api/tests/utils/auth.py
+++ b/api/tests/utils/auth.py
@@ -1,13 +1,17 @@
 from requests import Response
 from starlette.testclient import TestClient
 
+from api.routers.v2.auth import connection_api
+
 path = "/v2/utilisateur_droits"
 
 
-def add_ecriture_droit(
-    client: TestClient, ademe_user_id="dummy", epci_id="test", ecriture=True
-) -> Response:
-    droits = {"ademe_user_id": ademe_user_id, "epci_id": epci_id, "ecriture": ecriture}
+def add_ecriture_droit(client: TestClient, epci_id: str, ecriture=True) -> Response:
+    droits = {
+        "ademe_user_id": connection_api.user.ademe_user_id,
+        "epci_id": epci_id,
+        "ecriture": ecriture,
+    }
 
     response = client.post(
         path,
@@ -18,5 +22,6 @@ def add_ecriture_droit(
     return response
 
 
-def auth_headers(access_token="xx") -> dict:
-    return {"Authorization": f"Bearer {access_token}"}
+def auth_headers() -> dict:
+    tokens = connection_api.get_tokens(code="", redirect_uri="")
+    return {"Authorization": f"Bearer {tokens.access_token}"}

--- a/app.territoiresentransitions.react/src/app/pages/Auth/IdentityPage.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/IdentityPage.tsx
@@ -1,22 +1,14 @@
-import {connected, currentUser} from 'core-logic/api/authentication';
+import {connected} from 'core-logic/api/authentication';
 
 /**
  * Allows to check current user identity. Not used for now.
  */
 export const IdentityPage = () => {
   const isConnected = connected();
-  const user = currentUser();
-
   if (isConnected) {
     return (
       <div>
-        <span>Vous êtes connecté </span>
-        {user !== null && (
-          <span>
-            en tant que {user.prenom} {user.nom} ({user.email})
-          </span>
-        )}
-        <span>.</span>
+        <span>Vous êtes connecté !</span>
       </div>
     );
   } else {

--- a/app.territoiresentransitions.react/src/app/pages/Auth/TokenSignInPage.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/TokenSignInPage.tsx
@@ -59,11 +59,7 @@ export const TokenSignInPage = () => {
           {isConnected && (
             <>
               <h6>Connecté </h6>
-              {user && (
-                <p>
-                  en tant que {user.prenom} {user.nom} ({user.email})
-                </p>
-              )}
+
               <button className="fr-btn" onClick={disconnect}>
                 Se déconnecter
               </button>

--- a/app.territoiresentransitions.react/src/core-logic/api/authentication.ts
+++ b/app.territoiresentransitions.react/src/core-logic/api/authentication.ts
@@ -1,12 +1,13 @@
 import jwt_decode, {JwtPayload} from 'jwt-decode';
 import {UtilisateurConnecteLocalStorable} from 'storables/UtilisateurConnecteStorable';
-import {utilisateurConnecteStore} from './localStore';
+import {utilisateurConnecteLocalStore} from './localStore';
 import type {UtilisateurDroitsInterface} from 'generated/models/utilisateur_droits';
 import {UtilisateurDroits} from 'generated/models/utilisateur_droits';
 import {ENV} from 'environmentVariables';
 import {ChangeNotifier} from 'core-logic/api/reactivity';
 
-const _dummyToken = 'xx';
+const _dummyToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkdW1teSIsImdpdmVuX25hbWUiOiJGcmVkIiwiZmFtaWx5X25hbWUiOiJEdXBvbnQiLCJlbWFpbCI6ImR1bW15QHRlcnJpdG9pcmVzZW50cmFuc2l0aW9ucy5mciJ9.u42Ygg2_TtgjjuVBakqHpIotwOZMlRFHIYdvAnLhj9c';
 
 /**
  * Authentication, only manage rights for now.
@@ -29,7 +30,7 @@ class Authentication extends ChangeNotifier {
  */
 export const auth = new Authentication();
 
-utilisateurConnecteStore.addListener(() => {
+utilisateurConnecteLocalStore.addListener(() => {
   auth.currentUtilisateurDroits = null;
 });
 
@@ -37,15 +38,7 @@ utilisateurConnecteStore.addListener(() => {
  * Save fake tokens, the user will be connected until replaced.
  */
 export const saveDummyTokens = () => {
-  const storable = new UtilisateurConnecteLocalStorable({
-    ademe_user_id: 'dummy',
-    access_token: _dummyToken,
-    refresh_token: _dummyToken,
-    email: 'dummy@territoiresentransitions.fr',
-    nom: 'Territoires en Transitions',
-    prenom: 'Dummy',
-  });
-  utilisateurConnecteStore.store(storable);
+  saveTokens(_dummyToken, _dummyToken);
 };
 
 /**
@@ -57,11 +50,8 @@ export const saveTokens = (accessToken: string, refreshToken: string) => {
     ademe_user_id: decoded['sub'] || '',
     access_token: accessToken,
     refresh_token: refreshToken,
-    email: '', // decoded["email"] ||
-    nom: '', // decoded["family_name"] ||
-    prenom: '', // decoded["given_name"] ||
   });
-  utilisateurConnecteStore.store(storable);
+  utilisateurConnecteLocalStore.store(storable);
 };
 
 /**
@@ -69,9 +59,8 @@ export const saveTokens = (accessToken: string, refreshToken: string) => {
  */
 export const connected = (): boolean => {
   let utilisateur: UtilisateurConnecteLocalStorable;
-
   try {
-    utilisateur = utilisateurConnecteStore.retrieveById(
+    utilisateur = utilisateurConnecteLocalStore.retrieveById(
       UtilisateurConnecteLocalStorable.id
     );
   } catch (e) {
@@ -92,7 +81,7 @@ export const connected = (): boolean => {
  */
 export const currentUser = (): UtilisateurConnecteLocalStorable | null => {
   if (connected())
-    return utilisateurConnecteStore.retrieveById(
+    return utilisateurConnecteLocalStore.retrieveById(
       UtilisateurConnecteLocalStorable.id
     );
   return null;
@@ -120,7 +109,7 @@ export const currentRefreshToken = (): string | null => {
  * Sign the current user out. Return true on success, false otherwise.
  */
 export const signOut = (): boolean => {
-  return utilisateurConnecteStore.deleteById(
+  return utilisateurConnecteLocalStore.deleteById(
     UtilisateurConnecteLocalStorable.id
   );
 };

--- a/app.territoiresentransitions.react/src/core-logic/api/localStore.ts
+++ b/app.territoiresentransitions.react/src/core-logic/api/localStore.ts
@@ -195,7 +195,7 @@ export const indicateurPersonnaliseResultatStore =
       new AnyIndicateurValueStorable(serialized as AnyIndicateurValueInterface),
   });
 
-export const utilisateurConnecteStore =
+export const utilisateurConnecteLocalStore =
   new LocalStore<UtilisateurConnecteLocalStorable>({
     pathname: UtilisateurConnecte.pathname,
     serializer: storable => storable,

--- a/app.territoiresentransitions.react/src/core-logic/hooks/authentication.ts
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/authentication.ts
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import {UtilisateurDroits} from 'generated/models/utilisateur_droits';
 import {auth, currentUtilisateurDroits} from 'core-logic/api/authentication';
 import {UtilisateurConnecteLocalStorable} from 'storables/UtilisateurConnecteStorable';
-import {utilisateurConnecteStore} from 'core-logic/api/localStore';
+import {utilisateurConnecteLocalStore} from 'core-logic/api/localStore';
 
 export const useDroits = (): UtilisateurDroits[] => {
   const [droits, setDroits] = useState<UtilisateurDroits[]>([]);
@@ -35,14 +35,14 @@ export const useUser = (): UtilisateurConnecteLocalStorable | null => {
 
   useEffect(() => {
     const listener = async () => {
-      const storable = await utilisateurConnecteStore.retrieveById(
+      const storable = await utilisateurConnecteLocalStore.retrieveById(
         UtilisateurConnecteLocalStorable.id
       );
       setUser(storable);
     };
 
     try {
-      const retrieved = utilisateurConnecteStore.retrieveById(
+      const retrieved = utilisateurConnecteLocalStore.retrieveById(
         UtilisateurConnecteLocalStorable.id
       );
       if (retrieved.ademe_user_id !== user?.ademe_user_id) setUser(retrieved);
@@ -50,9 +50,9 @@ export const useUser = (): UtilisateurConnecteLocalStorable | null => {
       setUser(null);
     }
 
-    utilisateurConnecteStore.addListener(listener);
+    utilisateurConnecteLocalStore.addListener(listener);
     return () => {
-      utilisateurConnecteStore.removeListener(listener);
+      utilisateurConnecteLocalStore.removeListener(listener);
     };
   }, [user]);
 

--- a/app.territoiresentransitions.react/src/storables/UtilisateurConnecteStorable.ts
+++ b/app.territoiresentransitions.react/src/storables/UtilisateurConnecteStorable.ts
@@ -2,9 +2,6 @@ export interface UtilisateurConnecteInterface {
   ademe_user_id: string;
   access_token: string;
   refresh_token: string;
-  email: string;
-  nom: string;
-  prenom: string;
 }
 
 export class UtilisateurConnecte {
@@ -15,9 +12,6 @@ export class UtilisateurConnecte {
   ademe_user_id: string;
   access_token: string;
   refresh_token: string;
-  email: string;
-  nom: string;
-  prenom: string;
 
   /**
    * Creates a UtilisateurConnecte instance.
@@ -26,33 +20,21 @@ export class UtilisateurConnecte {
     ademe_user_id,
     access_token,
     refresh_token,
-    email,
-    nom,
-    prenom,
   }: {
     ademe_user_id: string;
     access_token: string;
     refresh_token: string;
-    email: string;
-    nom: string;
-    prenom: string;
   }) {
     this.ademe_user_id = ademe_user_id;
     this.access_token = access_token;
     this.refresh_token = refresh_token;
-    this.email = email;
-    this.nom = nom;
-    this.prenom = prenom;
   }
   equals(other: UtilisateurConnecteInterface | null): boolean {
     if (!other) return false;
     return (
       other.ademe_user_id === this.ademe_user_id &&
       other.access_token === this.access_token &&
-      other.refresh_token === this.refresh_token &&
-      other.email === this.email &&
-      other.nom === this.nom &&
-      other.prenom === this.prenom
+      other.refresh_token === this.refresh_token
     );
   }
 }


### PR DESCRIPTION
Refacto connection_api so that the InMemory (dummy) adapter generate a fake token and the decoding is made in the abstract parent class. Also, check that decoded payload has valid shape.
Closes #777 