### PR TITLE
Modification 5.2

### DIFF
--- a/markdown/referentiels/eci/5.2.md
+++ b/markdown/referentiels/eci/5.2.md
@@ -5,7 +5,7 @@ points: 30
 climat_pratic_id: parten_coop
 ```
 ## Description
-L'objectif est d'encourager la collectivité à déployer une politique d'actions économie circulaire vers les collectivités infra et supra et les EPCI qui interviennent sur son territoire sur l'ensemble des 7 piliers de l'économie circulaire.
+L'objectif est d'encourager la collectivité à déployer une politique d'actions économie circulaire vers les collectivités infra et supra qui interviennent sur son territoire sur l'ensemble des 7 piliers de l'économie circulaire.
 Ces actions peuvent être déjà mentionnées dans les axes précédents.
 
 ## Ressources
@@ -55,13 +55,13 @@ collectivités donnent de l’élan à leur territoire</a>
 
 
 ## Actions
-### Informer, sensibiliser et former les autres collectivités et EPCI de son territoire
+### Informer, sensibiliser et former les autres collectivités de son territoire
 ```yaml
 identifiant: 5.2.1
 pourcentage: 20
 ```
 #### Description
-Dans une logique de sobriété, la collectivité informe, sensibilise et forme les autres collectivités et EPCI de son territoire sur les 7 piliers de l'économie circulaire
+Dans une logique de sobriété, la collectivité informe, sensibilise et forme les autres collectivités de son territoire sur les 7 piliers de l'économie circulaire
 
 #### Exemples
 Diffuser des documents d'information (déjà disponibles auprès des Communautés de commune, Conseils régionaux, ADEME ou réalisé en propre).
@@ -143,17 +143,17 @@ pourcentage: 15
 Au moins 1 action pour les collectivités avec une population inférieure à 100 000 habitants. Au moins 2 actions pour les collectivités avec une population supérieure à 100 000 habitants.
 
 
-### Aider à l'action des autres collectivités et EPCI de son territoire
+### Aider à l'action des autres collectivités de son territoire
 ```yaml
 identifiant: 5.2.2
 pourcentage: 40
 ```
 #### Description
-La collectivité soutient des actions concrètes réalisées en direction des autres EPCI sur les 7 piliers de l'économie circulaire.
-Les actions peuvent être réalisées par la collectivité elle-même ou avec d'autres EPCI.
+La collectivité soutient des actions concrètes réalisées en direction des collectivités infra et supra sur les 7 piliers de l'économie circulaire.
+Les actions peuvent être réalisées par la collectivité elle-même ou avec d'autres collectivités.
 
 #### Exemples
-Lancer ou participer à des initiatives en matière d'économie circulaire entre les EPCI du territoire, par exemple : mutualisation de moyens ou de formations.
+Lancer ou participer à des initiatives en matière d'économie circulaire entre les collectivités du territoire, par exemple : mutualisation de moyens ou de formations.
 Bourse d'échanges de matériel de voierie réformé.
 Mise en commun de cahier des charges achats responsables ou d'un réseau d'acheteurs publics.
 Mise à disposition par les EPCI de locaux pour une ressourcerie.
@@ -229,23 +229,23 @@ identifiant: 5.2.3
 pourcentage: 40
 ```
 #### Description
-La collectivité structure des partenariats avec les EPCI pour généraliser et amplifier la démarche sur l'ensemble du territoire.
+La collectivité structure des partenariats avec les collectivités infra et supra pour généraliser et amplifier la démarche sur l'ensemble du territoire.
 Elle mesure la réussite des partenariats mis en place et valorise les résultats.
 Un partenariat peut couvrir plusieurs piliers de l'économie circualire.
 
 #### Exemples
-Créer ou participer à des espaces communs de dialogue pour les EPCI du territoire: restauration collective, établissements scolaires et culturelles, habitat social - bailleurs sociaux, etc.
-Mettre en place des accords avec un ou plusieurs EPCI du territoire permettant de progresser sur une thématique de l'économie circulaire. Chaque accord devrait comprendre des indicateurs de performance pour mesurer la réussite du partenariat (ex. gaspillage alimentaire, consommation d'eau, artificialisation du sol, etc.).
+Créer ou participer à des espaces communs de dialogue pour les autres collectivités du territoire: restauration collective, établissements scolaires et culturelles, habitat social - bailleurs sociaux, etc.
+Mettre en place des accords avec une ou plusieurs autres collectivités du territoire permettant de progresser sur une thématique de l'économie circulaire. Chaque accord devrait comprendre des indicateurs de performance pour mesurer la réussite du partenariat (ex. gaspillage alimentaire, consommation d'eau, artificialisation du sol, etc.).
 La collectivité publie les indicateurs de réussite afin de valoriser les résultats de ces partenariats et encourager à la reproduction des actions : site internet, journal de la commune, réseaux sociaux, etc.  
 Les indicateurs de réussite (simples et peu nombreux) ont pour but d'aider la collectivité à juger de la pertinence de ce partenariat au regard de sa politique Economie Circulaire.
 
 #### Preuve
-- Liste des EPCI à potentiel de collaboration
-- Liste d'EPCI et d'enjeux identifiés
+- Liste des autres collectivités à potentiel de collaboration
+- Liste des autres collectivités et des enjeux identifiés
 - Conventions de partenariat
 
 #### Actions
-##### Identifier les EPCI à potentiel de collaboration
+##### Identifier les collectivités à potentiel de collaboration
 ```yaml
 identifiant: 5.2.3.1
 pourcentage: 20
@@ -257,7 +257,7 @@ identifiant: 5.2.3.2
 pourcentage: 30
 ```
 
-##### Conclure un/des accord(s) avec un ou plusieurs EPCI du territoire
+##### Conclure un/des accord(s) avec une ou plusieurs collectivités du territoire
 ```yaml
 identifiant: 5.2.3.3
 pourcentage: 50


### PR DESCRIPTION
Suppression ou remplacement "EPCI" par "collectivité infra et supra" ou "autres collectivités" dans la description, les exemples, les preuves, les titres des sous-actions et des tâches