### PR TITLE
ajoute la chatbox Crisp

### DIFF
--- a/app.territoiresentransitions.react/.env.sample
+++ b/app.territoiresentransitions.react/.env.sample
@@ -1,3 +1,4 @@
 REACT_APP_SUPABASE_KEY= // secret key
 REACT_APP_SUPABASE_URL= // secret url
 REACT_APP_FLAVOR=sandbox // sandbox | prod. If nothing, then localhost:8000
+REACT_APP_CRISP_WEBSITE_ID= // Crisp integration (warning: use different ID by deployment env.)

--- a/app.territoiresentransitions.react/public/index.html
+++ b/app.territoiresentransitions.react/public/index.html
@@ -18,6 +18,17 @@
     <meta name="theme-color" content="#333333">
     <title>Territoires en Transitions</title>
     <script async src="https://stats.data.gouv.fr//piwik.js"></script>
+    <script type="text/javascript">
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = '%REACT_APP_CRISP_WEBSITE_ID%';
+      (function () {
+        d = document;
+        s = d.createElement('script');
+        s.src = 'https://client.crisp.chat/l.js';
+        s.async = 1;
+        d.getElementsByTagName('head')[0].appendChild(s);
+      })();
+    </script>
   </head>
   <body class="fr">
   <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
ATTENTION : la variable `REACT_APP_CRISP_WEBSITE_ID` doit être passée au moment du build front pour que l'intégration fonctionne correctement
retrouvez la valeur à passer dans le [paramétrage Crisp](https://app.crisp.chat/settings/websites/) 