### PR TITLE
Upcoming small fixes2

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/ActionsField.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/ActionsField.tsx
@@ -25,6 +25,11 @@ export const ActionsField: FC<ActionsFieldProps & FieldProps> = ({
   const isTouched = touched[field.name];
   const titles = useActionTitleList('all');
 
+  // don't display anything if data are not available...
+  if (!titles?.length) {
+    return null;
+  }
+
   const allActionIds = titles
     .filter(title => title.type !== 'referentiel')
     .map(title => title.id);

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/FicheActionForm.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/FicheActionForm.tsx
@@ -120,10 +120,11 @@ const LinkedIndicateurPersonnaliseCards = () => {
     useIndicateurPersonnaliseDefinitionList(collectivieId);
 
   const {values} = useFormikContext<FicheActionRead>();
-  const linkedIndicateursPersonnalises = values.indicateur_personnalise_ids.map(
-    indicateurId =>
+  const linkedIndicateursPersonnalises = values.indicateur_personnalise_ids
+    .map(indicateurId =>
       indicateurPersonnalises.find(indicateur => indicateur.id === indicateurId)
-  );
+    )
+    .filter(Boolean); // filtre les entrées vides
 
   return (
     <div className="flex flex-col justify-between mt-6">

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/IndicateursPersonnalisesField.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/IndicateursPersonnalisesField.tsx
@@ -31,7 +31,7 @@ export const IndicateursPersonnalisesField: FC<
 
   const allSortedIndicateurIds = [...indicateursPersoDefs.entries()]
     .sort((a, b) => compareIndexes(a[1].titre, b[1].titre))
-    .map(entry => entry[0]);
+    .map(entry => entry[1].id);
 
   const renderIndicateurOption = (id: number) => {
     const indicateur = indicateursPersoDefs.find(

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/PlanCategoriesSelectionField.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/Forms/PlanCategoriesSelectionField.tsx
@@ -18,6 +18,7 @@ import * as R from 'ramda';
 import {usePlanActionList} from 'core-logic/hooks/plan_action';
 import {PlanActionRead} from 'generated/dataLayer/plan_action_read';
 import {useCollectiviteId} from 'core-logic/hooks/params';
+import {ModifierArboDialogButton} from '../ModifierArboDialogButton';
 
 type LinkedPlanCategoriesFieldProps = {
   ficheUid: string;
@@ -96,9 +97,15 @@ const PlanDropdown = (props: {
         anchorOrigin={{vertical: 'bottom', horizontal: 'left'}}
         transformOrigin={{vertical: 'top', horizontal: 'left'}}
       >
-        {categoriesToItems(categories, categorieUid => {
-          props.onSelect(categorieUid, plan.uid);
-        })}
+        {categories?.length ? (
+          categoriesToItems(categories, categorieUid => {
+            props.onSelect(categorieUid, plan.uid);
+          })
+        ) : (
+          <MenuItem>
+            <ModifierArboDialogButton plan={plan} />
+          </MenuItem>
+        )}
       </Menu>
     </>
   );
@@ -222,6 +229,8 @@ export const PlanCategoriesSelectionField: FC<
         const categorie = R.find(categorie => {
           return categorie.uid === selected?.categorieUid;
         }, plan.categories);
+        const categories = nestPlanCategories(plan.categories);
+
         return (
           <div
             className="flex flex-row items-center gap-2 ml-4 my-4 w-full"
@@ -240,6 +249,9 @@ export const PlanCategoriesSelectionField: FC<
                 {categorie && <span>{categorie.nom}</span>}
               </div>
             </PlanDropdown>
+            {categories?.length ? (
+              <ModifierArboDialogButton plan={plan} />
+            ) : null}
           </div>
         );
       })}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/ModifierArboDialogButton.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/ModifierArboDialogButton.tsx
@@ -1,0 +1,21 @@
+import {Spacer} from 'ui/shared/Spacer';
+import {useState} from 'react';
+import {PlanEditionForm} from './Forms/PlanEditionForm';
+import {PlanActionRead} from 'generated/dataLayer/plan_action_read';
+import {UiDialogButton} from 'ui/UiDialogButton';
+
+export const ModifierArboDialogButton = (props: {plan: PlanActionRead}) => {
+  const [editing, setEditing] = useState<boolean>(false);
+
+  return (
+    <UiDialogButton
+      title="Modifier l'arborescence"
+      opened={editing}
+      setOpened={setEditing}
+      buttonClasses="fr-btn--secondary"
+    >
+      <Spacer />
+      <PlanEditionForm plan={props.plan} />
+    </UiDialogButton>
+  );
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/PlanActions.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlanActions/PlanActions.tsx
@@ -10,7 +10,6 @@ import {
   nestCategorized,
 } from './sorting';
 import {useState} from 'react';
-import {PlanEditionForm} from './Forms/PlanEditionForm';
 import {PlanCreationForm} from './Forms/PlanCreationForm';
 import {defaultDisplayCategorie} from 'app/pages/collectivite/PlanActions/defaultDisplayCategorie';
 import {LazyDetailsWithChevron} from 'ui/shared/LazyDetails';
@@ -19,6 +18,7 @@ import {PlanActionRead} from 'generated/dataLayer/plan_action_read';
 import {makeCollectiviteNouvelleFicheUrl, planActionDefaultId} from 'app/paths';
 import {UiDialogButton} from 'ui/UiDialogButton';
 import {useCollectiviteId} from 'core-logic/hooks/params';
+import {ModifierArboDialogButton} from './ModifierArboDialogButton';
 
 /**
  * The title of a category
@@ -97,22 +97,6 @@ const PlanButtons = (props: {plan: PlanActionRead}) => {
       <ModifierArboDialogButton plan={props.plan} />
       <AddFicheActionLink plan={props.plan} />
     </div>
-  );
-};
-
-const ModifierArboDialogButton = (props: {plan: PlanActionRead}) => {
-  const [editing, setEditing] = useState<boolean>(false);
-
-  return (
-    <UiDialogButton
-      title="Modifier l'arborescence"
-      opened={editing}
-      setOpened={setEditing}
-      buttonClasses="fr-btn--secondary"
-    >
-      <Spacer />
-      <PlanEditionForm plan={props.plan} />
-    </UiDialogButton>
   );
 };
 

--- a/app.territoiresentransitions.react/src/core-logic/observables/collectiviteBloc.ts
+++ b/app.territoiresentransitions.react/src/core-logic/observables/collectiviteBloc.ts
@@ -20,12 +20,22 @@ export class CurrentCollectiviteBloc {
     makeAutoObservable(this);
   }
 
+  private setCollectiviteId = (id: number | null) => {
+    this._collectiviteId = id;
+  };
+  private setNom = (nom: string | null) => {
+    this._nom = nom;
+  };
+  private setRoleName = (roleName: RoleName | null) => {
+    this._roleName = roleName;
+  };
+
   update({collectiviteId}: {collectiviteId: number | null}) {
     console.log('CollectiviteBloc update ', collectiviteId);
     if (collectiviteId === null) {
-      this._collectiviteId = null;
-      this._nom = null;
-      this._roleName = null;
+      this.setCollectiviteId(null);
+      this.setNom(null);
+      this.setRoleName(null);
     } else if (collectiviteId !== this._collectiviteId) {
       this._fetchCollectivite({collectiviteId});
     }
@@ -38,9 +48,9 @@ export class CurrentCollectiviteBloc {
       })
     )[0];
     if (ownedFetched) {
-      this._nom = ownedFetched.nom;
-      this._collectiviteId = ownedFetched.collectivite_id;
-      this._roleName = ownedFetched.role_name as RoleName;
+      this.setNom(ownedFetched.nom);
+      this.setCollectiviteId(ownedFetched.collectivite_id);
+      this.setRoleName(ownedFetched.role_name as RoleName);
     } else {
       const elsesFetched = (
         await elsesCollectiviteReadEndpoint.getBy({
@@ -48,9 +58,9 @@ export class CurrentCollectiviteBloc {
         })
       )[0];
       if (elsesFetched) {
-        this._nom = elsesFetched.nom;
-        this._collectiviteId = elsesFetched.collectivite_id;
-        this._roleName = null;
+        this.setNom(elsesFetched.nom);
+        this.setCollectiviteId(elsesFetched.collectivite_id);
+        this.setRoleName(null);
       } else {
         console.log('Collectivite is not active, should throw !');
       }

--- a/app.territoiresentransitions.react/src/ui/shared/actions/ActionStatusDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/actions/ActionStatusDropdown.tsx
@@ -139,12 +139,16 @@ class ActionStatusAvancementRadioButtonBloc {
     this.fetch();
   }
 
+  private setStatut = (s: SelectableStatut) => (this._statut = s);
+  private setAvancement = (a: ActionAvancement) => (this.avancement = a);
+  private setConcerne = (c: boolean) => (this.concerne = c);
+
   public async pickStatutValue(value: number) {
     const statut = ActionStatusAvancementRadioButtonBloc.statutByValue(value);
-    this._statut = statut;
-    this.avancement = statut.avancement;
-    this.concerne = statut.concerne;
-    await this.saveStatut();
+    this.setStatut(statut);
+    this.setAvancement(statut.avancement);
+    this.setConcerne(statut.concerne);
+    this.saveStatut();
   }
 
   get statut(): SelectableStatut {
@@ -161,8 +165,9 @@ class ActionStatusAvancementRadioButtonBloc {
       })
       .then(saved => {
         if (saved) {
-          this._statut =
-            ActionStatusAvancementRadioButtonBloc.statutByEntity(saved);
+          this.setStatut(
+            ActionStatusAvancementRadioButtonBloc.statutByEntity(saved)
+          );
         }
       });
   }
@@ -175,8 +180,9 @@ class ActionStatusAvancementRadioButtonBloc {
       })
       .then(fetched => {
         if (fetched) {
-          this._statut =
-            ActionStatusAvancementRadioButtonBloc.statutByEntity(fetched);
+          this.setStatut(
+            ActionStatusAvancementRadioButtonBloc.statutByEntity(fetched)
+          );
         }
       });
   }


### PR DESCRIPTION
traite les points suivants : 
- Dans la fiche action, pas possible de cliquer sur “action en retard” et indicateurs personnalisés toujours affichés en … (carte #1289)
- Dans le formulaire d’une fiche action, si pas d’axe créer, un petit carré moche dans le dropdown (carte #1170)

pour ce dernier point, j'ai pris l'initiative de donner la possibilité d'accéder à l'édition de l'arbo
si ce n'est pas validé je l'enlève bien sûr :)