### PR TITLE
Datalayer & business: remplace les données de personnalisation.

### DIFF
--- a/business/business/evaluation/adapters/supabase_names.py
+++ b/business/business/evaluation/adapters/supabase_names.py
@@ -34,7 +34,7 @@ class rpc:
     upsert_indicateurs = "business_upsert_indicateurs"
     update_actions = "business_update_actions"
     upsert_questions = "business_upsert_questions"
-    upsert_personnalisations = "business_upsert_personnalisations"
+    business_replace_personnalisations = "business_replace_personnalisations"
 
 
 @dataclass

--- a/business/business/referentiel/adapters/sql_referentiel_repo.py
+++ b/business/business/referentiel/adapters/sql_referentiel_repo.py
@@ -58,7 +58,7 @@ class SqlReferentielRepository(InMemoryReferentielRepository):
     ):
         raise NotImplementedError
 
-    def upsert_personnalisations(
+    def replace_personnalisations(
         self,
         personnalisations: List[ActionPersonnalisationRegles],
     ):

--- a/business/business/referentiel/adapters/supabase_referentiel_repo.py
+++ b/business/business/referentiel/adapters/supabase_referentiel_repo.py
@@ -194,7 +194,7 @@ class SupabaseReferentielRepository(SupabaseRepository, AbstractReferentielRepos
             questions=questions_as_dict,
         )
 
-    def upsert_personnalisations(
+    def replace_personnalisations(
         self,
         personnalisations: List[ActionPersonnalisationRegles],
     ):
@@ -202,7 +202,7 @@ class SupabaseReferentielRepository(SupabaseRepository, AbstractReferentielRepos
             asdict(personnalisation) for personnalisation in personnalisations
         ]
         self.client.rpc.call(
-            supabase_names.rpc.upsert_personnalisations,
+            supabase_names.rpc.business_replace_personnalisations,
             personnalisations=personnalisation_as_dicts,
         )
 

--- a/business/business/referentiel/domain/ports/referentiel_repo.py
+++ b/business/business/referentiel/domain/ports/referentiel_repo.py
@@ -89,7 +89,7 @@ class AbstractReferentielRepository(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def upsert_personnalisations(
+    def replace_personnalisations(
         self,
         personnalisations: List[ActionPersonnalisationRegles],
     ) -> None:
@@ -225,7 +225,7 @@ class InMemoryReferentielRepository(AbstractReferentielRepository):
     ):
         self._questions += questions
 
-    def upsert_personnalisations(
+    def replace_personnalisations(
         self,
         personnalisations: List[ActionPersonnalisationRegles],
     ):

--- a/business/business/referentiel/domain/use_cases/store_referentiel.py
+++ b/business/business/referentiel/domain/use_cases/store_referentiel.py
@@ -148,5 +148,5 @@ class StoreReferentielPersonnalisations(UseCase):
 
     def execute(self, trigger: events.QuestionAndReglesChecked):
         self.referentiel_repo.upsert_questions(trigger.questions)
-        self.referentiel_repo.upsert_personnalisations(trigger.regles)
+        self.referentiel_repo.replace_personnalisations(trigger.regles)
         self.bus.publish_event(events.ReferentielPersonnalisationStored())

--- a/business/tests/integration/test_supabase_referentiel_repo.py
+++ b/business/tests/integration/test_supabase_referentiel_repo.py
@@ -272,7 +272,7 @@ def test_can_get_engine_actions(
     assert isinstance(retrieved_fake_engine_actions[0], QuestionEngine)
 
 
-def test_can_upsert_and_retrieve_referentiel_personnalisations(
+def test_can_replace_and_retrieve_referentiel_personnalisations(
     supabase_referentiel_repo: SupabaseReferentielRepository,
     supabase_client: SupabaseClient,
 ):
@@ -302,7 +302,7 @@ def test_can_upsert_and_retrieve_referentiel_personnalisations(
             ),
         ],
     )
-    supabase_referentiel_repo.upsert_personnalisations([personnalisation])
+    supabase_referentiel_repo.replace_personnalisations([personnalisation])
 
     # Assert
     # 1. Check that the personnalisation is there

--- a/data_layer/postgres/definitions/31-business_replace_personnalisations.sql
+++ b/data_layer/postgres/definitions/31-business_replace_personnalisations.sql
@@ -1,0 +1,17 @@
+create or replace function
+    business_replace_personnalisations(personnalisations json[])
+    returns void
+as
+$$
+begin
+    if is_service_role() then
+        truncate personnalisation cascade;
+        truncate personnalisation_regle;
+        perform business_upsert_personnalisations(personnalisations);
+    else
+        perform set_config('response.status', '401', true);
+    end if;
+end;
+$$ language plpgsql;
+comment on function business_replace_personnalisations is
+    'Remplace les règles de personnalisation.';


### PR DESCRIPTION
Une rpc pour remplacer les contenus qui `truncate` avant l'insertion.