### PR TITLE
améliore l'affichage du score dans le cartouche de personnalisation

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -14,6 +14,7 @@ jobs:
       e2e-directory: ./e2e
       datalayer-directory: ./data_layer
       project-docker-directory: ./
+      LANG: 'fr_FR.UTF-8'
       SUPABASE_KEY: ${{secrets.TEST_ANON_SUPABASE_KEY}}
       ANON_KEY: ${{secrets.TEST_ANON_SUPABASE_KEY}}
       SERVICE_ROLE_KEY: ${{secrets.TEST_SERVICE_SUPABASE_KEY}}
@@ -25,6 +26,13 @@ jobs:
     steps:
       # cf. https://github.com/actions/checkout
       - uses: actions/checkout@v2
+
+      # fixe la langue de l'environnement de test : permet de faire passer les
+      # tests de composant utilisant des fonctions telles que toLocaleString()
+      - name: Set locale
+        run: |
+          sudo locale-gen ${{env.LANG}}
+          sudo update-locale LANG=${{env.LANG}}
 
       # Copy all projet .sample.env into .env with the variables
       - name: Make .env files

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/PersoPotentielDoc.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/PersoPotentielDoc.tsx
@@ -30,7 +30,7 @@ export const PersoPotentielDoc = (props: TPersoPotentielDocProps) => {
         )}
         <li>
           Nombre de points initial pour cette {actionDef.type} :{' '}
-          {toLocaleFixed(actionScore.point_referentiel, 2)}
+          {toLocaleFixed(actionScore.point_potentiel, 2)}
         </li>
       </ul>
     </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/PointsPotentiels.stories.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/PointsPotentiels.stories.tsx
@@ -29,7 +29,7 @@ export const PersonnaliseDeuxDigits = Template.bind({});
 PersonnaliseDeuxDigits.args = {
   actionDef: ACTION_DEF,
   actionScore: {
-    point_referentiel: 6.7,
+    point_potentiel: 6.7,
     point_potentiel_perso: 3.35,
   },
   onEdit: null,
@@ -39,5 +39,12 @@ export const PersonnaliseEtEditable = Template.bind({});
 PersonnaliseEtEditable.args = {
   actionDef: ACTION_DEF,
   actionScore: SCORE_MODIFIE,
+  onEdit: action('onEdit'),
+};
+
+export const PersonnaliseScoreZero = Template.bind({});
+PersonnaliseScoreZero.args = {
+  actionDef: ACTION_DEF,
+  actionScore: {point_potentiel: 20, point_potentiel_perso: 0},
   onEdit: action('onEdit'),
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/PointsPotentiels.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/PointsPotentiels.tsx
@@ -43,21 +43,21 @@ const getLabel = (
   actionScore: ActionScore
 ): string => {
   const {type} = actionDef;
-  const {point_referentiel, point_potentiel_perso, desactive} = actionScore;
+  const {point_potentiel, point_potentiel_perso, desactive} = actionScore;
 
   if (desactive) {
     return `Potentiel pour cette ${type} : 0 point`;
   }
 
-  const value = point_potentiel_perso || point_referentiel;
+  const value = point_potentiel_perso ?? point_potentiel;
   const points = toLocaleFixed(value, 2) + ' point' + (value > 1 ? 's' : '');
 
   const isModified =
     point_potentiel_perso !== undefined &&
-    point_potentiel_perso !== point_referentiel;
+    point_potentiel_perso !== point_potentiel;
   if (isModified) {
     const modifLabel =
-      point_potentiel_perso! > point_referentiel ? 'augmenté' : 'réduit';
+      point_potentiel_perso! > point_potentiel ? 'augmenté' : 'réduit';
     return `Potentiel ${modifLabel} pour cette ${type} : ${points}`;
   }
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/__snapshots__/PointsPotentiels.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/__snapshots__/PointsPotentiels.stories.storyshot
@@ -101,3 +101,33 @@ exports[`Storyshots App/Pages/Collectivite/Perso Potentiel Modal/Points Potentie
   </div>
 </div>
 `;
+
+exports[`Storyshots App/Pages/Collectivite/Perso Potentiel Modal/Points Potentiels Personnalise Score Zero 1`] = `
+<div
+  className="fr-highlight"
+  style={
+    Object {
+      "border": "1px solid var(--yellow-moutarde-850)",
+      "boxShadow": "inset 0.25rem 0 0 0 var(--yellow-moutarde-850)",
+      "marginLeft": 0,
+      "maxWidth": "fit-content",
+      "paddingBottom": "1rem",
+      "paddingRight": "2rem",
+      "paddingTop": "1rem",
+    }
+  }
+>
+  <div
+    className="flex items-center"
+    data-test="PointsPotentiels"
+  >
+    Potentiel réduit pour cette sous-action : 0 point
+    <button
+      className="fr-link fr-link--icon-left fr-fi-settings-line fr-ml-10v"
+      onClick={[Function]}
+    >
+      Personnaliser
+    </button>
+  </div>
+</div>
+`;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/fixture.json
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PersoPotentielModal/fixture.json
@@ -27,11 +27,11 @@
     "formulation": "Quelle est la part de la collectivité dans l’EPCI compétent en matière de <b>politique du logement et cadre de vie ?</b>"
   },
   "SCORE": {
-    "point_referentiel": 6.7,
+    "point_potentiel": 6.7,
     "point_potentiel_perso": 6.7
   },
   "SCORE_MODIFIE": {
-    "point_referentiel": 6.7,
+    "point_potentiel": 6.7,
     "point_potentiel_perso": 3.3
   },
   "REGLES": [

--- a/e2e/cypress/integration/06-personnaliser-le-referentiel.feature
+++ b/e2e/cypress/integration/06-personnaliser-le-referentiel.feature
@@ -10,18 +10,18 @@ Fonctionnalité: Personnaliser le référentiel
     Et le "cartouche de personnalisation" vérifie les conditions suivantes :
       | Element              | Condition | Valeur                                   |
       | bouton Personnaliser | visible   |                                          |
-      |                      | contient  | Potentiel réduit pour cette action : 9.6 points |
+      |                      | contient  | Potentiel pour cette action : 9,6 points |
 
     Quand je clique sur le bouton "Personnaliser" du "cartouche de personnalisation"
     Alors le "dialogue Personnaliser le potentiel" est visible
     Et le "dialogue Personnaliser le potentiel" vérifie les conditions suivantes :
-      | Element   | Condition | Valeur                                 |
-      | cartouche | contient  | Potentiel réduit pour cette action : 9.6 points |
+      | Element   | Condition | Valeur                                   |
+      | cartouche | contient  | Potentiel pour cette action : 9,6 points |
     Et la liste des questions contient les entrées suivantes :
       """
       La collectivité a-t-elle la compétence habitat ?
       binaire: non définie
 
-      La collectivité est-elle chargée de la réalisation d'un "Programme local de prévention des déchets ménagers et assimilés" (PLPDMA) du fait de sa compétence collecte et/ou par délégation d'une autre collectivité ?
-      binaire: non définie
+      Quelle est la part de la collectivité dans la structure compétente en matière de logement et d'habitat ?
+      part: 80
       """


### PR DESCRIPTION
- utilise point_potentiel plutôt que point_referentiel pour afficher un score non modifié par la personnalisation
- affiche bien 0 (plutôt que la valeur du référentiel) lorsque le potentiel personnalisé vaut 0