### PR TITLE
Datalayer: ajoute la vue retool_labellisation_demande

### DIFF
--- a/data_layer/postgres/definitions/90-retool.sql
+++ b/data_layer/postgres/definitions/90-retool.sql
@@ -226,3 +226,16 @@ as
 select l.*, nom as collectivite_nom
 from labellisation l
          join named_collectivite nc on l.collectivite_id = nc.collectivite_id;
+
+create or replace view retool_labellisation_demande
+as
+select ld.id,
+       ld.en_cours,
+       ld.collectivite_id,
+       ld.referentiel,
+       ld.etoiles,
+       ld.date,
+       nc.nom
+from labellisation_demande ld
+         left join named_collectivite nc on ld.collectivite_id = nc.collectivite_id
+;


### PR DESCRIPTION
Ajoute la vue `retool_labellisation_demande` déployée sur sandbox mais pas dans la codebase.

Déployée sur production.