### PR TITLE
Répare le statut de labellisation.

### DIFF
--- a/data_layer/migrations/17-fix_labellisation_demande.sql
+++ b/data_layer/migrations/17-fix_labellisation_demande.sql
@@ -1,0 +1,1 @@
+-- run 33a-demande_labellisation.sql

--- a/data_layer/postgres/definitions/33a-demande_labellisation.sql
+++ b/data_layer/postgres/definitions/33a-demande_labellisation.sql
@@ -6,7 +6,7 @@ $$
 with data as (select labellisation_demande.collectivite_id,
                      labellisation_demande.referentiel,
                      labellisation_demande.etoiles
-              where is_any_role_on(labellisation_demande.collectivite_id))
+              where is_authenticated())
 
 insert
 into labellisation.demande (collectivite_id, referentiel, etoiles)


### PR DESCRIPTION
Répare le cas où la collectivité n'a pas de demande en cours ce qui rends l'affichage du statut incorect. #2009

Fix : La fonction `labellisation_demande` peut être appelée par n'importe quel utilisateur authenfifié, en effet elle ne fait que créer une demande temporaire si aucune n'est présente.