### PR TITLE
Front: Réinitialisation du mot de passe

### DIFF
--- a/app.territoiresentransitions.react/src/app/Redirector.tsx
+++ b/app.territoiresentransitions.react/src/app/Redirector.tsx
@@ -1,19 +1,16 @@
 import {useEffect} from 'react';
 import {useHistory, useLocation} from 'react-router-dom';
-import {
-  myCollectivitesPath,
-  signInPath,
-  resetPwdPath,
-  resetPwdToken,
-} from 'app/paths';
+import {myCollectivitesPath, signInPath} from 'app/paths';
 import {useAuth} from 'core-logic/api/auth/AuthProvider';
 import {useInvitationState} from 'core-logic/hooks/useInvitationState';
+import {useRecoveryToken} from 'core-logic/hooks/useRecoveryToken';
 
 export const Redirector = () => {
   const history = useHistory();
-  const {pathname, hash} = useLocation();
+  const {pathname} = useLocation();
   const {isConnected} = useAuth();
   const {invitationState} = useInvitationState();
+  const recoveryToken = useRecoveryToken();
 
   // réagit aux changements de l'état "invitation"
   useEffect(() => {
@@ -25,6 +22,8 @@ export const Redirector = () => {
 
   // réagit aux changements de l'état utilisateur connecté/déconnecté
   useEffect(() => {
+    // n'applique pas les règles suivantes si un jeton de réinit. du mdp est trouvé
+    if (recoveryToken) return;
     // si déconnecté on redirige sur la page d'accueil (ou la page "se
     // connecter" dans le cas d'une invitation en attente de connexion)
     if (!isConnected) {
@@ -33,30 +32,7 @@ export const Redirector = () => {
       // si connecté et qu'on navigue sur la home on redirige vers "mes collectivités"
       history.push(myCollectivitesPath);
     }
-  }, [isConnected, invitationState]);
-
-  const {type: _type, access_token} = parseHash(hash);
-  if (access_token && _type === 'recovery') {
-    // on est en mode récupération de mdp
-    history.push(resetPwdPath.replace(`:${resetPwdToken}`, access_token));
-    return null;
-  }
+  }, [isConnected, invitationState, recoveryToken]);
 
   return null;
 };
-
-// génère un dictionnaire de clé/valeur à partir d'une chaîne de la forme
-// #cle=valeur&cle2=val2
-type TKeyValues = {[k: string]: string};
-const parseHash = (hash: string): TKeyValues =>
-  hash
-    .substring(1) // saute le # en début de chaîne
-    .split('&') // sépare les groupes de clé/valeur
-    .reduce((dict, kv) => {
-      // ajoute la clé/valeur au dictionnaire
-      const [k, v] = kv.split('=');
-      return {
-        ...dict,
-        [k]: v,
-      };
-    }, {});

--- a/app.territoiresentransitions.react/src/app/Redirector.tsx
+++ b/app.territoiresentransitions.react/src/app/Redirector.tsx
@@ -1,9 +1,15 @@
 import {useEffect} from 'react';
 import {useHistory, useLocation} from 'react-router-dom';
-import {myCollectivitesPath, signInPath} from 'app/paths';
+import {
+  myCollectivitesPath,
+  resetPwdPath,
+  resetPwdToken,
+  signInPath,
+} from 'app/paths';
 import {useAuth} from 'core-logic/api/auth/AuthProvider';
 import {useInvitationState} from 'core-logic/hooks/useInvitationState';
 import {useRecoveryToken} from 'core-logic/hooks/useRecoveryToken';
+import {useAccessToken} from 'core-logic/hooks/useVerifyRecoveryToken';
 
 export const Redirector = () => {
   const history = useHistory();
@@ -11,6 +17,7 @@ export const Redirector = () => {
   const {isConnected} = useAuth();
   const {invitationState} = useInvitationState();
   const recoveryToken = useRecoveryToken();
+  const accessToken = useAccessToken();
 
   // réagit aux changements de l'état "invitation"
   useEffect(() => {
@@ -19,6 +26,14 @@ export const Redirector = () => {
     // si l'invitation requiert la connexion on redirigue sur "se connecter"
     if (invitationState === 'waitingForLogin') history.push(signInPath);
   }, [invitationState]);
+
+  useEffect(() => {
+    // redirige vers le formulaire de réinit. de mdp si un jeton d'accès a été créé
+    if (accessToken) {
+      history.push(resetPwdPath.replace(`:${resetPwdToken}`, accessToken));
+      return;
+    }
+  }, [accessToken]);
 
   // réagit aux changements de l'état utilisateur connecté/déconnecté
   useEffect(() => {

--- a/app.territoiresentransitions.react/src/app/pages/Auth/AuthRoutes.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/AuthRoutes.tsx
@@ -1,8 +1,14 @@
 import {Route} from 'react-router-dom';
 import {RegisterPage} from 'app/pages/Auth/RegisterPage';
 import {SignInPage} from 'app/pages/Auth/SignInPage';
-import {signUpPath, signInPath, resetPwdPath} from 'app/paths';
+import {
+  signUpPath,
+  signInPath,
+  resetPwdPath,
+  recoverLandingPath,
+} from 'app/paths';
 import {ResetPasswordPage} from './ResetPasswordPage';
+import {RecoverLandingPage} from 'app/pages/Auth/RecoverLandingPage';
 
 export const AuthRoutes = () => {
   return (
@@ -15,6 +21,9 @@ export const AuthRoutes = () => {
       </Route>
       <Route path={resetPwdPath}>
         <ResetPasswordPage />
+      </Route>
+      <Route path={recoverLandingPath}>
+        <RecoverLandingPage />
       </Route>
     </>
   );

--- a/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLanding.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLanding.tsx
@@ -1,67 +1,22 @@
 import {useState} from 'react';
-import {useQuery} from 'react-query';
-import {useHistory} from 'react-router-dom';
-import {ENV} from 'environmentVariables';
-import {supabaseClient} from 'core-logic/api/supabase';
-import {resetPwdPath, resetPwdToken} from 'app/paths';
-
-/**
- * Réponse de l'appel à la fonction verify de gotrue.
- */
-type VerifyResponse = {
-  access_token: string;
-  refresh_token: string;
-  token_type: string;
-};
-
-/**
- * Permet de s'authentifier avec un recovery token.
- *
- * Consomme le recovery token et authentifie l'utilisateur.
- *
- * Port d'une fonction présente dans lib gotrue-js
- * mais absente de la version supabase.
- *
- * @param token: recovery token provenant du mail.
- * @returns un access token.
- */
-async function recover(token: String): Promise<VerifyResponse> {
-  const url = `${ENV.supabase_url!}/auth/v1/verify`;
-  const type = 'recovery';
-  const body = JSON.stringify({token, type});
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      apikey: ENV.supabase_anon_key!,
-    },
-    body,
-  });
-  const data = await response.json();
-  // supabaseClient.auth.setAuth(data.access_token); ne fonctionne pas.
-  // fixme va sans doute être redirigée.
-  await supabaseClient.auth.signIn({refreshToken: data.refresh_token});
-  return data;
-}
+import {useVerifyRecoveryToken} from 'core-logic/hooks/useVerifyRecoveryToken';
 
 /**
  * Consomme le recovery token pour obtenir un auth token.
  * Affiche le statut de la vérification du token.
  */
-const Recovery = ({token}: {token: string}) => {
-  const history = useHistory();
-  const {isError, data} = useQuery(['recover', token], () => recover(token));
-
-  if (data) {
-    history.push(resetPwdPath.replace(`:${resetPwdToken}`, data.access_token));
-  }
+const Recovery = () => {
+  const {isError, isLoading} = useVerifyRecoveryToken();
 
   if (isError) {
     return <span>Une erreur est survenue</span>;
   }
 
-  return <span>Vérification en cours</span>;
+  if (isLoading) {
+    return <span>Vérification en cours</span>;
+  }
+
+  return null;
 };
 
 /**
@@ -73,10 +28,10 @@ const Recovery = ({token}: {token: string}) => {
  *
  * @param token: recovery token provenant du mail.
  */
-const RecoverLanding = ({token}: {token: string}) => {
+const RecoverLanding = () => {
   const [recovering, setRecovering] = useState<boolean>(false);
 
-  if (recovering) return <Recovery token={token} />;
+  if (recovering) return <Recovery />;
   return (
     <section className="max-w-2xl mx-auto p-5">
       <h2 className="fr-h2 flex justify-center">Changer de mot de passe</h2>

--- a/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLanding.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLanding.tsx
@@ -1,9 +1,9 @@
-import React, {useState} from 'react';
+import {useState} from 'react';
 import {useQuery} from 'react-query';
+import {useHistory} from 'react-router-dom';
 import {ENV} from 'environmentVariables';
 import {supabaseClient} from 'core-logic/api/supabase';
 import {resetPwdPath, resetPwdToken} from 'app/paths';
-import {useHistory} from 'react-router-dom';
 
 /**
  * Réponse de l'appel à la fonction verify de gotrue.
@@ -36,7 +36,7 @@ async function recover(token: String): Promise<VerifyResponse> {
       'Content-Type': 'application/json',
       apikey: ENV.supabase_anon_key!,
     },
-    body: body,
+    body,
   });
   const data = await response.json();
   // supabaseClient.auth.setAuth(data.access_token); ne fonctionne pas.
@@ -78,7 +78,17 @@ const RecoverLanding = ({token}: {token: string}) => {
 
   if (recovering) return <Recovery token={token} />;
   return (
-    <button onClick={() => setRecovering(true)}>Changer de mot de passe</button>
+    <section className="max-w-2xl mx-auto p-5">
+      <h2 className="fr-h2 flex justify-center">Changer de mot de passe</h2>
+      <p>Vous avez demandé le renouvellement de votre mot de passe.</p>
+      <button
+        className="fr-btn"
+        data-test="Recovering"
+        onClick={() => setRecovering(true)}
+      >
+        Changer de mot de passe
+      </button>
+    </section>
   );
 };
 

--- a/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLanding.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLanding.tsx
@@ -1,0 +1,85 @@
+import React, {useState} from 'react';
+import {useQuery} from 'react-query';
+import {ENV} from 'environmentVariables';
+import {supabaseClient} from 'core-logic/api/supabase';
+import {resetPwdPath, resetPwdToken} from 'app/paths';
+import {useHistory} from 'react-router-dom';
+
+/**
+ * Réponse de l'appel à la fonction verify de gotrue.
+ */
+type VerifyResponse = {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+};
+
+/**
+ * Permet de s'authentifier avec un recovery token.
+ *
+ * Consomme le recovery token et authentifie l'utilisateur.
+ *
+ * Port d'une fonction présente dans lib gotrue-js
+ * mais absente de la version supabase.
+ *
+ * @param token: recovery token provenant du mail.
+ * @returns un access token.
+ */
+async function recover(token: String): Promise<VerifyResponse> {
+  const url = `${ENV.supabase_url!}/auth/v1/verify`;
+  const type = 'recovery';
+  const body = JSON.stringify({token, type});
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: ENV.supabase_anon_key!,
+    },
+    body: body,
+  });
+  const data = await response.json();
+  // supabaseClient.auth.setAuth(data.access_token); ne fonctionne pas.
+  // fixme va sans doute être redirigée.
+  await supabaseClient.auth.signIn({refreshToken: data.refresh_token});
+  return data;
+}
+
+/**
+ * Consomme le recovery token pour obtenir un auth token.
+ * Affiche le statut de la vérification du token.
+ */
+const Recovery = ({token}: {token: string}) => {
+  const history = useHistory();
+  const {isError, data} = useQuery(['recover', token], () => recover(token));
+
+  if (data) {
+    history.push(resetPwdPath.replace(`:${resetPwdToken}`, data.access_token));
+  }
+
+  if (isError) {
+    return <span>Une erreur est survenue</span>;
+  }
+
+  return <span>Vérification en cours</span>;
+};
+
+/**
+ * Oblige l'utilisateur à cliquer sur un bouton
+ * pour que le renouvellement du mot de passe puisse avoir lieu.
+ *
+ * Empêche les robots qui visitent le lien du mail de consommer le
+ * recovery token.
+ *
+ * @param token: recovery token provenant du mail.
+ */
+const RecoverLanding = ({token}: {token: string}) => {
+  const [recovering, setRecovering] = useState<boolean>(false);
+
+  if (recovering) return <Recovery token={token} />;
+  return (
+    <button onClick={() => setRecovering(true)}>Changer de mot de passe</button>
+  );
+};
+
+export default RecoverLanding;

--- a/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLandingPage.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLandingPage.tsx
@@ -1,7 +1,6 @@
 import {lazy, Suspense} from 'react';
 import {renderLoader} from 'utils/renderLoader';
 import {Spacer} from 'ui/shared/Spacer';
-import {useParams} from 'react-router-dom';
 
 const RecoverLanding = lazy(() => import('./RecoverLanding'));
 
@@ -11,10 +10,9 @@ const RecoverLanding = lazy(() => import('./RecoverLanding'));
  * On arrive ici depuis un lien.
  */
 export const RecoverLandingPage = () => {
-  const {token} = useParams<{token: string}>();
   return (
     <Suspense fallback={renderLoader()}>
-      <RecoverLanding token={token} />
+      <RecoverLanding />
       <Spacer />
     </Suspense>
   );

--- a/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLandingPage.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLandingPage.tsx
@@ -3,18 +3,18 @@ import {renderLoader} from 'utils/renderLoader';
 import {Spacer} from 'ui/shared/Spacer';
 import {useParams} from 'react-router-dom';
 
-const ResetPasswordForm = lazy(() => import('./ResetPasswordForm'));
+const RecoverLanding = lazy(() => import('./RecoverLanding'));
 
 /**
- * Permet à l'utilisateur de réinitialiser son mot de passe.
+ * La page de reset de mot passe.
  *
- * On arrive ici une fois que l'on est passé par RecoverLandingPage.
+ * On arrive ici depuis un lien.
  */
-export const ResetPasswordPage = () => {
+export const RecoverLandingPage = () => {
   const {token} = useParams<{token: string}>();
   return (
     <Suspense fallback={renderLoader()}>
-      <ResetPasswordForm token={token} />
+      <RecoverLanding token={token} />
       <Spacer />
     </Suspense>
   );

--- a/app.territoiresentransitions.react/src/app/paths.ts
+++ b/app.territoiresentransitions.react/src/app/paths.ts
@@ -3,6 +3,8 @@ export const signInPath = `${authBasePath}/signin`;
 export const signUpPath = `${authBasePath}/signup`;
 export const resetPwdToken = 'token';
 export const resetPwdPath = `${authBasePath}/recover/:${resetPwdToken}`;
+export const recoverToken = 'token';
+export const recoverLandingPath = `${authBasePath}/recover_landing/:${recoverToken}`;
 
 export const invitationIdParam = 'invitationId';
 export const invitationLandingPath = `/invitation/:${invitationIdParam}`;

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useInvitationState.ts
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useInvitationState.ts
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import {supabaseClient} from 'core-logic/api/supabase';
 import {useAuth} from 'core-logic/api/auth/AuthProvider';
-import {invitationLandingPath} from 'app/paths';
+import {invitationIdParam, invitationLandingPath} from 'app/paths';
 
 type TInvitationState =
   | 'empty' // aucune invitation en cours
@@ -14,8 +14,10 @@ type TInvitationState =
 // gère l'état associé à un lien d'invitation
 export const useInvitationState = () => {
   // extrait l'id d'invitation de l'url si il est présent
-  const match = useRouteMatch<{invitationId: string}>(invitationLandingPath);
-  const idFromURL = match?.params?.invitationId || null;
+  const match = useRouteMatch<{[invitationIdParam]: string}>(
+    invitationLandingPath
+  );
+  const idFromURL = match?.params?.[invitationIdParam] || null;
 
   // état de l'auth.
   const {isConnected} = useAuth();

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useRecoveryToken.ts
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useRecoveryToken.ts
@@ -1,6 +1,7 @@
 import {useRouteMatch} from 'react-router-dom';
 import {recoverLandingPath, recoverToken} from 'app/paths';
 
+// détecte un jeton de récupération du mot de passe (extrait d'un lien renvoyé par mail)
 export const useRecoveryToken = (): string | null => {
   const match = useRouteMatch<{[recoverToken]: string}>(recoverLandingPath);
   return match?.params?.[recoverToken] || null;

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useRecoveryToken.ts
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useRecoveryToken.ts
@@ -1,0 +1,7 @@
+import {useRouteMatch} from 'react-router-dom';
+import {recoverLandingPath, recoverToken} from 'app/paths';
+
+export const useRecoveryToken = (): string | null => {
+  const match = useRouteMatch<{[recoverToken]: string}>(recoverLandingPath);
+  return match?.params?.[recoverToken] || null;
+};

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useVerifyRecoveryToken.ts
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useVerifyRecoveryToken.ts
@@ -1,0 +1,80 @@
+import {useQuery, useQueryClient} from 'react-query';
+import {supabaseClient} from 'core-logic/api/supabase';
+import {ENV} from 'environmentVariables';
+import {useRecoveryToken} from './useRecoveryToken';
+
+// renvoi une clé d'identificaton de la requête de vérification du jeton de récupération
+const getQueryKey = (recoveryToken: string | null) => [
+  'recover',
+  recoveryToken,
+];
+// vérifie un jeton récupération et renvoi le jeton d'accès quand la requête réussie
+
+export const useVerifyRecoveryToken = () => {
+  const recoveryToken = useRecoveryToken();
+  const {
+    isLoading,
+    isError,
+    data: accessToken,
+  } = useQuery(getQueryKey(recoveryToken), () => recover(recoveryToken));
+  return {
+    isError,
+    isLoading,
+    accessToken,
+  };
+};
+// renvoi le dernier jeton d'accès obtenu après vérification du jeton de récupération
+
+export const useAccessToken = (): string | null | undefined => {
+  const recoveryToken = useRecoveryToken();
+  const queryClient = useQueryClient();
+  return queryClient.getQueryData(getQueryKey(recoveryToken));
+};
+/**
+ * Réponse de l'appel à la fonction verify de gotrue.
+ */
+type VerifyResponse = {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+};
+/**
+ * Permet de s'authentifier avec un recovery token.
+ *
+ * Consomme le recovery token et authentifie l'utilisateur.
+ *
+ * Port d'une fonction présente dans lib gotrue-js
+ * mais absente de la version supabase.
+ *
+ * @param token: recovery token provenant du mail.
+ * @returns un access token.
+ */
+const recover = async (
+  token: string | null
+): Promise<VerifyResponse | null> => {
+  if (!token) {
+    return null;
+  }
+
+  const url = `${ENV.supabase_url!}/auth/v1/verify`;
+  const type = 'recovery';
+  const body = JSON.stringify({token, type});
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: ENV.supabase_anon_key!,
+    },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error('Erreur de vérification du jeton');
+  }
+  const data = await response.json();
+
+  // supabaseClient.auth.setAuth(data.access_token); ne fonctionne pas.
+  // fixme va sans doute être redirigée.
+  await supabaseClient.auth.signIn({refreshToken: data.refresh_token});
+  return data?.access_token || null;
+};

--- a/data_layer/requests/password_recovery.http
+++ b/data_layer/requests/password_recovery.http
@@ -1,0 +1,37 @@
+
+### Generate a recovery link as a service, the link will be sent to the user via mail.
+POST {{api}}/auth/v1/admin/generate_link
+apikey: {{service}}
+Authorization: Bearer {{service}}
+Content-Type: application/json
+
+{
+  "type": "recovery",
+  "email": "yolo@dodo.com"
+}
+
+> {%
+    client.test("Request executed successfully", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+    client.global.set("recovery_token", response.body['action_link'].match(/token=([A-Z0-9\-\_]+)/i)[1]);
+%}
+
+### Consume the recovery as an user.
+POST {{api}}/auth/v1/verify
+apikey: {{anon}}
+Content-Type: application/json
+
+{
+  "type": "recovery",
+  "token": "{{recovery_token}}"
+}
+
+
+> {%
+    client.test("Request executed successfully", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body["access_token"], "La réponse ne comporte pas access_token");
+        client.assert(response.body["token_type"] === "bearer", "Le token n'est pas un bearer token");
+    });
+%}

--- a/e2e/cypress/integration/01-se-connecter.feature
+++ b/e2e/cypress/integration/01-se-connecter.feature
@@ -128,7 +128,11 @@ Fonctionnalité: Accéder au site et se connecter
     Alors la page vérifie les conditions suivantes :
       | Elément                               | Condition |
       | formulaire de connexion               | absent    |
-      | formulaire de réinitialisation du mdp | visible   |
+      | formulaire de réinitialisation du mdp | absent    |
+      | changer de mdp                        | présent   |
+
+    Quand je clique sur le bouton "changer de mdp"
+    Alors le "formulaire de réinitialisation du mdp" est visible
 
     Quand je remplis le "formulaire de réinitialisation du mdp" avec les valeurs suivantes :
       | Champ | Valeur                |
@@ -146,7 +150,11 @@ Fonctionnalité: Accéder au site et se connecter
     Alors la page vérifie les conditions suivantes :
       | Elément                               | Condition |
       | formulaire de connexion               | absent    |
-      | formulaire de réinitialisation du mdp | visible   |
+      | formulaire de réinitialisation du mdp | absent    |
+      | changer de mdp                        | présent   |
+
+    Quand je clique sur le bouton "changer de mdp"
+    Alors le "formulaire de réinitialisation du mdp" est visible
 
     Quand je remplis le "formulaire de réinitialisation du mdp" avec les valeurs suivantes :
       | Champ | Valeur                |

--- a/e2e/cypress/integration/01-se-connecter/selectors.js
+++ b/e2e/cypress/integration/01-se-connecter/selectors.js
@@ -16,6 +16,9 @@ export const LocalSelectors = {
       'Retour à la connexion': 'button',
     },
   },
+  'changer de mdp': {
+    selector: '[data-test=Recovering]',
+  },
   'formulaire de réinitialisation du mdp': {
     selector: '[data-test=ResetPassword]',
     children: {

--- a/e2e/cypress/integration/01-se-connecter/steps.js
+++ b/e2e/cypress/integration/01-se-connecter/steps.js
@@ -7,11 +7,25 @@ beforeEach(() => {
   cy.wrap(LocalMocks).as('LocalMocks');
 });
 
-const fakeToken = 'header.payload.sign';
 Given(
   "j'ouvre le site depuis un lien de réinitialisation du mot de passe",
-  () =>
-    cy.visit(
-      `/#access_token=${fakeToken}&refresh_token=y&expires_in=z&token_type=bearer&type=recovery`
-    )
+  () => {
+    // génère le lien tel qui sera généré par le back et envoyé par mail (il est
+    // difficile de tester la réception de mail directement)
+    cy.task('supabase_generateLink', {
+      type: 'recovery',
+      email: 'yolo@dodo.com',
+    }).then((res) => {
+      // vérifie le lien
+      const action_link = res?.data?.action_link;
+      assert(action_link, 'lien de réinit de mdp non trouvé');
+
+      // extrait le token
+      const token = action_link.match(/token=([A-Z0-9\-\_]+)/i)[1];
+      assert(token, 'token non trouvé');
+
+      // crée un lien tel qui doit être reçu par email et visite cette page
+      cy.visit(`/auth/recover_landing/${token}`);
+    });
+  }
 );

--- a/e2e/cypress/plugins/supabase.js
+++ b/e2e/cypress/plugins/supabase.js
@@ -15,5 +15,9 @@ module.exports = (on, config) => {
       const res = await supabase.rpc(name, params);
       return res || null;
     },
+    supabase_generateLink: async ({ type, email }) => {
+      const res = await supabase.auth.api.generateLink(type, email);
+      return res || null;
+    },
   });
 };


### PR DESCRIPTION
Ajoute une page `RecoverLandingPage` dont l'adresse `auth/recover_landing/{token}` sera envoyée par mail aux utilisateurs par Supabase grâce à une modification du template d'email.

Le but de cette page est de consommer le recovery token après un clic, d'authentifier l'utilisateur, et de rediriger vers la page existante `ResetPasswordPage`, et ainsi éviter qu'un bot ne consomme le recovery token avant l'utilisateur.

Ajoute également un test http: `data_layer/requests/password_recovery.http`

cf #1641