### PR TITLE
Répare l'identificaton des utilisateurs dans Crisp.

### DIFF
--- a/app.territoiresentransitions.react/src/core-logic/api/auth/AuthProvider.tsx
+++ b/app.territoiresentransitions.react/src/core-logic/api/auth/AuthProvider.tsx
@@ -35,6 +35,8 @@ export const AuthProvider = ({children}: {children: ReactNode}) => {
 
   // initialisation : enregistre l'écouteur de changements d'état
   useEffect(() => {
+    // Initialise les données crisp.
+    setCrispUserData(userData);
     // écoute les changements d'état (connecté, déconnecté, etc.)
     const {data: listener} = supabaseClient.auth.onAuthStateChange(
       async (event, updatedSession) => {


### PR DESCRIPTION
Lorsque qu'un utilisateur arrive sur la page déjà loggé alors ses DCP ne sont pas chargées dans Crisp. cf #2321