### PR TITLE
Fix front gestion membres

### DIFF
--- a/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteAccesChip.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteAccesChip.tsx
@@ -20,7 +20,7 @@ const CollectiviteAccesChip = ({acces, className}: Props) => {
         }
       )}
     >
-      {acces ?? 'Visiteur'}
+      {acces ?? 'Visite'}
     </div>
   );
 };

--- a/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteAccesChip.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteAccesChip.tsx
@@ -13,11 +13,10 @@ const CollectiviteAccesChip = ({acces, className}: Props) => {
         `${className} px-2 py-0.5 font-bold text-xs uppercase rounded-md text-blue-600 bg-blue-200`,
         {
           ['text-blue-600 bg-blue-100']:
-            acces === 'admin' || acces === 'edition',
+            acces === 'admin' || acces === 'edition' || acces === 'lecture',
         },
         {
-          ['text-yellow-800 bg-yellow-100']:
-            acces === 'lecture' || acces === null,
+          ['text-yellow-800 bg-yellow-100']: acces === null,
         }
       )}
     >

--- a/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteAccesChip.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteAccesChip.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import classNames from 'classnames';
 import {NiveauAcces} from 'generated/dataLayer';
 
@@ -7,6 +8,16 @@ type Props = {
 };
 
 const CollectiviteAccesChip = ({acces, className}: Props) => {
+  const displayedAcces = useMemo(() => {
+    if (!acces) {
+      return 'visite';
+    }
+    if (acces === 'edition') {
+      return 'édition';
+    }
+    return acces;
+  }, [acces]);
+
   return (
     <div
       className={classNames(
@@ -20,7 +31,7 @@ const CollectiviteAccesChip = ({acces, className}: Props) => {
         }
       )}
     >
-      {acces ?? 'Visite'}
+      {displayedAcces}
     </div>
   );
 };

--- a/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteNavigation.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteNavigation.tsx
@@ -1,9 +1,6 @@
-import {useMemo} from 'react';
-import {Link, NavLink} from 'react-router-dom';
+import {NavLink} from 'react-router-dom';
 import CollectiviteNavigationDropdownTab from './CollectiviteNavigationDropdownTab';
-import {makeCollectiviteTableauBordUrl} from 'app/paths';
 import {
-  CollectiviteNavDropdown,
   CollectiviteNavItems,
   isSingleNavItemDropdown,
 } from '../makeCollectiviteNavItems';

--- a/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteSwitchDropdown.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteSwitchDropdown.tsx
@@ -38,12 +38,16 @@ const CollectiviteSwitchDropdown = ({
   return (
     <>
       {collectiviteList.length === 0 ? (
-        <div className="flex items-center max-w-sm ml-auto p-4 text-sm font-bold">
-          <span className="line-clamp-1">{currentCollectivite.nom}</span>
-          <CollectiviteAccesChip
-            acces={currentCollectivite.niveau_acces}
-            className="ml-4"
-          />
+        <div className="flex ml-auto pl-2 w-full max-w-sm">
+          <div className="flex items-center w-full mt-auto mb-2 py-2 px-4 font-bold border border-gray-300">
+            <span className="mr-auto line-clamp-1 border border-transparent">
+              {currentCollectivite.nom}
+            </span>
+            <CollectiviteAccesChip
+              acces={currentCollectivite.niveau_acces}
+              className="ml-4"
+            />
+          </div>
         </div>
       ) : (
         <DropdownFloater

--- a/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteSwitchDropdown.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/CollectiviteNavigation/CollectiviteSwitchDropdown.tsx
@@ -50,11 +50,6 @@ const CollectiviteSwitchDropdown = ({
           placement="bottom-end"
           render={({close}) => (
             <nav className="border border-gray-300">
-              <p className="mb-0 px-3 py-2 italic text-sm text-gray-600">
-                {collectiviteList.length > 1
-                  ? 'Mes collectivités'
-                  : 'Ma collectivité'}
-              </p>
               <ul className="m-0 p-0">
                 {collectiviteList.map(collectivite => (
                   <li className="fr-nav__item p-0" key={collectivite.label}>

--- a/app.territoiresentransitions.react/src/app/Layout/Header/MobileNavigation/MobileCollectiviteNavigation/MobileCollectiviteNavigationDropdown/MobileCollectiviteNavigationDropdown.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/MobileNavigation/MobileCollectiviteNavigation/MobileCollectiviteNavigationDropdown/MobileCollectiviteNavigationDropdown.tsx
@@ -40,11 +40,6 @@ const MobileCollectiviteNavigationDropdown = ({
       <div className={`${isOpen ? 'block' : 'hidden'} pb-8`}>
         {item.isSelectCollectivite ? (
           <>
-            <p className="px-8 py-2 italic text-sm text-gray-600">
-              {item.listPathsAndLabels.length > 1
-                ? 'Mes collectivités'
-                : 'Ma collectivité'}
-            </p>
             {item.listPathsAndLabels.map(e => (
               <Link
                 key={e.path}

--- a/app.territoiresentransitions.react/src/app/Layout/Header/makeCollectiviteNavItems.ts
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/makeCollectiviteNavItems.ts
@@ -153,28 +153,26 @@ export const makeCollectiviteNavItems = (
     },
   ];
 
-  if (collectivite.readonly) {
-    return common;
+  const parametres = {
+    menuLabel: 'Paramètres',
+    listPathsAndLabels: [
+      {
+        label: 'Gestion des membres',
+        path: makeCollectiviteUsersUrl({
+          collectiviteId,
+        }),
+      },
+    ],
+  };
+
+  if (!collectivite.readonly) {
+    parametres.listPathsAndLabels.unshift({
+      label: 'Personnalisation des référentiels',
+      path: makeCollectivitePersoRefUrl({
+        collectiviteId,
+      }),
+    });
   }
 
-  return [
-    ...common,
-    {
-      menuLabel: 'Paramètres',
-      listPathsAndLabels: [
-        {
-          label: 'Personnalisation des référentiels',
-          path: makeCollectivitePersoRefUrl({
-            collectiviteId,
-          }),
-        },
-        {
-          label: 'Gestion des membres',
-          path: makeCollectiviteUsersUrl({
-            collectiviteId,
-          }),
-        },
-      ],
-    },
-  ];
+  return [...common, parametres];
 };

--- a/app.territoiresentransitions.react/src/app/pages/Auth/RegisterForm.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/RegisterForm.tsx
@@ -84,7 +84,10 @@ const RegistrationFormTextField = ({
 const CGU = ({showWarning}: {showWarning?: boolean}) => (
   <label className="cgu">
     {showWarning && (
-      <div className="mb-2 text-sm opacity-80 text-red-500">
+      <div
+        className="mb-2 text-sm opacity-80 text-red-500"
+        data-test="cgu_error"
+      >
         L'acceptation de la politique de protection des données à caractère
         personnel est nécessaire pour créer un compte.
       </div>
@@ -124,7 +127,10 @@ const RegistrationForm = () => {
     );
   } else if (state === 'success') {
     return (
-      <section className="max-w-2xl mx-auto p-5 text-center">
+      <section
+        className="max-w-2xl mx-auto p-5 text-center"
+        data-test="signup_success"
+      >
         <Spacer />
         <p>Votre compte a bien été créé ! </p>
         <Spacer />
@@ -156,7 +162,7 @@ const RegistrationForm = () => {
   };
 
   return (
-    <section className="max-w-2xl mx-auto p-5">
+    <section className="max-w-2xl mx-auto p-5" data-test="SignUpPage">
       <Spacer />
       <h2 className="fr-h2 flex justify-center">Créer un compte</h2>
       <div className="mx-auto">

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/__snapshots__/Membres.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/__snapshots__/Membres.stories.storyshot
@@ -51,7 +51,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
             <th
               className="py-3 px-5 whitespace-nowrap"
             >
-              Champs d'intervention
+              Champ d'intervention
                
               <span
                 className="block text-xs font-normal"
@@ -71,10 +71,10 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </span>
             </th>
             <th
-              className="py-3 px-5 whitespace-nowrap text-right"
+              className="py-3 px-5 whitespace-nowrap"
             >
               <div
-                className="flex items-center justify-end"
+                className="flex items-center"
               >
                 Accès
               </div>
@@ -183,7 +183,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -315,7 +315,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -444,7 +444,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -481,22 +481,43 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               colSpan={5}
             >
               <span
-                className="block mb-1 text-sm text-gray-500"
+                className="block mb-0.5 text-xs text-gray-500"
               >
                 invite@dodo.com
               </span>
               <span
-                className="text-sm text-gray-600"
+                className="font-medium text-xs text-gray-600"
               >
                 Création de compte en attente
               </span>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
-              <span>
-                Lecture
-              </span>
+              <div
+                data-test="acces-dropdown"
+              >
+                <button
+                  aria-label="ouvrir le menu"
+                  className="flex items-center w-full p-2 -ml-2 text-left text-sm"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onPointerDown={[Function]}
+                >
+                  <span
+                    className="mr-auto"
+                  >
+                    Lecture
+                  </span>
+                  <span
+                    className="fr-fi-arrow-down-s-line mt-1 ml-1 scale-90 "
+                  />
+                </button>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -565,7 +586,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
             hidden={true}
             value=""
           >
-            Selectionnez une option
+            Sélectionnez une option
           </option>
           <option
             value="admin"
@@ -647,7 +668,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
             <th
               className="py-3 px-5 whitespace-nowrap"
             >
-              Champs d'intervention
+              Champ d'intervention
                
               <span
                 className="block text-xs font-normal"
@@ -667,10 +688,10 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </span>
             </th>
             <th
-              className="py-3 px-5 whitespace-nowrap text-right"
+              className="py-3 px-5 whitespace-nowrap"
             >
               <div
-                className="flex items-center justify-end"
+                className="flex items-center"
               >
                 Accès
               </div>
@@ -779,7 +800,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -911,7 +932,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -1040,7 +1061,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -1077,22 +1098,43 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               colSpan={5}
             >
               <span
-                className="block mb-1 text-sm text-gray-500"
+                className="block mb-0.5 text-xs text-gray-500"
               >
                 invite@dodo.com
               </span>
               <span
-                className="text-sm text-gray-600"
+                className="font-medium text-xs text-gray-600"
               >
                 Création de compte en attente
               </span>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
-              <span>
-                Lecture
-              </span>
+              <div
+                data-test="acces-dropdown"
+              >
+                <button
+                  aria-label="ouvrir le menu"
+                  className="flex items-center w-full p-2 -ml-2 text-left text-sm"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onPointerDown={[Function]}
+                >
+                  <span
+                    className="mr-auto"
+                  >
+                    Lecture
+                  </span>
+                  <span
+                    className="fr-fi-arrow-down-s-line mt-1 ml-1 scale-90 "
+                  />
+                </button>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -1161,7 +1203,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
             hidden={true}
             value=""
           >
-            Selectionnez une option
+            Sélectionnez une option
           </option>
           <option
             value="admin"
@@ -1243,7 +1285,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
             <th
               className="py-3 px-5 whitespace-nowrap"
             >
-              Champs d'intervention
+              Champ d'intervention
                
               <span
                 className="block text-xs font-normal"
@@ -1263,10 +1305,10 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </span>
             </th>
             <th
-              className="py-3 px-5 whitespace-nowrap text-right"
+              className="py-3 px-5 whitespace-nowrap"
             >
               <div
-                className="flex items-center justify-end"
+                className="flex items-center"
               >
                 Accès
               </div>
@@ -1375,7 +1417,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -1507,7 +1549,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -1636,7 +1678,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -1673,22 +1715,43 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
               colSpan={5}
             >
               <span
-                className="block mb-1 text-sm text-gray-500"
+                className="block mb-0.5 text-xs text-gray-500"
               >
                 invite@dodo.com
               </span>
               <span
-                className="text-sm text-gray-600"
+                className="font-medium text-xs text-gray-600"
               >
                 Création de compte en attente
               </span>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
-              <span>
-                Lecture
-              </span>
+              <div
+                data-test="acces-dropdown"
+              >
+                <button
+                  aria-label="ouvrir le menu"
+                  className="flex items-center w-full p-2 -ml-2 text-left text-sm"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onPointerDown={[Function]}
+                >
+                  <span
+                    className="mr-auto"
+                  >
+                    Lecture
+                  </span>
+                  <span
+                    className="fr-fi-arrow-down-s-line mt-1 ml-1 scale-90 "
+                  />
+                </button>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -1757,7 +1820,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Qu Admin Qui In
             hidden={true}
             value=""
           >
-            Selectionnez une option
+            Sélectionnez une option
           </option>
           <option
             value="admin"
@@ -1839,7 +1902,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Que Lecteur 1`]
             <th
               className="py-3 px-5 whitespace-nowrap"
             >
-              Champs d'intervention
+              Champ d'intervention
                
               <span
                 className="block text-xs font-normal"
@@ -1859,10 +1922,10 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Que Lecteur 1`]
               </span>
             </th>
             <th
-              className="py-3 px-5 whitespace-nowrap text-right"
+              className="py-3 px-5 whitespace-nowrap"
             >
               <div
-                className="flex items-center justify-end"
+                className="flex items-center"
               >
                 Accès
               </div>
@@ -1924,7 +1987,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Que Lecteur 1`]
               </span>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <span>
                 Admin
@@ -1990,7 +2053,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Que Lecteur 1`]
               </span>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <span>
                 Édition
@@ -2098,7 +2161,7 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Que Lecteur 1`]
               </div>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <div
                 data-test="acces-dropdown"
@@ -2135,18 +2198,18 @@ exports[`Storyshots app/pages/collectivite/Users/Membres En Tant Que Lecteur 1`]
               colSpan={5}
             >
               <span
-                className="block mb-1 text-sm text-gray-500"
+                className="block mb-0.5 text-xs text-gray-500"
               >
                 invite@dodo.com
               </span>
               <span
-                className="text-sm text-gray-600"
+                className="font-medium text-xs text-gray-600"
               >
                 Création de compte en attente
               </span>
             </td>
             <td
-              className="relative px-4 text-right"
+              className="relative px-4"
             >
               <span>
                 Lecture

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/InvitationForm.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/InvitationForm.tsx
@@ -67,6 +67,9 @@ const InvitationForm = ({
   const formRef = useRef<FormikProps<any>>(null);
 
   const [formIsFilling, setFormIsFilling] = useState(true);
+  const [accesInvitationForm, setAccesInvitationForm] = useState<
+    NiveauAcces | undefined
+  >(undefined);
 
   const handleClearForm = () => {
     setFormIsFilling(true);
@@ -80,13 +83,16 @@ const InvitationForm = ({
     email: string;
     acces: NiveauAcces | '';
   }) => {
-    const req: AddUserToCollectiviteRequest = {
-      collectiviteId: currentCollectivite.collectivite_id,
-      email: values.email,
-      niveauAcces: values.acces === '' ? 'lecture' : values.acces,
-    };
-    addUser(req);
-    setFormIsFilling(false);
+    if (values.acces) {
+      const req: AddUserToCollectiviteRequest = {
+        collectiviteId: currentCollectivite.collectivite_id,
+        email: values.email,
+        niveauAcces: values.acces,
+      };
+      addUser(req);
+      setFormIsFilling(false);
+      setAccesInvitationForm(values.acces);
+    }
   };
 
   return (
@@ -119,12 +125,13 @@ const InvitationForm = ({
           </button>
         </Form>
       </Formik>
-      {!formIsFilling && (
+      {!formIsFilling && accesInvitationForm && (
         <AddUserResponse
           addUserResponse={addUserResponse}
           currentCollectivite={currentCollectivite}
           currentUser={currentUser}
           handleClearForm={handleClearForm}
+          acces={accesInvitationForm}
         />
       )}
     </div>
@@ -136,18 +143,20 @@ const AddUserResponse = ({
   currentCollectivite,
   currentUser,
   handleClearForm,
+  acces,
 }: {
   addUserResponse: AddUserToCollectiviteResponse | null;
   currentCollectivite: CurrentCollectivite;
   currentUser: UserData;
   handleClearForm: () => void;
+  acces: NiveauAcces;
 }) => {
   if (addUserResponse?.invitationUrl) {
     return (
       <InvitationMessage
         currentCollectivite={currentCollectivite}
         currentUser={currentUser}
-        acces={'edition'}
+        acces={acces}
         invitationUrl={addUserResponse.invitationUrl}
       />
     );
@@ -202,7 +211,7 @@ const SelectField = (props: SelectFieldProps) => (
             {...field}
           >
             <option value="" disabled hidden>
-              Selectionnez une option
+              Sélectionnez une option
             </option>
             {props.options.map((option: AccesOption) => (
               <option key={option.value} value={option.value}>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/InvitationMessage.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/InvitationMessage.tsx
@@ -42,9 +42,16 @@ const InvitationMessage = ({
     return;
   }, [copiedText]);
 
+  const accesDisplayed = useMemo(() => {
+    if (acces === 'edition') {
+      return 'édition';
+    }
+    return acces;
+  }, [acces]);
+
   const message = useMemo(
     () =>
-      `Objet : Invitation à collaborer sur Territoires en transitions.fr\n\nBonjour,\n\n${currentUser.prenom} ${currentUser.nom} de ${currentCollectivite.nom} vous invite à collaborer.\n\nLe lien suivant vous donnera un accès ${acces} pour cette collectivité.\n\nCliquez sur le lien suivant pour accepter l’invitation et créer votre compte :\nlien ${invitationUrl}\n\n---------\n\nTerritoires en transitions est une initiative de l’ADEME pour accompagner la transition écologique des collectivités.`,
+      `Objet : Invitation à collaborer sur Territoires en transitions.fr\n\nBonjour,\n\n${currentUser.prenom} ${currentUser.nom} de ${currentCollectivite.nom} vous invite à collaborer.\n\nLe lien suivant vous donnera un accès ${accesDisplayed} pour cette collectivité.\n\nCliquez sur le lien suivant pour accepter l’invitation et créer votre compte :\nlien ${invitationUrl}\n\n---------\n\nTerritoires en transitions est une initiative de l’ADEME pour accompagner la transition écologique des collectivités.`,
     [currentCollectivite, currentUser, acces, invitationUrl]
   );
 
@@ -88,7 +95,7 @@ const InvitationMessage = ({
         </button>
         {copiedText && (
           <span className="absolute left-0 bottom-full mb-2 px-4 py-1 rounded bg-green-500 text-white">
-            copié&nbsp;!
+            Copié&nbsp;!
           </span>
         )}
       </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTable.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTable.tsx
@@ -39,7 +39,7 @@ const MembreListTable = ({
                 </span>
               </th>
               <th className={thClassNames}>
-                Champs d'intervention{' '}
+                Champ d'intervention{' '}
                 <span className="block text-xs font-normal">
                   dans cette collectivité
                 </span>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTable.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTable.tsx
@@ -50,8 +50,8 @@ const MembreListTable = ({
                   dans cette collectivité
                 </span>
               </th>
-              <th className={`${thClassNames} text-right`}>
-                <div className="flex items-center justify-end">Accès</div>
+              <th className={`${thClassNames}`}>
+                <div className="flex items-center">Accès</div>
               </th>
             </tr>
           </thead>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTableRow.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTableRow.tsx
@@ -163,7 +163,7 @@ const MembreListTableRow = ({
           </span>
         )}
       </td>
-      <td className={`${cellClassNames} text-right`}>
+      <td className={`${cellClassNames}`}>
         {canUpdate ? (
           <>
             <AccesDropdown

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTableRow.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTableRow.tsx
@@ -81,12 +81,12 @@ const MembreListTableRow = ({
     return (
       <tr data-test={`MembreRow-${email}`} className={rowClassNames}>
         <td colSpan={5} className={cellClassNames}>
-          <span className="block mb-1 text-sm text-gray-500">{email}</span>
-          <span className="text-sm text-gray-600">
+          <span className="block mb-0.5 text-xs text-gray-500">{email}</span>
+          <span className="font-medium text-xs text-gray-600">
             Création de compte en attente
           </span>
         </td>
-        <td className={`${cellClassNames} text-right`}>
+        <td className={`${cellClassNames}`}>
           <span>{niveauAccesLabels[niveau_acces]}</span>
         </td>
       </tr>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTableRow.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/MembreListTableRow.tsx
@@ -76,6 +76,10 @@ const MembreListTableRow = ({
     TAccesDropdownOption | undefined
   >(undefined);
 
+  const onRemoveInvite = (membreEmail: string) => {
+    removeFromCollectivite(membreEmail);
+  };
+
   // Si le membre est en attente d'acceptation d'une invitation
   if (membre_id === null) {
     return (
@@ -87,7 +91,17 @@ const MembreListTableRow = ({
           </span>
         </td>
         <td className={`${cellClassNames}`}>
-          <span>{niveauAccesLabels[niveau_acces]}</span>
+          {/* currentUserAccess="edition" permet de n'afficher que l'option "remove" même en étant admin */}
+          {canUpdate ? (
+            <AccesDropdown
+              isCurrentUser={isCurrentUser}
+              currentUserAccess="edition"
+              value={niveau_acces}
+              onSelect={() => onRemoveInvite(membre.email)}
+            />
+          ) : (
+            <span>{niveauAccesLabels[niveau_acces]}</span>
+          )}
         </td>
       </tr>
     );
@@ -177,6 +191,7 @@ const MembreListTableRow = ({
               setIsOpen={setIsAccesModalOpen}
               selectedOption={accesOptionSelected}
               membreId={membre_id}
+              membreEmail={membre.email}
               isCurrentUser={isCurrentUser}
               updateMembre={updateMembre}
               removeFromCollectivite={removeFromCollectivite}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/UpdateMembreAccesModal.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/UpdateMembreAccesModal.tsx
@@ -12,6 +12,7 @@ export type AccesModalProps = {
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   selectedOption: TAccesDropdownOption | undefined;
   membreId: string;
+  membreEmail: string;
   isCurrentUser: boolean;
   removeFromCollectivite: TRemoveFromCollectivite;
   updateMembre: TUpdateMembre;
@@ -22,6 +23,7 @@ const UpdateMemberAccesModal = ({
   setIsOpen,
   selectedOption,
   membreId,
+  membreEmail,
   isCurrentUser,
   removeFromCollectivite,
   updateMembre,
@@ -47,7 +49,7 @@ const UpdateMemberAccesModal = ({
             <div className="mt-2 fr-btns-group fr-btns-group--left fr-btns-group--inline-reverse fr-btns-group--inline-lg">
               <button
                 onClick={() => {
-                  removeFromCollectivite(membreId);
+                  removeFromCollectivite(membreEmail);
                   setIsOpen(false);
                 }}
                 aria-label="Confirmer"

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/__snapshots__/InvitationForm.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/__snapshots__/InvitationForm.stories.storyshot
@@ -53,7 +53,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/InvitationForm As Ad
           hidden={true}
           value=""
         >
-          Selectionnez une option
+          Sélectionnez une option
         </option>
         <option
           value="edition"
@@ -131,7 +131,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/InvitationForm As Ed
           hidden={true}
           value=""
         >
-          Selectionnez une option
+          Sélectionnez une option
         </option>
         <option
           value="edition"

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/__snapshots__/InvitationMessage.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/__snapshots__/InvitationMessage.stories.storyshot
@@ -20,7 +20,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/InvitationMessage Ac
       className="text-gray-600 text-sm mb-0"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "Objet : Invitation à collaborer sur Territoires en transitions.fr<br><br>Bonjour,<br><br>Yolo Dodo de Fake Collectivite vous invite à collaborer.<br><br>Le lien suivant vous donnera un accès edition pour cette collectivité.<br><br>Cliquez sur le lien suivant pour accepter l’invitation et créer votre compte :<br>lien https://invitationUrl<br><br>---------<br><br>Territoires en transitions est une initiative de l’ADEME pour accompagner la transition écologique des collectivités.",
+          "__html": "Objet : Invitation à collaborer sur Territoires en transitions.fr<br><br>Bonjour,<br><br>Yolo Dodo de Fake Collectivite vous invite à collaborer.<br><br>Le lien suivant vous donnera un accès édition pour cette collectivité.<br><br>Cliquez sur le lien suivant pour accepter l’invitation et créer votre compte :<br>lien https://invitationUrl<br><br>---------<br><br>Territoires en transitions est une initiative de l’ADEME pour accompagner la transition écologique des collectivités.",
         }
       }
       data-test="invitation-message"

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/__snapshots__/MembreListTable.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/__snapshots__/MembreListTable.stories.storyshot
@@ -37,7 +37,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As A
           <th
             className="py-3 px-5 whitespace-nowrap"
           >
-            Champs d'intervention
+            Champ d'intervention
              
             <span
               className="block text-xs font-normal"
@@ -57,10 +57,10 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As A
             </span>
           </th>
           <th
-            className="py-3 px-5 whitespace-nowrap text-right"
+            className="py-3 px-5 whitespace-nowrap"
           >
             <div
-              className="flex items-center justify-end"
+              className="flex items-center"
             >
               Accès
             </div>
@@ -169,7 +169,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As A
             </div>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <div
               data-test="acces-dropdown"
@@ -301,7 +301,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As A
             </div>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <div
               data-test="acces-dropdown"
@@ -430,7 +430,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As A
             </div>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <div
               data-test="acces-dropdown"
@@ -467,22 +467,43 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As A
             colSpan={5}
           >
             <span
-              className="block mb-1 text-sm text-gray-500"
+              className="block mb-0.5 text-xs text-gray-500"
             >
               invite@dodo.com
             </span>
             <span
-              className="text-sm text-gray-600"
+              className="font-medium text-xs text-gray-600"
             >
               Création de compte en attente
             </span>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
-            <span>
-              Lecture
-            </span>
+            <div
+              data-test="acces-dropdown"
+            >
+              <button
+                aria-label="ouvrir le menu"
+                className="flex items-center w-full p-2 -ml-2 text-left text-sm"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onPointerDown={[Function]}
+              >
+                <span
+                  className="mr-auto"
+                >
+                  Lecture
+                </span>
+                <span
+                  className="fr-fi-arrow-down-s-line mt-1 ml-1 scale-90 "
+                />
+              </button>
+            </div>
           </td>
         </tr>
       </tbody>
@@ -528,7 +549,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As E
           <th
             className="py-3 px-5 whitespace-nowrap"
           >
-            Champs d'intervention
+            Champ d'intervention
              
             <span
               className="block text-xs font-normal"
@@ -548,10 +569,10 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As E
             </span>
           </th>
           <th
-            className="py-3 px-5 whitespace-nowrap text-right"
+            className="py-3 px-5 whitespace-nowrap"
           >
             <div
-              className="flex items-center justify-end"
+              className="flex items-center"
             >
               Accès
             </div>
@@ -613,7 +634,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As E
             </span>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <span>
               Admin
@@ -724,7 +745,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As E
             </div>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <div
               data-test="acces-dropdown"
@@ -806,7 +827,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As E
             </span>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <span>
               Lecture
@@ -822,18 +843,18 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As E
             colSpan={5}
           >
             <span
-              className="block mb-1 text-sm text-gray-500"
+              className="block mb-0.5 text-xs text-gray-500"
             >
               invite@dodo.com
             </span>
             <span
-              className="text-sm text-gray-600"
+              className="font-medium text-xs text-gray-600"
             >
               Création de compte en attente
             </span>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <span>
               Lecture
@@ -883,7 +904,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As L
           <th
             className="py-3 px-5 whitespace-nowrap"
           >
-            Champs d'intervention
+            Champ d'intervention
              
             <span
               className="block text-xs font-normal"
@@ -903,10 +924,10 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As L
             </span>
           </th>
           <th
-            className="py-3 px-5 whitespace-nowrap text-right"
+            className="py-3 px-5 whitespace-nowrap"
           >
             <div
-              className="flex items-center justify-end"
+              className="flex items-center"
             >
               Accès
             </div>
@@ -968,7 +989,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As L
             </span>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <span>
               Admin
@@ -1034,7 +1055,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As L
             </span>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <span>
               Édition
@@ -1142,7 +1163,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As L
             </div>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <div
               data-test="acces-dropdown"
@@ -1179,18 +1200,18 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable As L
             colSpan={5}
           >
             <span
-              className="block mb-1 text-sm text-gray-500"
+              className="block mb-0.5 text-xs text-gray-500"
             >
               invite@dodo.com
             </span>
             <span
-              className="text-sm text-gray-600"
+              className="font-medium text-xs text-gray-600"
             >
               Création de compte en attente
             </span>
           </td>
           <td
-            className="relative px-4 text-right"
+            className="relative px-4"
           >
             <span>
               Lecture
@@ -1240,7 +1261,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable Empt
           <th
             className="py-3 px-5 whitespace-nowrap"
           >
-            Champs d'intervention
+            Champ d'intervention
              
             <span
               className="block text-xs font-normal"
@@ -1260,10 +1281,10 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable Empt
             </span>
           </th>
           <th
-            className="py-3 px-5 whitespace-nowrap text-right"
+            className="py-3 px-5 whitespace-nowrap"
           >
             <div
-              className="flex items-center justify-end"
+              className="flex items-center"
             >
               Accès
             </div>
@@ -1324,7 +1345,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable Is L
           <th
             className="py-3 px-5 whitespace-nowrap"
           >
-            Champs d'intervention
+            Champ d'intervention
              
             <span
               className="block text-xs font-normal"
@@ -1344,10 +1365,10 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTable Is L
             </span>
           </th>
           <th
-            className="py-3 px-5 whitespace-nowrap text-right"
+            className="py-3 px-5 whitespace-nowrap"
           >
             <div
-              className="flex items-center justify-end"
+              className="flex items-center"
             >
               Accès
             </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/__snapshots__/MembreListTableRow.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/components/__snapshots__/MembreListTableRow.stories.storyshot
@@ -102,7 +102,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTableRow A
     </div>
   </td>
   <td
-    className="relative px-4 text-right"
+    className="relative px-4"
   >
     <div
       data-test="acces-dropdown"
@@ -237,7 +237,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTableRow E
     </div>
   </td>
   <td
-    className="relative px-4 text-right"
+    className="relative px-4"
   >
     <div
       data-test="acces-dropdown"
@@ -307,7 +307,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTableRow I
     />
   </td>
   <td
-    className="relative px-4 text-right"
+    className="relative px-4"
   >
     <span>
       Lecture
@@ -418,7 +418,7 @@ exports[`Storyshots app/pages/collectivite/Users/components/MembreListTableRow L
     </div>
   </td>
   <td
-    className="relative px-4 text-right"
+    className="relative px-4"
   >
     <div
       data-test="acces-dropdown"

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/types.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/types.ts
@@ -32,4 +32,4 @@ export type TUpdateMembreArgs = {
 
 export type TUpdateMembre = (args: TUpdateMembreArgs) => Promise<boolean>;
 
-export type TRemoveFromCollectivite = (user_id: string) => void;
+export type TRemoveFromCollectivite = (userEmail: string) => void;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Users/useRemoveFromCollectivite.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Users/useRemoveFromCollectivite.tsx
@@ -10,12 +10,12 @@ type RemoveMembreResponse = {
 
 const removeMembre = async (
   collectiviteId: number,
-  userId: string
+  userEmail: string
 ): Promise<RemoveMembreResponse | null> => {
   const {data, error} = await supabaseClient.rpc(
     'remove_membre_from_collectivite',
     {
-      membre_id: userId,
+      email: userEmail,
       collectivite_id: collectiviteId,
     }
   );
@@ -33,9 +33,9 @@ export const useRemoveFromCollectivite = () => {
   const collectivite_id = useCollectiviteId();
   const queryClient = useQueryClient();
   const {isLoading, mutate} = useMutation(
-    (user_id: string) =>
+    (userEmail: string) =>
       collectivite_id
-        ? removeMembre(collectivite_id, user_id)
+        ? removeMembre(collectivite_id, userEmail)
         : Promise.resolve(null),
     {
       onSuccess: () => {

--- a/app.territoiresentransitions.react/src/ui/shared/SelectDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/SelectDropdown.tsx
@@ -1,5 +1,12 @@
 import {keys} from 'ramda';
-import {forwardRef, ReactElement, Ref, useState} from 'react';
+import {
+  forwardRef,
+  ReactElement,
+  Ref,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {Placement} from '@floating-ui/react-dom-interactions';
 import DropdownFloater from 'ui/shared/floating-ui/DropdownFloater';
 
@@ -162,6 +169,19 @@ export const MultiSelectDropdown = <T extends string>({
   placeholderText?: string;
 }) => {
   const [selectedValues, setSelectedValues] = useState<T[]>(values || []);
+
+  // On execute onSelect() uniquement après un changement et non au premier render du composant
+  const isFirstRender = useRef(true);
+  // On execute onSelect() dans un useEffect pour avoir la bonne valeur car useState étant asynchrone,
+  // si l'on performe onSelect sur le onClick du bouton on se retrouve avec la version précédente des selectedValues
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    onSelect(selectedValues);
+  }, [selectedValues]);
+
   return (
     <DropdownFloater
       render={() =>
@@ -182,7 +202,6 @@ export const MultiSelectDropdown = <T extends string>({
                 } else {
                   setSelectedValues([...selectedValues, v as T]);
                 }
-                onSelect(selectedValues);
               }}
             >
               <div className="w-6 mr-2">

--- a/app.territoiresentransitions.react/src/ui/shared/SelectDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/SelectDropdown.tsx
@@ -164,7 +164,7 @@ export const MultiSelectDropdown = <T extends string>({
   const [selectedValues, setSelectedValues] = useState<T[]>(values || []);
   return (
     <DropdownFloater
-      render={({close}) =>
+      render={() =>
         Object.keys(labels).map(v => {
           const label = labels[v as T];
           return (
@@ -183,7 +183,6 @@ export const MultiSelectDropdown = <T extends string>({
                   setSelectedValues([...selectedValues, v as T]);
                 }
                 onSelect(selectedValues);
-                close();
               }}
             >
               <div className="w-6 mr-2">

--- a/data_layer/postgres/test/02-droits.sql
+++ b/data_layer/postgres/test/02-droits.sql
@@ -24,8 +24,8 @@ create or replace function
 as
 $$
 -- Vide la tables
-truncate private_utilisateur_droit;
-truncate utilisateur.invitation;
+truncate utilisateur.invitation cascade ;
+truncate private_utilisateur_droit cascade ;
 
 -- Restaure les copies.
 insert into public.private_utilisateur_droit

--- a/data_layer/postgres/test/02-droits.sql
+++ b/data_layer/postgres/test/02-droits.sql
@@ -8,18 +8,33 @@ from public.private_utilisateur_droit;
 comment on table test.private_utilisateur_droit is
     'Copie de la table des droits.';
 
-create function
+
+-- Copie la table des invitations.
+create table test.invitation
+as
+select *
+from utilisateur.invitation i;
+comment on table test.invitation is
+    'Copie de la table des invitations.';
+
+
+create or replace function
     test_reset_droits()
     returns void
 as
 $$
--- Vide la table des droits
+-- Vide la tables
 truncate private_utilisateur_droit;
+truncate utilisateur.invitation;
 
--- Restaure la copie.
+-- Restaure les copies.
 insert into public.private_utilisateur_droit
 select *
 from test.private_utilisateur_droit;
+
+insert into utilisateur.invitation (niveau, email, collectivite_id, created_by, accepted_at)
+select niveau, email, collectivite_id, created_by, accepted_at
+from test.invitation;
 $$ language sql security definer;
 comment on function test_reset_droits is
     'Reinitialise les droits.';

--- a/data_layer/sqitch/deploy/utilisateur/add_phone_to_dcp.sql
+++ b/data_layer/sqitch/deploy/utilisateur/add_phone_to_dcp.sql
@@ -2,6 +2,7 @@
 
 BEGIN;
 
-alter table dcp add telephone text not null default '';
+alter table dcp
+    add telephone varchar(30);
 
 COMMIT;

--- a/data_layer/sqitch/revert/utilisateur/droits_v2.sql
+++ b/data_layer/sqitch/revert/utilisateur/droits_v2.sql
@@ -4,7 +4,8 @@ BEGIN;
 
 drop function if exists test_attach_user;
 drop function if exists test_add_random_user;
-drop table if exists  test.private_utilisateur_droit;
+drop table if exists test.private_utilisateur_droit;
+drop table if exists test.invitation;
 
 alter table private_utilisateur_droit
     add role_name role_name not null default 'aucun';

--- a/data_layer/tests/test.sql
+++ b/data_layer/tests/test.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(8);
+select plan(11);
 
 select *
 into random_admin
@@ -21,6 +21,27 @@ select set_has(
                'select user_id from random_admin;',
                'The random user should be in the droits table.'
            );
+
+select test_remove_user(ra.email)
+from random_admin ra;
+
+select set_hasnt(
+               'select id, email from auth.users;',
+               'select user_id as id, email from random_admin;',
+               'The random user should not be in the auth.users table anymore.'
+           );
+select set_hasnt(
+               'select user_id, nom, prenom, email from dcp;',
+               'select user_id, nom, prenom, email from random_admin;',
+               'The random user should not be in the dcp table anymore.'
+           );
+
+select set_hasnt(
+               'select user_id from private_utilisateur_droit where collectivite_id = 10 and niveau_acces = ''admin'';',
+               'select user_id from random_admin;',
+               'The random user should not be in the droits table anymore.'
+           );
+
 
 select test.identify_as('yolo@dodo.com');
 select ok(

--- a/e2e/cypress/integration/02-associer-une-collectivite-a-mon-compte.feature
+++ b/e2e/cypress/integration/02-associer-une-collectivite-a-mon-compte.feature
@@ -3,6 +3,8 @@
 Fonctionnalité: Associer une collectivité à mon compte
 
   Scénario: Sélectionner la première collectivité à associer à mon compte (cas d'une collectivité déjà activée)
+    Etant donné que les droits utilisateur sont réinitialisés
+    Et que les informations des membres sont réinitialisées
     Etant donné que je suis connecté en tant que "yulu"
 
     Quand je visite la vue "Toutes les collectivités"

--- a/e2e/cypress/integration/09-creer-un-compte.feature
+++ b/e2e/cypress/integration/09-creer-un-compte.feature
@@ -1,0 +1,73 @@
+# language: fr
+
+Fonctionnalité: Création de compte
+
+  Scénario: Nono Dodo créé un compte
+    Etant donné que l'utilisateur "nono@dodo.com" est supprimé
+    Etant donné que j'ouvre le site
+    Alors la page vérifie les conditions suivantes :
+      | Elément                 | Condition |
+      | header                  | visible   |
+      | home                    | visible   |
+      | formulaire de connexion | absent    |
+      | footer                  | visible   |
+      | bouton support          | présent   |
+
+    Quand je clique sur le bouton "Créer un compte" du "header"
+    Alors la page vérifie les conditions suivantes :
+      | Elément                          | Condition |
+      | header                           | visible   |
+      | home                             | absent    |
+      | formulaire de création de compte | visible   |
+      | footer                           | visible   |
+
+    Quand je remplis le "formulaire de création de compte" avec les valeurs suivantes :
+      | Champ  | Valeur        |
+      | email  | nono@dodo.com |
+      | mdp    | Noo0000oo00!! |
+      | prenom | Nono          |
+      | nom    | Dodo          |
+
+    Et que je clique sur le bouton "Valider" du "formulaire de création de compte"
+    Alors la page vérifie les conditions suivantes :
+      | Elément                          | Condition |
+      | formulaire de création de compte | visible   |
+      | CGU en erreur                    | visible   |
+
+
+    Quand je clique sur le bouton "cgu" du "formulaire de création de compte"
+    Et que je clique sur le bouton "Valider" du "formulaire de création de compte"
+    Alors la page vérifie les conditions suivantes :
+      | Elément                            | Condition |
+      | header                             | visible   |
+      | home                               | absent    |
+      | formulaire de création de compte   | absent    |
+      | Confirmation de création de compte | visible   |
+      | footer                             | visible   |
+
+    # Devrait passer mais l'auth n'est pas reactive.
+    # Alors le bouton compte contient le texte "Nono"
+
+    # -----------
+    # On est connecté mais on affiche un bouton se connecter
+    # Le flow va changer
+    Quand je me déconnecte
+    Et que je clique sur le bouton "Se connecter" du "header"
+    Alors la page vérifie les conditions suivantes :
+      | Elément                                    | Condition |
+      | formulaire de connexion                    | visible   |
+
+    Quand je remplis le "formulaire de connexion" avec les valeurs suivantes :
+      | Champ | Valeur        |
+      | email | nono@dodo.com |
+      | mdp   | Noo0000oo00!! |
+    Et que je clique sur le bouton "Valider" du "formulaire de connexion"
+    # -----------
+
+    Alors la page vérifie les conditions suivantes :
+      | Elément                  | Condition |
+      | header                   | visible   |
+      | home                     | absent    |
+      | formulaire de connexion  | absent    |
+      | toutes les collectivités | visible   |
+      | footer                   | visible   |

--- a/e2e/cypress/integration/09-creer-un-compte/selectors.js
+++ b/e2e/cypress/integration/09-creer-un-compte/selectors.js
@@ -1,0 +1,8 @@
+export const LocalSelectors = {
+  'CGU en erreur': {
+    selector: '[data-test=cgu_error]',
+  },
+  'Confirmation de création de compte': {
+    selector: '[data-test=signup_success]',
+  },
+};

--- a/e2e/cypress/integration/09-creer-un-compte/steps.js
+++ b/e2e/cypress/integration/09-creer-un-compte/steps.js
@@ -1,0 +1,13 @@
+/// <reference types="Cypress" />
+
+import { LocalSelectors } from './selectors';
+
+beforeEach(() => {
+  // enregistre les définitions locales
+  cy.wrap(LocalSelectors).as('LocalSelectors');
+});
+
+Given(/le bouton compte contient le texte "([^"]+)"/, (message) => {
+  cy.get('[data-test="connectedMenu"] button').should('contain', message);
+});
+

--- a/e2e/cypress/integration/10-flow-invitation.feature
+++ b/e2e/cypress/integration/10-flow-invitation.feature
@@ -1,0 +1,69 @@
+# language: fr
+
+Fonctionnalité: Ajouter un membre au profil de la collectivité
+
+  Scénario: J'invite Nono qui n'est pas un utilisateur
+    Etant donné que l'utilisateur "nono@dodo.com" est supprimé
+    Etant donné que les droits utilisateur sont réinitialisés
+    Et que je suis connecté en tant que "yolo"
+
+    Quand je suis sur la page "Gestion des membres" de la collectivité "1"
+    Alors un formulaire d'invitation est affiché
+
+    Quand je renseigne l'email "nono@dodo.com" de la personne à inviter en "admin"
+    Et que je valide le formulaire
+    Alors un message d'invitation est affiché
+
+    Quand je clique sur le bouton "Copier le message"
+    Alors le presse-papier contient "Yolo Dodo de Ambérieu-en-Bugey vous invite à collaborer."
+
+    Quand je clique sur le bouton "Copier le lien"
+    Alors le presse-papier contient "/invitation/"
+
+    Quand je me déconnecte
+    Alors la page "home" est visible
+
+    Quand je visite le lien copié
+    Alors le "formulaire de connexion" est visible
+
+    Quand je clique sur le bouton "Créer un compte" du "header"
+    Et que je remplis le "formulaire de création de compte" avec les valeurs suivantes :
+      | Champ  | Valeur        |
+      | email  | nono@dodo.com |
+      | mdp    | Noo0000oo00!! |
+      | prenom | Nono          |
+      | nom    | Dodo          |
+
+    Et que je clique sur le bouton "cgu" du "formulaire de création de compte"
+    Et que je clique sur le bouton "Valider" du "formulaire de création de compte"
+
+    # ------------
+    # Cette partie déco/reco n'a pas lieu d'être mais le flow va changer.
+    Quand je me déconnecte
+    Et que je clique sur le bouton "Se connecter" du "header"
+    Alors la page vérifie les conditions suivantes :
+      | Elément                                    | Condition |
+      | formulaire de connexion                    | visible   |
+
+    Quand je remplis le "formulaire de connexion" avec les valeurs suivantes :
+      | Champ | Valeur        |
+      | email | nono@dodo.com |
+      | mdp   | Noo0000oo00!! |
+    Et que je clique sur le bouton "Valider" du "formulaire de connexion"
+    # ------------
+
+    Alors la page vérifie les conditions suivantes :
+      | Elément                               | Condition |
+      | header                                | visible   |
+      | home                                  | absent    |
+      | formulaire de connexion               | absent    |
+      | le tableau de bord de la collectivité | visible   |
+      | footer                                | visible   |
+
+
+    Quand je suis sur la page "Gestion des membres" de la collectivité "1"
+    Alors le tableau des membres doit contenir l'utilisateur "nono@dodo.com"
+
+
+
+

--- a/e2e/cypress/integration/10-flow-invitation/selectors.js
+++ b/e2e/cypress/integration/10-flow-invitation/selectors.js
@@ -1,0 +1,20 @@
+export const LocalSelectors = {
+  "tableau des membres": {
+    selector: '[data-test=MembreListTable]',
+  },
+  "formulaire d'invitation": {
+    selector: '[data-test=invitation-form]',
+  },
+  "message d'invitation": {
+    selector: '[data-test=invitation-message]',
+  },
+  "Copier le message": {
+    selector: '[data-test=copier-message]', //[data-test=CopyLink]
+  },
+  "Copier le lien": {
+    selector: '[data-test=copier-url]', //[data-test=CopyLink]
+  },
+  // 'Générer un nouveau lien': {
+  //   selector: '[data-test=InvitationLink] [data-test=GenLink]',
+  // },
+};

--- a/e2e/cypress/integration/10-flow-invitation/steps.js
+++ b/e2e/cypress/integration/10-flow-invitation/steps.js
@@ -1,0 +1,75 @@
+/// <reference types="Cypress" />
+
+import { LocalSelectors } from './selectors';
+
+beforeEach(() => {
+  // enregistre les définitions locales
+  cy.wrap(LocalSelectors).as('LocalSelectors');
+});
+
+Given("un formulaire d'invitation est affiché", () => {
+  cy.get(LocalSelectors["formulaire d'invitation"].selector).should(
+  'be.visible'
+  );
+});
+
+Given("un message d'invitation est affiché", () => {
+  cy.get(LocalSelectors["message d'invitation"].selector).should(
+  'be.visible'
+  );
+});
+Given(/je renseigne l'email "([^"]+)" de la personne à inviter en "([^"]+)"/, (email, acces) => {
+  cy.get('input[name="email"]')
+  .clear()
+  .type(email)
+  cy.get('select[name="acces"]')
+  .select(acces)
+});
+
+
+Given(
+  /le tableau des membres doit contenir l'utilisateur "([^"]+)"/,
+  (mail) => {
+    cy.get(LocalSelectors["tableau des membres"].selector).should(
+      "contain",
+      mail
+    );
+  }
+);
+
+// pour que le test sur le contenu du presse-papier fonctionne correctement
+// on doit donner le focus au bouton et utiliser realClick au lien de click :(
+// Ref: https://github.com/cypress-io/cypress/issues/18198#issuecomment-1003756021
+Given('je clique sur le bouton "Copier le message"', () => {
+  cy.get(LocalSelectors['Copier le message'].selector).focus().realClick();
+});
+
+Given('je clique sur le bouton "Copier le lien"', () => {
+  cy.get(LocalSelectors['Copier le lien'].selector).focus().realClick();
+});
+
+Given(/le presse-papier contient "([^"]*)"/, (message) => {
+  cy.task('getClipboard').should('contain', message);
+});
+
+Given('je visite le lien copié', () =>
+  cy.task('getClipboard').then((val) => {
+    cy.visit({
+      url: val,
+    });
+  })
+);
+
+Given(
+  /la page contient (?:les|la) collectivités? "([^"]*)"/,
+  (collectiviteNames) => {
+    const names = collectiviteNames.split(',').map((s) => s.trim());
+    cy.get('[data-test=SimpleCollectiviteCard]').each(($el, index) =>
+      cy.wrap($el).should('contain.text', names[index])
+    );
+  }
+);
+
+Given('la page ne contient aucune collectivité', () => {
+  cy.get('[data-test=SimpleCollectiviteCard]').should('not.exist');
+});

--- a/e2e/cypress/integration/common/selectors.js
+++ b/e2e/cypress/integration/common/selectors.js
@@ -7,6 +7,7 @@ export const Selectors = {
     selector: 'header[role=banner]',
     children: {
       'Se connecter': '[data-test=signin]',
+      'Créer un compte': '[data-test=signup]',
     },
   },
   footer: {
@@ -31,6 +32,17 @@ export const Selectors = {
       mdp: 'input[name=password]',
       Valider: 'button[type=submit]',
       'Mot de passe oublié': '[data-test=forgotten-pwd]',
+    },
+  },
+  'formulaire de création de compte': {
+    selector: '[data-test=SignUpPage]',
+    children: {
+      email: 'input[name=email]',
+      mdp: 'input[name=password]',
+      nom: 'input[name=nom]',
+      prenom: 'input[name=prenom]',
+      cgu: 'input[name=vie_privee_conditions]',
+      Valider: 'button[type=submit]',
     },
   },
 };

--- a/e2e/cypress/integration/common/steps.js
+++ b/e2e/cypress/integration/common/steps.js
@@ -48,6 +48,10 @@ Given('les droits utilisateur sont réinitialisés', () => {
   cy.task('supabase_rpc', { name: 'test_reset_droits' });
 });
 
+Given(/l'utilisateur "([^"]*)" est supprimé/, (email) => {
+  cy.task('supabase_rpc', { name: 'test_remove_user', params: {'email': email} });
+});
+
 Given('les informations des membres sont réinitialisées', () => {
   cy.task('supabase_rpc', { name: 'test_reset_membres' });
 });


### PR DESCRIPTION
Fix des retours de test gestion des membres

Notion -> https://www.notion.so/territoires-en-transitions/Gestion-des-membres-7899ac5d98d94be097809fad5e212e8d

reste à faire:
- impossible de retirer un membre ou un invité, j'ai une 404 sur la requête. Maintenant on utilise le mail et non l'id.
- rien ne s'affiche quand on est visiteur -> normal il faut que tu serves les données
- j'ai vu avec emeline pour savoir si l'on affiche une modal de confirmation pour retirer un invité, j'attends le contenu.