### PR TITLE
fix input qui pouvait prendre des caractères spéciaux sur firefox et safari

### DIFF
--- a/app.territoiresentransitions.react/src/app/Redirector.tsx
+++ b/app.territoiresentransitions.react/src/app/Redirector.tsx
@@ -4,12 +4,10 @@ import {
   homePath,
   invitationPath,
   makeCollectiviteTableauBordUrl,
-  resetPwdPath,
   signInPath,
 } from 'app/paths';
 import {useAuth} from 'core-logic/api/auth/AuthProvider';
 import {useInvitationState} from 'core-logic/hooks/useInvitationState';
-import {useAccessToken} from 'core-logic/hooks/useVerifyRecoveryToken';
 import {useOwnedCollectivites} from 'core-logic/hooks/useOwnedCollectivites';
 
 export const Redirector = () => {
@@ -17,7 +15,6 @@ export const Redirector = () => {
   const {pathname} = useLocation();
   const {isConnected} = useAuth();
   const {invitationState} = useInvitationState();
-  const accessToken = useAccessToken();
   const userCollectivites = useOwnedCollectivites();
   const isSigninPath = pathname === signInPath;
   const isJustSignedIn = // L'utilisateur vient de se connecter.

--- a/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLanding.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Auth/RecoverLanding.tsx
@@ -1,14 +1,12 @@
 import * as Yup from 'yup';
-import {Field, Form, Formik, FormikHelpers} from 'formik';
+import {Field, Form, Formik} from 'formik';
 import LabeledTextField from 'ui/forms/LabeledTextField';
 import {emailValidator} from 'app/pages/Auth/RegisterForm';
 import {ValiderButton} from 'ui/shared/ValiderButton';
-import React from 'react';
-import {useVerifyRecoveryToken} from 'core-logic/hooks/useVerifyRecoveryToken';
 import {useRecoveryToken} from 'core-logic/hooks/useRecoveryToken';
 import {supabaseClient} from 'core-logic/api/supabase';
 import {useHistory} from 'react-router-dom';
-import {homePath, resetPwdPath} from 'app/paths';
+import {resetPwdPath} from 'app/paths';
 
 const validation = Yup.object({
   email: emailValidator,

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/AnyIndicateurValues.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/AnyIndicateurValues.tsx
@@ -1,8 +1,12 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {AnyIndicateurRepository} from 'core-logic/api/repositories/AnyIndicateurRepository';
 import {useCollectiviteId} from 'core-logic/hooks/params';
 import {Editable} from 'ui/shared/Editable';
 import {useCurrentCollectivite} from 'core-logic/hooks/useCurrentCollectivite';
+import {
+  onlyNumericWithFloatRegExp,
+  setInputFilter,
+} from 'ui/shared/input/utils';
 
 // Here we take advantage of IndicateurPersonnaliseValue and IndicateurValue
 // having the same shape.
@@ -34,6 +38,12 @@ function AnyIndicateurValueInput<T extends string | number>({
       });
   }, []);
 
+  /** Ajoute le filtre numérique sur l'input */
+  const ref = useRef<HTMLInputElement>(null);
+  useLayoutEffect(() => {
+    setInputFilter(ref, value => onlyNumericWithFloatRegExp.test(value));
+  }, []);
+
   const convertToFloatAndStore = (event: React.FormEvent<HTMLInputElement>) => {
     const inputValue = event.currentTarget.value;
 
@@ -52,6 +62,7 @@ function AnyIndicateurValueInput<T extends string | number>({
     <label className="flex flex-col mx-2 j">
       <div className="flex pl-2 justify-center">{year}</div>
       <input
+        ref={ref}
         className={`text-right fr-input mt-2 w-full bg-white p-3 border-b-2 text-sm font-normal text-gray-500 ${
           borderColor === 'blue' ? 'border-bf500' : 'border-gray-500'
         }`}
@@ -60,7 +71,7 @@ function AnyIndicateurValueInput<T extends string | number>({
           setInputValue(event.currentTarget.value)
         }
         onBlur={convertToFloatAndStore}
-        type="number"
+        type="text"
         lang="fr"
         disabled={collectivite.readonly}
       />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/AnyIndicateurValues.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/AnyIndicateurValues.tsx
@@ -41,8 +41,12 @@ function AnyIndicateurValueInput<T extends string | number>({
   /** Ajoute le filtre numérique sur l'input */
   const ref = useRef<HTMLInputElement>(null);
   useLayoutEffect(() => {
-    setInputFilter(ref, value => onlyNumericWithFloatRegExp.test(value));
-  }, []);
+    setInputFilter(
+      ref,
+      value => onlyNumericWithFloatRegExp.test(value),
+      'Nombre uniquement'
+    );
+  }, [ref.current]);
 
   const convertToFloatAndStore = (event: React.FormEvent<HTMLInputElement>) => {
     const inputValue = event.currentTarget.value;

--- a/app.territoiresentransitions.react/src/ui/shared/input/utils.ts
+++ b/app.territoiresentransitions.react/src/ui/shared/input/utils.ts
@@ -1,7 +1,7 @@
 export const onlyNumericWithFloatRegExp = new RegExp(/^-?\d*[.,]?\d*$/);
 
 /**
- * Permet de n'autoriser que certains caractères dans un  ou textarea.
+ * Permet de n'autoriser que certains caractères dans un input ou textarea.
  *
  * Basé sur cette solution:
  * https://stackoverflow.com/a/469362/16408731

--- a/app.territoiresentransitions.react/src/ui/shared/input/utils.ts
+++ b/app.territoiresentransitions.react/src/ui/shared/input/utils.ts
@@ -1,0 +1,71 @@
+export const onlyNumericWithFloatRegExp = new RegExp(/^-?\d*[.,]?\d*$/);
+
+/**
+ * Permet de n'autoriser que certains caractères dans un  ou textarea.
+ *
+ * Basé sur cette solution:
+ * https://stackoverflow.com/a/469362/16408731
+ * @param ref La référence de l'input
+ * @param inputFilter Regex que l'on souhaite appliquer au filtre
+ * @param errMsg Si le message d'erreur est défini, affiche le message quand un caractère non autorisé est renseigné
+ */
+export const setInputFilter = (
+  ref: React.RefObject<HTMLInputElement | HTMLTextAreaElement>,
+  inputFilter: (value: string) => boolean,
+  errMsg?: string
+): void => {
+  [
+    'input',
+    'keydown',
+    'keyup',
+    'mousedown',
+    'mouseup',
+    'select',
+    'contextmenu',
+    'drop',
+    'focusout',
+  ].forEach(event => {
+    ref &&
+      ref.current &&
+      ref.current.addEventListener(
+        event,
+        function (
+          this: (HTMLInputElement | HTMLTextAreaElement) & {
+            oldValue: string;
+            oldSelectionStart: number | null;
+            oldSelectionEnd: number | null;
+          },
+          e: Event
+        ) {
+          if (inputFilter(this.value)) {
+            if (
+              errMsg &&
+              ['keydown', 'mousedown', 'focusout'].indexOf(e.type) >= 0
+            ) {
+              this.setCustomValidity('');
+            }
+            this.oldValue = this.value;
+            this.oldSelectionStart = this.selectionStart;
+            this.oldSelectionEnd = this.selectionEnd;
+          } else if (Object.prototype.hasOwnProperty.call(this, 'oldValue')) {
+            if (errMsg) {
+              this.setCustomValidity(errMsg);
+              this.reportValidity();
+            }
+            this.value = this.oldValue;
+            if (
+              this.oldSelectionStart !== null &&
+              this.oldSelectionEnd !== null
+            ) {
+              this.setSelectionRange(
+                this.oldSelectionStart,
+                this.oldSelectionEnd
+              );
+            }
+          } else {
+            this.value = '';
+          }
+        }
+      );
+  });
+};


### PR DESCRIPTION
⚠️ J'ai un comportement bizarre en local, des fois ca marche et d'autre fois non je ne comprends pas pourquoi. Cela devrait marcher à chaque fois. Si vous pouvez test sur différents navigateurs pour être sur.

Les navigateurs ne prennent pas tous en charge le `type="number"` sur les inputs ou seulement au submit d'un form, ce qui n'est pas le cas dans le composant que l'on utilise. De plus ce type permet quand meme de rentrer la lettre "e" et "E" sur chrome.

J'implémente cette fonction que j'ai trouvé sur SO: https://stackoverflow.com/a/469362/16408731

C'est la plus exhaustive que j'ai trouvé, permettant avec la Regex `onlyNumericWithFloatRegExp` de n'avoir que des nombres entiers, décimaux avec , et .