### PR TITLE
Ajout sous-action manquante 5.2.2.3

### DIFF
--- a/data_layer/migrations/20-add-sous-action-5.2.2.3.sql
+++ b/data_layer/migrations/20-add-sous-action-5.2.2.3.sql
@@ -1,0 +1,40 @@
+BEGIN; 
+
+-- Move cae_5.2.2.8 children into cae_5.2.2.9 children
+select private.move_action_data('cae_5.2.2.8.1', 'cae_5.2.2.9.1');
+select private.move_action_data('cae_5.2.2.8.2', 'cae_5.2.2.9.2');
+
+
+-- Move cae_5.2.2.7 into cae_5.2.2.8
+select private.move_action_data('cae_5.2.2.7', 'cae_5.2.2.8');
+
+-- Move cae_5.2.2.6 children into cae_5.2.2.7 children
+select private.move_action_data('cae_5.2.2.6.1', 'cae_5.2.2.7.1');
+select private.move_action_data('cae_5.2.2.6.2', 'cae_5.2.2.7.2');
+select private.move_action_data('cae_5.2.2.6.3', 'cae_5.2.2.7.3');
+select private.move_action_data('cae_5.2.2.6.4', 'cae_5.2.2.7.4');
+select private.move_action_data('cae_5.2.2.6.5', 'cae_5.2.2.7.5');
+select private.move_action_data('cae_5.2.2.6.6', 'cae_5.2.2.7.6');
+select private.move_action_data('cae_5.2.2.6.7', 'cae_5.2.2.7.7');
+
+-- Move cae_5.2.2.5 children into cae_5.2.2.6 children
+select private.move_action_data('cae_5.2.2.5.1', 'cae_5.2.2.6.1');
+select private.move_action_data('cae_5.2.2.5.2', 'cae_5.2.2.6.2');
+
+-- Move cae_5.2.2.4 children into cae_5.2.2.5 children
+select private.move_action_data('cae_5.2.2.4.1', 'cae_5.2.2.5.1');
+select private.move_action_data('cae_5.2.2.4.2', 'cae_5.2.2.5.2');
+
+-- Move cae_5.2.2.3 children into cae_5.2.2.4 children
+select private.move_action_data('cae_5.2.2.3.1', 'cae_5.2.2.4.1');
+select private.move_action_data('cae_5.2.2.3.2', 'cae_5.2.2.4.2');
+select private.move_action_data('cae_5.2.2.3.3', 'cae_5.2.2.4.3');
+
+
+-- Remove definitions
+delete from action_definition where action_id in ('cae_5.2.2.6.4', 'cae_5.2.2.6.5', 'cae_5.2.2.6.6', 'cae_5.2.2.6.7', 'cae_5.2.2.3.3', 'cae_5.2.2.8.1', 'cae_5.2.2.8.2'); 
+delete from action_computed_points where action_id in ('cae_5.2.2.6.4', 'cae_5.2.2.6.5', 'cae_5.2.2.6.6', 'cae_5.2.2.6.7', 'cae_5.2.2.3.3', 'cae_5.2.2.8.1', 'cae_5.2.2.8.2'); 
+delete from action_relation where id  in ('cae_5.2.2.6.4', 'cae_5.2.2.6.5', 'cae_5.2.2.6.6', 'cae_5.2.2.6.7', 'cae_5.2.2.3.3', 'cae_5.2.2.8.1', 'cae_5.2.2.8.2'); 
+
+
+COMMIT; 

--- a/markdown/referentiels/cae/5.2.2.md
+++ b/markdown/referentiels/cae/5.2.2.md
@@ -114,11 +114,25 @@ identifiant: 5.2.2.2.1
 ```yaml
 identifiant: 5.2.2.2.2
 ```
+### Faire usage de sobriété pour éviter certains achats
+```yaml
+identifiant: 5.2.2.3
+pourcentage: 5
+categorie: bases
+```
+#### Description
+Notamment pour les commandes publiques d’importance (hors consommables de base), la collectivité avant tout investissement ou commande publique : 
+- s’interroge sur le besoin, l’impact énergétique et environnemental de l’achat, 
+- dimensionne celui-ci au plus juste,
+- évite les achats à fort impact intrinsèque (par exemple, elle s’assure avant un changement de parc d’équipements que le nouveau parc aura un impact énergétique et GES total plus faible que le précédent (même si les fonctionnalités sont plus nombreuses)).
 
+#### Preuve
+- Il n'y a pas de document type attendu pour cette action du référentiel
+- Vous pouvez ajouter les documents preuves que vous jugez utiles pour justifier de l'avancement de cette action
 
 ### Mener les actions simples
 ```yaml
-identifiant: 5.2.2.3
+identifiant: 5.2.2.4
 pourcentage: 10
 categorie: mise en œuvre
 ```
@@ -129,23 +143,23 @@ categorie: mise en œuvre
 #### Actions
 ##### Identifier et changer les pratiques pour les produits faciles à éviter ou substituer
 ```yaml
-identifiant: 5.2.2.3.1
+identifiant: 5.2.2.4.1
 ```
 
 ##### Effectuer les achats d'articles en papier (papier à imprimer, papier hygiénique), de détergents et d'appareils de bureau selon des critères écologiques (exemple : écolabel et notamment écolabel européen)
 ```yaml
-identifiant: 5.2.2.3.2
+identifiant: 5.2.2.4.2
 ```
 
 ##### Privilégier les produits de saison, locaux et biologiques pour les évènements ponctuels organisés par la collectivité, les achats alimentaires
 ```yaml
-identifiant: 5.2.2.3.3
+identifiant: 5.2.2.4.3
 ```
 cf. mesure 6.4.1  pour la restauration collective
 
 ### Contribuer à un réseau local achats responsables
 ```yaml
-identifiant: 5.2.2.4
+identifiant: 5.2.2.5
 pourcentage: 5
 categorie: mise en œuvre
 ```
@@ -156,44 +170,17 @@ categorie: mise en œuvre
 #### Actions
 ##### Entrer dans un réseau local d'achats responsables et y participer activement
 ```yaml
-identifiant: 5.2.2.4.1
+identifiant: 5.2.2.5.1
 ```
 
 ##### Favoriser les plateformes locales de distribution
 ```yaml
-identifiant: 5.2.2.4.2
+identifiant: 5.2.2.5.2
 ```
 cf. mesure 6.4.1  pour la restauration collective
 
 
 ### Adopter une délibération définissant un plan pour les achats responsables, recenser les pratiques, effectuer un état des lieux de la production locale
-```yaml
-identifiant: 5.2.2.5
-pourcentage: 20
-categorie: mise en œuvre
-```
-#### Preuve
-- Il n'y a pas de document type attendu pour cette action du référentiel
-- Vous pouvez ajouter les documents preuves que vous jugez utiles pour justifier de l'avancement de cette action
-
-#### Actions
-##### Connaître et formaliser dans un document (listing) l'étendue de l'offre locale pour répondre aux besoins de la collectivité (producteurs, fournisseurs...)
-```yaml
-identifiant: 5.2.2.5.1
-```
-
-##### Identifier dans cette délibération, les pratiques d'achats et les améliorations à apporter
-```yaml
-identifiant: 5.2.2.5.2
-```
-
-##### Détailler les directives pour les achats dans les domaines du matériel du bureau, entretien des bâtiments, véhicules et mobilité, matériaux de construction
-```yaml
-identifiant: 5.2.2.5.3
-```
-
-
-### Appliquer des clauses environnementales variées et systématiser la logique cycle de vie des produits et services, afin de déterminer les dispositions environnementales pertinentes selon les familles d'achat
 ```yaml
 identifiant: 5.2.2.6
 pourcentage: 20
@@ -204,47 +191,74 @@ categorie: mise en œuvre
 - Vous pouvez ajouter les documents preuves que vous jugez utiles pour justifier de l'avancement de cette action
 
 #### Actions
-##### Inviter les candidats à répondre aux appels d'offres de manière électronique
+##### Connaître et formaliser dans un document (listing) l'étendue de l'offre locale pour répondre aux besoins de la collectivité (producteurs, fournisseurs...)
 ```yaml
 identifiant: 5.2.2.6.1
 ```
 
-##### Évaluer les fournisseurs sur l’application de leurs engagements environnementaux pendant le déroulement de leur prestation (par exemple prestataires de restauration collective ou travaux)
+##### Identifier dans cette délibération, les pratiques d'achats et les améliorations à apporter
 ```yaml
 identifiant: 5.2.2.6.2
+```
+
+##### Détailler les directives pour les achats dans les domaines du matériel du bureau, entretien des bâtiments, véhicules et mobilité, matériaux de construction
+```yaml
+identifiant: 5.2.2.6.3
+```
+
+
+### Appliquer des clauses environnementales variées et systématiser la logique cycle de vie des produits et services, afin de déterminer les dispositions environnementales pertinentes selon les familles d'achat
+```yaml
+identifiant: 5.2.2.7
+pourcentage: 20
+categorie: mise en œuvre
+```
+#### Preuve
+- Il n'y a pas de document type attendu pour cette action du référentiel
+- Vous pouvez ajouter les documents preuves que vous jugez utiles pour justifier de l'avancement de cette action
+
+#### Actions
+##### Inviter les candidats à répondre aux appels d'offres de manière électronique
+```yaml
+identifiant: 5.2.2.7.1
+```
+
+##### Évaluer les fournisseurs sur l’application de leurs engagements environnementaux pendant le déroulement de leur prestation (par exemple prestataires de restauration collective ou travaux)
+```yaml
+identifiant: 5.2.2.7.2
 ```
 ###### Description
 Exemple : La pondération des critères environnementaux est au moins égale à 10% de la note globale d’un marché et se fonde sur des éléments vérifiables (ex : note de frais d’aliments bio et locaux, remboursement de billets de train, etc.) que l’attributaire devra remettre au commanditaire
 
 ##### Encourager la fourniture du bilan GES des produits/services achetés dans les appels d’offres
 ```yaml
-identifiant: 5.2.2.6.3
+identifiant: 5.2.2.7.3
 ```
 
 ##### Effectuer l'entretien des bâtiments et des espaces publics selon des critères écologiques
 ```yaml
-identifiant: 5.2.2.6.4
+identifiant: 5.2.2.7.4
 ```
 
 ##### Effectuer le choix des matériaux de construction selon des critères écologiques (le bois est notamment systématiquement étudié) et repose sur les gisements locaux (Pisé, paille, etc.)
 ```yaml
-identifiant: 5.2.2.6.5
+identifiant: 5.2.2.7.5
 ```
 
 ##### Choisir les techniques et matériaux de finition, ainsi que le mobilier pour limiter la pollution de l'air intérieur (faibles émissions de COV et formaldéhydes notamment), soit en privilégiant des produits avec étiquette A+, soit en achetant des produits d’occasion
 ```yaml
-identifiant: 5.2.2.6.6
+identifiant: 5.2.2.7.6
 ```
 
 ##### Inclure la prise en compte de la durée de vie et de la fin de vie des produits achetés dans les critères d’achats
 ```yaml
-identifiant: 5.2.2.6.7
+identifiant: 5.2.2.7.7
 ```
 
 
 ### Participer à l'amélioration de l'offre en services et produits responsables / entraîner les acteurs locaux
 ```yaml
-identifiant: 5.2.2.7
+identifiant: 5.2.2.8
 pourcentage: 5
 categorie: mise en œuvre
 ```
@@ -255,11 +269,10 @@ Les fournisseurs et producteurs sont informés de la politique d’achats respon
 - Il n'y a pas de document type attendu pour cette action du référentiel
 - Vous pouvez ajouter les documents preuves que vous jugez utiles pour justifier de l'avancement de cette action
 
-
 ### Passer au crible l'ensemble des achats publics
 ```yaml
-identifiant: 5.2.2.8
-pourcentage: 20
+identifiant: 5.2.2.9
+pourcentage: 15
 categorie: effets
 ```
 #### Preuve
@@ -269,10 +282,10 @@ categorie: effets
 #### Actions
 ##### % des marchés (en nombre) intégrant des clauses environnementales (et sociales) dans les spécifications techniques ou les critères d’attribution en augmentation
 ```yaml
-identifiant: 5.2.2.8.1
+identifiant: 5.2.2.9.1
 ```
 
 ##### % des marchés (en €) intégrant des clauses environnementales (et sociales) dans les spécifications techniques ou les critères d’attribution en augmentation
 ```yaml
-identifiant: 5.2.2.8.2
+identifiant: 5.2.2.9.2
 ```


### PR DESCRIPTION
Ajout de la sous-action CAE manquante 5.2.2.3 (à intercaler)
5% Faire usage de sobriété pour éviter certains achats
Notamment pour les commandes publiques d’importance (hors consommables de base), la collectivité avant tout investissement ou commande publique : 
- s’interroge sur le besoin, l’impact énergétique et environnemental de l’achat, 
- dimensionne celui-ci au plus juste
- évite les achats à fort impact intrinsèque (par exemple, elle s’assure avant un changement de parc d’équipements que le nouveau parc aura un impact énergétique et GES total plus faible que le précédent (même si les fonctionnalités sont plus nombreuses))