### PR TITLE
Audit front (lot 1)

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditDetail.stories.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditDetail.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {Story, Meta} from '@storybook/react';
+import {
+  ActionAuditDetailBase,
+  TActionAuditDetailBaseProps,
+} from './ActionAuditDetail';
+
+export default {
+  component: ActionAuditDetailBase,
+  parameters: {storyshots: false},
+} as Meta;
+
+const Template: Story<TActionAuditDetailBaseProps> = args => (
+  <ActionAuditDetailBase {...args} />
+);
+
+export const NonRenseigne = Template.bind({});
+NonRenseigne.args = {
+  auditStatut: {
+    avis: '',
+    ordre_du_jour: false,
+  },
+};
+
+export const Renseigne = Template.bind({});
+Renseigne.args = {
+  auditStatut: {
+    avis: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud.',
+    ordre_du_jour: true,
+  },
+};
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+  readonly: true,
+  auditStatut: {
+    avis: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud.',
+    ordre_du_jour: true,
+  },
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditDetail.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditDetail.tsx
@@ -1,0 +1,86 @@
+import {ActionDefinitionSummary} from 'core-logic/api/endpoints/ActionDefinitionSummaryReadEndpoint';
+import React, {ChangeEvent, useState} from 'react';
+import {AutoTextArea} from 'ui/shared/AutoTextArea';
+import {TActionAuditStatut} from './types';
+import {useActionAuditStatut} from './useActionAuditStatut';
+import {useAudit, useIsAuditeur} from './useAudit';
+import {useUpdateActionAuditStatut} from './useUpdateActionAuditStatut';
+
+export type TActionAuditDetailProps = {
+  action: ActionDefinitionSummary;
+};
+
+export type TActionAuditDetailBaseProps = {
+  auditStatut: TActionAuditStatut;
+  readonly: boolean;
+  onChange: (data: {avis: string} | {ordre_du_jour: boolean}) => void;
+};
+
+/**
+ * Affiche le détail de l'audit d'une action (notes, flag "inscrire à l'ordre du jour")
+ */
+export const ActionAuditDetailBase = (props: TActionAuditDetailBaseProps) => {
+  const {auditStatut, readonly, onChange} = props;
+  const {avis: avisInitial, ordre_du_jour} = auditStatut;
+  const [avis, setAvis] = useState(avisInitial);
+
+  return (
+    <>
+      <AutoTextArea
+        data-test="avis"
+        value={avis}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          setAvis(event.currentTarget.value)
+        }
+        onBlur={() => avis.trim() !== avisInitial && onChange({avis})}
+        label="Notes de l’auditeur, auditrice"
+        hint="Remarques sur l’action, questions pour la séance d’audit"
+        disabled={readonly}
+      />
+      <div className="fr-checkbox-group fr-checkbox-inline">
+        <input
+          type="checkbox"
+          id="ordre_du_jour"
+          name="ordre_du_jour"
+          checked={ordre_du_jour}
+          disabled={readonly}
+          onChange={(evt: ChangeEvent<HTMLInputElement>) =>
+            onChange({ordre_du_jour: evt.target.checked})
+          }
+        />
+        <label htmlFor="ordre_du_jour">
+          Ajouter cette action à l’ordre du jour de la séance d’audit
+        </label>
+      </div>
+    </>
+  );
+};
+
+/**
+ * Charge les données et fait le rendu
+ */
+export const ActionAuditDetail = (props: TActionAuditDetailProps) => {
+  const {action} = props;
+
+  // donnée de l'audit en cours (si il y en a un)
+  const {data: audit} = useAudit();
+
+  // indique si l'utilisateur courant est l'auditeur
+  const isAuditeur = useIsAuditeur();
+
+  // statut d'audit de l'action
+  const {data: auditStatut} = useActionAuditStatut(action);
+
+  // fonctions d'enregistrement des modifications
+  const {mutate} = useUpdateActionAuditStatut();
+  const handleChange: TActionAuditDetailBaseProps['onChange'] = data =>
+    auditStatut && mutate({...auditStatut, ...data});
+
+  return audit && auditStatut ? (
+    <ActionAuditDetailBase
+      auditStatut={auditStatut}
+      readonly={!isAuditeur}
+      onChange={handleChange}
+    />
+  ) : null;
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditStatut.stories.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditStatut.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {Story, Meta} from '@storybook/react';
+import {
+  ActionAuditStatutBase,
+  TActionAuditStatutBaseProps,
+} from './ActionAuditStatut';
+
+export default {
+  component: ActionAuditStatutBase,
+} as Meta;
+
+const Template: Story<TActionAuditStatutBaseProps> = args => (
+  <ActionAuditStatutBase {...args} />
+);
+
+export const NonAudite = Template.bind({});
+NonAudite.args = {
+  auditStatut: {
+    statut: 'non_audite',
+  },
+};
+export const EnCours = Template.bind({});
+EnCours.args = {
+  auditStatut: {
+    statut: 'en_cours',
+  },
+};
+export const Audite = Template.bind({});
+Audite.args = {
+  auditStatut: {
+    statut: 'audite',
+  },
+};
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+  readonly: true,
+  auditStatut: {
+    statut: 'audite',
+  },
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditStatut.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditStatut.tsx
@@ -36,7 +36,7 @@ export const ActionAuditStatutBase = (props: TActionAuditStatutBaseProps) => {
   return (
     <div className="px-2 w-full bg-[#e8edff]">
       {readonly ? (
-        <div className="py-2">
+        <div className="py-2" data-test="action-audit-statut-ro">
           <BadgeStatut statut={statut} />
         </div>
       ) : (

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditStatut.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/ActionAuditStatut.tsx
@@ -1,0 +1,98 @@
+import {ActionDefinitionSummary} from 'core-logic/api/endpoints/ActionDefinitionSummaryReadEndpoint';
+import {Badge, TBadgeProps} from 'ui/shared/Badge';
+import {SelectDropdownCustom} from 'ui/shared/SelectDropdown';
+import {TActionAuditStatut, TAuditStatut} from './types';
+import {useActionAuditStatut} from './useActionAuditStatut';
+import {useAudit, useIsAuditeur} from './useAudit';
+import {useUpdateActionAuditStatut} from './useUpdateActionAuditStatut';
+
+export type TActionAuditStatutProps = {
+  action: ActionDefinitionSummary;
+};
+
+export type TActionAuditStatutBaseProps = {
+  auditStatut: TActionAuditStatut;
+  readonly: boolean;
+  onChange: (newStatut: TAuditStatut) => void;
+};
+
+const statutToOption: Record<
+  TAuditStatut,
+  {label: string; badge: TBadgeProps['status']}
+> = {
+  non_audite: {label: 'Non audité', badge: 'warning'},
+  en_cours: {label: 'Audit en cours', badge: 'info'},
+  audite: {label: 'Audité', badge: 'success'},
+};
+
+const options: TAuditStatut[] = ['non_audite', 'en_cours', 'audite'];
+
+/**
+ * Affiche le sélecteur de statut d'audit d'une action
+ */
+export const ActionAuditStatutBase = (props: TActionAuditStatutBaseProps) => {
+  const {auditStatut, readonly, onChange} = props;
+  const {statut} = auditStatut;
+  return (
+    <div className="px-2 w-full bg-[#e8edff]">
+      {readonly ? (
+        <div className="py-2">
+          <BadgeStatut statut={statut} />
+        </div>
+      ) : (
+        <div className="w-52">
+          <SelectDropdownCustom
+            data-test="action-audit-statut"
+            options={options}
+            displayOption={statut => <BadgeStatut statut={statut} />}
+            value={statut}
+            onSelect={onChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Affiche un badge représentant un statut d'audit
+ */
+const BadgeStatut = ({statut}: {statut: TAuditStatut}) => {
+  const {label, badge} = statutToOption[statut];
+  return (
+    <Badge status={badge} className="fr-badge--no-icon">
+      {label}
+    </Badge>
+  );
+};
+
+/**
+ * Charge les données et fait le rendu
+ */
+const ActionAuditStatut = (props: TActionAuditStatutProps) => {
+  const {action} = props;
+
+  // donnée de l'audit en cours (si il y en a un)
+  const {data: audit} = useAudit();
+
+  // indique si l'utilisateur courant est l'auditeur
+  const isAuditeur = useIsAuditeur();
+
+  // statut d'audit de l'action
+  const {data: auditStatut} = useActionAuditStatut(action);
+
+  // fonction d'enregistrement des modifications
+  const {mutate} = useUpdateActionAuditStatut();
+  const handleChange = (statut: TAuditStatut) =>
+    auditStatut && mutate({...auditStatut, statut});
+
+  return audit && auditStatut ? (
+    <ActionAuditStatutBase
+      auditStatut={auditStatut}
+      readonly={!isAuditeur}
+      onChange={handleChange}
+    />
+  ) : null;
+};
+
+export default ActionAuditStatut;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/__snapshots__/ActionAuditStatut.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/__snapshots__/ActionAuditStatut.stories.storyshot
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots app/pages/collectivite/Audit/ActionAuditStatut Audite 1`] = `
+<div
+  className="px-2 w-full bg-[#e8edff]"
+>
+  <div
+    className="w-52"
+  >
+    <button
+      aria-label="ouvrir le menu"
+      className="flex items-center w-full p-2 -ml-2 text-left text-sm"
+      data-test="action-audit-statut"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onPointerDown={[Function]}
+    >
+      <span
+        className="mr-auto"
+      >
+        <p
+          className="fr-badge fr-badge--success fr-badge--no-icon"
+        >
+          Audité
+        </p>
+      </span>
+      <span
+        className="fr-fi-arrow-down-s-line mt-1 ml-1 scale-90 "
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Storyshots app/pages/collectivite/Audit/ActionAuditStatut En Cours 1`] = `
+<div
+  className="px-2 w-full bg-[#e8edff]"
+>
+  <div
+    className="w-52"
+  >
+    <button
+      aria-label="ouvrir le menu"
+      className="flex items-center w-full p-2 -ml-2 text-left text-sm"
+      data-test="action-audit-statut"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onPointerDown={[Function]}
+    >
+      <span
+        className="mr-auto"
+      >
+        <p
+          className="fr-badge fr-badge--info fr-badge--no-icon"
+        >
+          Audit en cours
+        </p>
+      </span>
+      <span
+        className="fr-fi-arrow-down-s-line mt-1 ml-1 scale-90 "
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Storyshots app/pages/collectivite/Audit/ActionAuditStatut Non Audite 1`] = `
+<div
+  className="px-2 w-full bg-[#e8edff]"
+>
+  <div
+    className="w-52"
+  >
+    <button
+      aria-label="ouvrir le menu"
+      className="flex items-center w-full p-2 -ml-2 text-left text-sm"
+      data-test="action-audit-statut"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onPointerDown={[Function]}
+    >
+      <span
+        className="mr-auto"
+      >
+        <p
+          className="fr-badge fr-badge--warning fr-badge--no-icon"
+        >
+          Non audité
+        </p>
+      </span>
+      <span
+        className="fr-fi-arrow-down-s-line mt-1 ml-1 scale-90 "
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Storyshots app/pages/collectivite/Audit/ActionAuditStatut Read Only 1`] = `
+<div
+  className="px-2 w-full bg-[#e8edff]"
+>
+  <p
+    className="fr-badge fr-badge--success fr-badge--no-icon"
+  >
+    Audité
+  </p>
+</div>
+`;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/__snapshots__/ActionAuditStatut.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/__snapshots__/ActionAuditStatut.stories.storyshot
@@ -112,10 +112,14 @@ exports[`Storyshots app/pages/collectivite/Audit/ActionAuditStatut Read Only 1`]
 <div
   className="px-2 w-full bg-[#e8edff]"
 >
-  <p
-    className="fr-badge fr-badge--success fr-badge--no-icon"
+  <div
+    className="py-2"
   >
-    Audité
-  </p>
+    <p
+      className="fr-badge fr-badge--success fr-badge--no-icon"
+    >
+      Audité
+    </p>
+  </div>
 </div>
 `;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/__snapshots__/ActionAuditStatut.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/__snapshots__/ActionAuditStatut.stories.storyshot
@@ -114,6 +114,7 @@ exports[`Storyshots app/pages/collectivite/Audit/ActionAuditStatut Read Only 1`]
 >
   <div
     className="py-2"
+    data-test="action-audit-statut-ro"
   >
     <p
       className="fr-badge fr-badge--success fr-badge--no-icon"

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/types.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/types.ts
@@ -1,0 +1,15 @@
+import {Referentiel} from 'types/litterals';
+
+export type TAuditStatut = 'non_audite' | 'en_cours' | 'audite';
+
+// statut d'audit d'une action
+export type TActionAuditStatut = {
+  collectivite_id: number;
+  referentiel: Referentiel;
+  audit_id: number;
+  action_id: string;
+  state_id: number;
+  statut: TAuditStatut;
+  avis: string | null;
+  ordre_du_jour: boolean;
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/types.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/types.ts
@@ -2,6 +2,17 @@ import {Referentiel} from 'types/litterals';
 
 export type TAuditStatut = 'non_audite' | 'en_cours' | 'audite';
 
+// statut de l'audit en cours
+export type TAudit = {
+  id: number;
+  collectivite_id: number;
+  referentiel: Referentiel;
+  demande_id: number | null;
+  auditeur: string;
+  date_debut: string;
+  date_fin: string | null;
+};
+
 // statut d'audit d'une action
 export type TActionAuditStatut = {
   collectivite_id: number;
@@ -10,6 +21,6 @@ export type TActionAuditStatut = {
   action_id: string;
   state_id: number;
   statut: TAuditStatut;
-  avis: string | null;
+  avis: string;
   ordre_du_jour: boolean;
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useActionAuditStatut.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useActionAuditStatut.ts
@@ -3,55 +3,51 @@ import {supabaseClient} from 'core-logic/api/supabase';
 import {useCollectiviteId, useReferentielId} from 'core-logic/hooks/params';
 import {ActionDefinitionSummary} from 'core-logic/api/endpoints/ActionDefinitionSummaryReadEndpoint';
 import {TActionAuditStatut} from './types';
-import {Referentiel} from 'types/litterals';
 
 export type TActionDef = Pick<
   ActionDefinitionSummary,
   'id' | 'identifiant' | 'referentiel'
 >;
 
-type TFilters = {
-  action?: TActionDef;
-};
-
 // charge les données
-export const fetch = async (
-  collectivite_id: number,
-  referentiel: Referentiel,
-  filters?: TFilters
-) => {
-  // lit la liste des statuts d'audit des actions
+export const fetch = async (collectivite_id: number, action: TActionDef) => {
+  // lit le statut d'audit d'une action
   const query = supabaseClient
-    .from<TActionAuditStatut>('action_audit_state_list')
+    .from<TActionAuditStatut>('action_audit_state')
     .select()
-    .match({collectivite_id, referentiel});
-
-  const action = filters?.action;
-  if (action) {
-    query.eq('action_id', action.id);
-  }
+    .eq('collectivite_id', collectivite_id)
+    .eq('action_id', action.id);
 
   const {data, error} = await query;
 
-  if (error || !data) {
-    return [];
+  if (error || !data?.length) {
+    return null;
   }
 
-  return data;
+  return data[0] as TActionAuditStatut;
 };
 
 /**
  * Statut d'audit d'une action du référentiel et de la collectivité courante.
+ * Renvoi un objet par défaut si le statut n'est pas trouvé.
  */
 export const useActionAuditStatut = (action: TActionDef) => {
   const collectivite_id = useCollectiviteId();
   const referentiel = useReferentielId();
-  const {data} = useQuery(
-    ['action_audit_state_list', collectivite_id, referentiel, action],
+  const defaultStatut = {
+    collectivite_id,
+    referentiel,
+    action_id: action.id,
+    ordre_du_jour: false,
+    avis: '',
+    statut: 'non_audite',
+  } as TActionAuditStatut;
+
+  return useQuery(
+    ['action_audit_state', collectivite_id, referentiel, action.id],
     () =>
       collectivite_id && referentiel
-        ? fetch(collectivite_id, referentiel as Referentiel, {action})
-        : []
+        ? fetch(collectivite_id, action).then(data => data || defaultStatut)
+        : defaultStatut
   );
-  return data?.[0] || null;
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useActionAuditStatuts.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useActionAuditStatuts.ts
@@ -1,0 +1,57 @@
+import {useQuery} from 'react-query';
+import {supabaseClient} from 'core-logic/api/supabase';
+import {useCollectiviteId, useReferentielId} from 'core-logic/hooks/params';
+import {ActionDefinitionSummary} from 'core-logic/api/endpoints/ActionDefinitionSummaryReadEndpoint';
+import {TActionAuditStatut} from './types';
+import {Referentiel} from 'types/litterals';
+
+export type TActionDef = Pick<
+  ActionDefinitionSummary,
+  'id' | 'identifiant' | 'referentiel'
+>;
+
+type TFilters = {
+  action?: TActionDef;
+};
+
+// charge les données
+export const fetch = async (
+  collectivite_id: number,
+  referentiel: Referentiel,
+  filters?: TFilters
+) => {
+  // lit la liste des statuts d'audit des actions
+  const query = supabaseClient
+    .from<TActionAuditStatut>('action_audit_state_list')
+    .select()
+    .match({collectivite_id, referentiel});
+
+  const action = filters?.action;
+  if (action) {
+    query.eq('action_id', action.id);
+  }
+
+  const {data, error} = await query;
+
+  if (error || !data) {
+    return [];
+  }
+
+  return data;
+};
+
+/**
+ * Statut d'audit d'une action du référentiel et de la collectivité courante.
+ */
+export const useActionAuditStatut = (action: TActionDef) => {
+  const collectivite_id = useCollectiviteId();
+  const referentiel = useReferentielId();
+  const {data} = useQuery(
+    ['action_audit_state_list', collectivite_id, referentiel, action],
+    () =>
+      collectivite_id && referentiel
+        ? fetch(collectivite_id, referentiel as Referentiel, {action})
+        : []
+  );
+  return data?.[0] || null;
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useActionAuditStatutsListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useActionAuditStatutsListe.ts
@@ -1,13 +1,13 @@
 import {useQuery} from 'react-query';
+import {supabaseClient} from 'core-logic/api/supabase';
 import {useCollectiviteId, useReferentielId} from 'core-logic/hooks/params';
 import {Referentiel} from 'types/litterals';
-import {fetch} from './useActionAuditStatuts';
+import {TActionAuditStatut} from './types';
 
 /**
  * Statut d'audit de toutes les actions du référentiel et de la collectivité
  * courante.
  */
-
 export const useActionAuditStatutsListe = () => {
   const collectivite_id = useCollectiviteId();
   const referentiel = useReferentielId();
@@ -19,4 +19,21 @@ export const useActionAuditStatutsListe = () => {
         : []
   );
   return data || [];
+};
+
+// charge les données
+const fetch = async (collectivite_id: number, referentiel: Referentiel) => {
+  // lit la liste des statuts d'audit des actions
+  const query = supabaseClient
+    .from<TActionAuditStatut>('action_audit_state')
+    .select()
+    .match({collectivite_id, referentiel});
+
+  const {data, error} = await query;
+
+  if (error || !data) {
+    return [];
+  }
+
+  return data;
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useActionAuditStatutsListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useActionAuditStatutsListe.ts
@@ -1,0 +1,22 @@
+import {useQuery} from 'react-query';
+import {useCollectiviteId, useReferentielId} from 'core-logic/hooks/params';
+import {Referentiel} from 'types/litterals';
+import {fetch} from './useActionAuditStatuts';
+
+/**
+ * Statut d'audit de toutes les actions du référentiel et de la collectivité
+ * courante.
+ */
+
+export const useActionAuditStatutsListe = () => {
+  const collectivite_id = useCollectiviteId();
+  const referentiel = useReferentielId();
+  const {data} = useQuery(
+    ['action_audit_state_list', collectivite_id, referentiel],
+    () =>
+      collectivite_id && referentiel
+        ? fetch(collectivite_id, referentiel as Referentiel)
+        : []
+  );
+  return data || [];
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useAudit.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useAudit.ts
@@ -15,16 +15,15 @@ export const fetch = async (
     .from<TAudit>('audit')
     .select()
     .match({collectivite_id, referentiel})
-    .limit(1)
-    .single();
+    .limit(1);
 
   const {data, error} = await query;
 
-  if (error || !data) {
+  if (error || !data?.length) {
     return null;
   }
 
-  return data as TAudit;
+  return data[0] as TAudit;
 };
 
 /**

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useAudit.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useAudit.ts
@@ -1,0 +1,47 @@
+import {useQuery} from 'react-query';
+import {supabaseClient} from 'core-logic/api/supabase';
+import {useCollectiviteId, useReferentielId} from 'core-logic/hooks/params';
+import {TAudit} from './types';
+import {Referentiel} from 'types/litterals';
+import {useAuth} from 'core-logic/api/auth/AuthProvider';
+
+// charge les données
+export const fetch = async (
+  collectivite_id: number,
+  referentiel: Referentiel
+) => {
+  // lit le statut de l'audit en cours (si il existe)
+  const query = supabaseClient
+    .from<TAudit>('audit')
+    .select()
+    .match({collectivite_id, referentiel})
+    .limit(1)
+    .single();
+
+  const {data, error} = await query;
+
+  if (error || !data) {
+    return null;
+  }
+
+  return data as TAudit;
+};
+
+/**
+ * Statut d'audit du référentiel et de la collectivité courante.
+ */
+export const useAudit = () => {
+  const collectivite_id = useCollectiviteId();
+  const referentiel = useReferentielId() as Referentiel;
+  return useQuery(['audit', collectivite_id, referentiel], () =>
+    collectivite_id && referentiel ? fetch(collectivite_id, referentiel) : null
+  );
+};
+
+/** Indique si l'utilisateur courant est l'auditeur pour la
+ * collectivité et le référentiel courants */
+export const useIsAuditeur = () => {
+  const {user} = useAuth();
+  const {data: audit} = useAudit();
+  return (audit && user && audit.auditeur === user.id) || false;
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useUpdateActionAuditStatut.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Audit/useUpdateActionAuditStatut.ts
@@ -1,0 +1,29 @@
+import {supabaseClient} from 'core-logic/api/supabase';
+import {useMutation, useQueryClient} from 'react-query';
+import {TActionAuditStatut} from './types';
+
+// renvoie une fonction de modification du statut d'audit d'une action
+export const useUpdateActionAuditStatut = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    async (actionAuditStatut: TActionAuditStatut) => {
+      const {collectivite_id, action_id, ordre_du_jour, avis, statut} =
+        actionAuditStatut;
+      return supabaseClient
+        .from<TActionAuditStatut>('action_audit_state')
+        .insert({collectivite_id, action_id, ordre_du_jour, avis, statut});
+    },
+    {
+      mutationKey: 'update_action_audit_state',
+      onSuccess: (data: unknown, variables: TActionAuditStatut) => {
+        const {collectivite_id, referentiel} = variables;
+        queryClient.invalidateQueries([
+          'action_audit_state',
+          collectivite_id,
+          referentiel,
+        ]);
+      },
+    }
+  );
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/Action.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/Action.tsx
@@ -35,6 +35,8 @@ import ActionNav from './ActionNav';
 import ActionPreuvePanel from 'ui/shared/actions/ActionPreuvePanel/ActionPreuvePanel';
 import {DownloadDocs} from './DownloadDocs';
 import DOMPurify from 'dompurify';
+import ActionAuditStatut from '../Audit/ActionAuditStatut';
+import {ActionAuditDetail} from '../Audit/ActionAuditDetail';
 
 const useActionLinkedIndicateurDefinitions = (actionId: string) => {
   const [linkedIndicateurDefinitions, setLinkedIndicateurDefinitions] =
@@ -126,6 +128,10 @@ const Action = ({action}: {action: ActionDefinitionSummary}) => {
     <div className="fr-container" data-test={`Action-${action.identifiant}`}>
       <div className="mt-8 mb-4">
         <OrientationQuickNav action={action} />
+      </div>
+      <ActionAuditStatut action={action} />
+      <div className="mt-4 mb-8">
+        <ActionAuditDetail action={action} />
       </div>
       <div className="sticky top-0 z-40 flex flex-row justify-between bg-white pr-8 py-4">
         <div className="flex flex-col w-4/5">

--- a/app.territoiresentransitions.react/src/ui/shared/AutoTextArea.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/AutoTextArea.tsx
@@ -1,59 +1,12 @@
-import React, {useState, useEffect, useRef} from 'react';
 import {TextInput} from '@dataesr/react-dsfr';
+import {useAutoSizeTextarea} from './useAutoSizeTextarea';
 
-// on va appliquer un offset négatif pour que la hauteur soit réduite quand le
-// champ est vide
-const OFFSET = -20;
-
-// on doit ausi surcharger la valeur par défaut du dsfr
-const TEXTAREA_OVERRIDES = {
-  minHeight: '2.75rem',
-};
-
-/**
- * Rend un champ de saisi qui se redimensionne en fonction de son contenu.
- * copié/adapté depuis: https://medium.com/@lucasalgus/creating-a-custom-auto-resize-textarea-component-for-your-react-web-application-6959c0ad68bc
- * (il ne parait pas nécessaire d'ajouter une dépendance supplémentaire pour cette fonctionnalité)
- */
 export const AutoTextArea = (props: TextInput<HTMLInputElement>) => {
-  const {value} = props;
-  const textAreaRef = useRef<HTMLInputElement>(null);
-  const [text, setText] = useState(value);
-  const [textAreaHeight, setTextAreaHeight] = useState('auto');
-  const [parentHeight, setParentHeight] = useState('auto');
+  const {value, onChange} = props;
 
-  // effet appliqué quand le texte change (chargement donnée ou édition par l'utilisateur)
-  useEffect(() => {
-    // la hauteur doit être réduite quand le champ est vide
-    const offset = value === '' ? OFFSET : 0;
-    setParentHeight(`${textAreaRef.current!.scrollHeight}px`);
-    setTextAreaHeight(`${textAreaRef.current!.scrollHeight + offset}px`);
-  }, [text, value]);
-
-  // appelé quand le champ est édité (va déclencher le recalcul de la hauteur)
-  const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setTextAreaHeight('auto');
-    setParentHeight(`${textAreaRef.current!.scrollHeight}px`);
-    setText(event.target.value);
-
-    if (props.onChange) {
-      props.onChange(event);
-    }
-  };
+  const textareaRef = useAutoSizeTextarea(value);
 
   return (
-    <div
-      style={{
-        minHeight: parentHeight,
-      }}
-    >
-      <TextInput
-        textarea
-        {...props}
-        ref={textAreaRef}
-        style={{...TEXTAREA_OVERRIDES, height: textAreaHeight}}
-        onChange={onChangeHandler}
-      />
-    </div>
+    <TextInput textarea {...props} ref={textareaRef} onChange={onChange} />
   );
 };

--- a/app.territoiresentransitions.react/src/ui/shared/SelectDropdown.stories.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/SelectDropdown.stories.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import {useState} from 'react';
-import {SelectDropdown, MultiSelectDropdown} from './SelectDropdown';
+import {action} from '@storybook/addon-actions';
+import {
+  SelectDropdown,
+  MultiSelectDropdown,
+  SelectDropdownCustom,
+} from './SelectDropdown';
 
 export default {
   component: SelectDropdown,
@@ -76,6 +81,17 @@ export const MultiSelectUneOptionSelectionee = () => {
       labels={fakeLabels}
       values={values}
       onSelect={v => setValues(v)}
+    />
+  );
+};
+
+export const RenduPersonnalise = () => {
+  return (
+    <SelectDropdownCustom
+      value="option 1"
+      options={['option 1', 'option2']}
+      displayOption={v => <div>rendu personnalisé de {v}</div>}
+      onSelect={action('onChange')}
     />
   );
 };

--- a/app.territoiresentransitions.react/src/ui/shared/SelectDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/SelectDropdown.tsx
@@ -230,3 +230,96 @@ export const MultiSelectDropdown = <T extends string>({
     </DropdownFloater>
   );
 };
+
+/** une variante qui affiche les items avec un renderer externe, y compris la
+ * valeur courante (quand la liste déroulante est fermée) */
+export const SelectDropdownCustom = <T extends string>({
+  placement,
+  value,
+  onSelect,
+  displayOption,
+  options,
+  placeholderText,
+  'data-test': dataTest,
+}: {
+  placement?: Placement;
+  value?: T;
+  displayOption: (option: T) => ReactElement;
+  onSelect: (value: T) => void;
+  options: T[];
+  placeholderText?: string;
+  'data-test'?: string;
+}) => {
+  const selectableOptions: T[] = options;
+  return (
+    <DropdownFloater
+      placement={placement}
+      render={({close}) => (
+        <div data-test={`${dataTest}-options`}>
+          {selectableOptions.map(v => {
+            return (
+              <button
+                key={v}
+                data-test={v}
+                className="flex items-center w-full p-2 text-left text-sm"
+                onClick={e => {
+                  e.preventDefault();
+                  onSelect(v as T);
+                  close();
+                }}
+              >
+                <span>{displayOption(v as T)}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    >
+      <SelectDropdownCustomOpenButton
+        data-test={dataTest}
+        placeholderText={placeholderText}
+        displayOption={v => displayOption(v as T)}
+        value={value}
+      />
+    </DropdownFloater>
+  );
+};
+
+/** le bouton d'ouverture pour la variante "custom" */
+const SelectDropdownCustomOpenButton = forwardRef(
+  <T extends string>(
+    {
+      value,
+      isOpen,
+      placeholderText,
+      displayOption,
+      ...props
+    }: {
+      value?: T;
+      isOpen?: boolean;
+      placeholderText?: string;
+      displayOption: (option: T) => ReactElement;
+    },
+    ref?: Ref<HTMLButtonElement>
+  ) => (
+    <button
+      ref={ref}
+      aria-label="ouvrir le menu"
+      className={buttonDisplayedClassname}
+      {...props}
+    >
+      {value ? (
+        <span className="mr-auto">{displayOption(value as T)}</span>
+      ) : (
+        <span className={buttonDisplayedPlaceholderClassname}>
+          {placeholderText ?? ''}
+        </span>
+      )}
+      <span
+        className={`${buttonDisplayedIconClassname} ${
+          isOpen ? 'rotate-180' : ''
+        }`}
+      />
+    </button>
+  )
+);

--- a/app.territoiresentransitions.react/src/ui/shared/__snapshots__/SelectDropdown.stories.storyshot
+++ b/app.territoiresentransitions.react/src/ui/shared/__snapshots__/SelectDropdown.stories.storyshot
@@ -139,3 +139,29 @@ exports[`Storyshots ui/shared/SelectDropdown Option Selectionee 1`] = `
   />
 </button>
 `;
+
+exports[`Storyshots ui/shared/SelectDropdown Rendu Personnalise 1`] = `
+<button
+  aria-label="ouvrir le menu"
+  className="flex items-center w-full p-2 -ml-2 text-left text-sm"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onPointerDown={[Function]}
+>
+  <span
+    className="mr-auto"
+  >
+    <div>
+      rendu personnalisé de 
+      option 1
+    </div>
+  </span>
+  <span
+    className="fr-fi-arrow-down-s-line mt-1 ml-1 scale-90 "
+  />
+</button>
+`;

--- a/app.territoiresentransitions.react/src/ui/shared/actions/ActionCommentaire.stories.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/actions/ActionCommentaire.stories.tsx
@@ -20,7 +20,7 @@ ExempleAction.args = {
   action: {
     type: 'action',
   } as ActionCommentaireFieldProps['action'],
-  value: 'mon commentaire',
+  initialValue: 'mon commentaire',
 };
 
 // Commentaire associé à une tâche
@@ -30,7 +30,7 @@ ExempleTache.args = {
   action: {
     type: 'tache',
   } as ActionCommentaireFieldProps['action'],
-  value: 'mon commentaire',
+  initialValue: 'mon commentaire',
 };
 
 // Le champ est redimensionné en fonction de la longueur du texte initial
@@ -40,7 +40,7 @@ CommentaireLong.args = {
   action: {
     type: 'tache',
   } as ActionCommentaireFieldProps['action'],
-  value: `mon commentaire vraiment très long ! 
+  initialValue: `mon commentaire vraiment très long ! 
         
           Lorem ipsum dolor sit amet. A quia animi aut aspernatur totam aut laboriosam enim qui velit repudiandae. Non ratione provident est mollitia voluptatibus ut quibusdam totam hic minima rerum et rerum reiciendis ab officia beatae et voluptate dolore. Eos labore exercitationem id dolorem dolorum eos itaque sapiente et sapiente ducimus aut pariatur autem. Ut pariatur aliquid non laborum facilis ab natus sint sit enim quia ut fuga earum nam debitis nihil est enim dolores. Sit fugiat molestiae est quia possimus nam magni quisquam hic voluptas sint. Ex illo quis ut illum quasi sit quia harum eum consequuntur veniam ut possimus harum.
           

--- a/app.territoiresentransitions.react/src/ui/shared/actions/ActionStatusDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/actions/ActionStatusDropdown.tsx
@@ -112,12 +112,13 @@ export const ActionStatusDropdown = ({actionId}: {actionId: string}) => {
   const {saveActionStatut} = useSaveActionStatut(args);
 
   // donnée liée à l'audit en cours (si il y en a un)
-  const audit = useAudit();
+  const {data: audit} = useAudit();
   const isAuditeur = useIsAuditeur();
 
   // détermine si l'édition du statut est désactivée
-  const disabled =
-    collectivite?.readonly || score?.desactive || (audit && !isAuditeur);
+  const disabled = Boolean(
+    collectivite?.readonly || score?.desactive || (audit && !isAuditeur)
+  );
 
   const handleChange: SelectInputProps['onChange'] = event => {
     const {avancement, concerne, avancement_detaille} = statutByValue(

--- a/app.territoiresentransitions.react/src/ui/shared/actions/ActionStatusDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/actions/ActionStatusDropdown.tsx
@@ -16,6 +16,7 @@ import {toPercentString} from 'utils/score';
 import {CloseDialogButton} from '../CloseDialogButton';
 import {DetailedScore} from '../DetailedScore/DetailedScore';
 import {AvancementValues} from '../DetailedScore/DetailedScoreSlider';
+import {useAudit, useIsAuditeur} from 'app/pages/collectivite/Audit/useAudit';
 
 interface SelectableStatut {
   value: number;
@@ -110,6 +111,14 @@ export const ActionStatusDropdown = ({actionId}: {actionId: string}) => {
 
   const {saveActionStatut} = useSaveActionStatut(args);
 
+  // donnée liée à l'audit en cours (si il y en a un)
+  const audit = useAudit();
+  const isAuditeur = useIsAuditeur();
+
+  // détermine si l'édition du statut est désactivée
+  const disabled =
+    collectivite?.readonly || score?.desactive || (audit && !isAuditeur);
+
   const handleChange: SelectInputProps['onChange'] = event => {
     const {avancement, concerne, avancement_detaille} = statutByValue(
       event.target.value as number
@@ -149,7 +158,7 @@ export const ActionStatusDropdown = ({actionId}: {actionId: string}) => {
         onChange={handleChange}
         displayEmpty
         inputProps={{'aria-label': 'Without label'}}
-        disabled={collectivite.readonly || score?.desactive}
+        disabled={disabled}
       >
         {selectables.map(({value, color, label}) => (
           <MenuItem key={value} value={value}>

--- a/app.territoiresentransitions.react/src/ui/shared/useAutoSizeTextarea.ts
+++ b/app.territoiresentransitions.react/src/ui/shared/useAutoSizeTextarea.ts
@@ -1,0 +1,22 @@
+import {useEffect, useRef} from 'react';
+
+/**
+ * Rend un champ de saisi qui se redimensionne en fonction de son contenu.
+ * copié/adapté depuis: https://www.kindacode.com/article/react-typescript-create-an-autosize-textarea-from-scratch/
+ * (il ne parait pas nécessaire d'ajouter une dépendance supplémentaire pour cette fonctionnalité)
+ */
+export const useAutoSizeTextarea = (value: string, minHeight?: string) => {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Permet de set la taille du textarea au changement de valeur
+  useEffect(() => {
+    if (textareaRef && textareaRef.current) {
+      textareaRef.current.style.height = '0px';
+      textareaRef.current.style.minHeight = minHeight ?? '2.5rem';
+      const scrollHeight = textareaRef.current.scrollHeight;
+      textareaRef.current.style.height = scrollHeight + 'px';
+    }
+  }, [value]);
+
+  return textareaRef;
+};

--- a/e2e/cypress/integration/05-modifier-etat-avancement.feature
+++ b/e2e/cypress/integration/05-modifier-etat-avancement.feature
@@ -95,3 +95,41 @@ Fonctionnalité: Modifier l'état d'avancement et visualiser l'évolution des sc
     Alors le détail de l'entrée 2 est affiché avec les valeurs suivantes :
       | Valeur précédente | Non renseigné |
       | Valeur courante   | Fait          |
+
+  Scénario: Ne pas pouvoir modifier l'état d'avancement quand un audit est en cours
+    Etant donné que je suis connecté en tant que "yolo"
+
+    Quand je visite le sous-axe "1.1" du référentiel "eci" de la collectivité "1"
+    Alors l'état d'avancement des tâches n'est pas éditable
+    Et la page vérifie les conditions suivantes :
+      | Elément                         | Condition | Valeur     |
+      | état audit action               | absent    |            |
+      | état audit action lecture seule | contient  | Non audité |
+      | avis audit                      | vide      |            |
+      | avis audit                      | désactivé |            |
+      | ajouter à l'ordre du jour       | décoché   |            |
+      | ajouter à l'ordre du jour       | désactivé |            |
+
+  Scénario: Modifier l'état d'avancement et le statut d'audit quand on est auditeur
+    Etant donné que je suis connecté en tant que "youlou"
+    Et que l'état d'avancement de l'action "eci_1.1%" pour la collectivité "1" est réinitialisé
+
+    Quand je visite le sous-axe "1.1" du référentiel "eci" de la collectivité "1"
+    Alors l'état d'avancement des tâches est éditable
+    Et la page vérifie les conditions suivantes :
+      | Elément                         | Condition | Valeur     |
+      | état audit action               | contient  | Non audité |
+      | état audit action lecture seule | absent    |            |
+      | avis audit                      | vide      |            |
+      | avis audit                      | activé    |            |
+      | ajouter à l'ordre du jour       | décoché   |            |
+      | ajouter à l'ordre du jour       | activé    |            |
+
+    Quand je sélectionne l'option "en_cours" dans la liste déroulante "état audit action"
+    Et que je saisi la valeur "mon commentaire d'audit" dans le champ "avis audit"
+    Et que je clique sur la case "ajouter à l'ordre du jour"
+    Alors la page vérifie les conditions suivantes :
+      | Elément                   | Condition | Valeur                  |
+      | état audit action         | contient  | Audit en cours          |
+      | avis audit                | contient  | mon commentaire d'audit |
+      | ajouter à l'ordre du jour | coché     |                         |

--- a/e2e/cypress/integration/05-modifier-etat-avancement.feature
+++ b/e2e/cypress/integration/05-modifier-etat-avancement.feature
@@ -5,10 +5,10 @@ Fonctionnalité: Modifier l'état d'avancement et visualiser l'évolution des sc
   Scénario: Modifier l'état d'avancement et visualiser les scores associés à une action
     Dans ce scénario, on teste la mise à jour d'un état d'avancement, puis d'un second et enfin le retour à l'état initial du second avancement, en vérifiant à chaque fois l'impact sur le score du sous-axes et des tâches concernées.
 
-    Etant donné que je suis connecté en tant que "yolo"
-    Et que l'état d'avancement de l'action "eci_1.1%" pour la collectivité "1" est réinitialisé
+    Etant donné que je suis connecté en tant que "yili"
+    Et que l'état d'avancement de l'action "eci_1.1%" pour la collectivité "2" est réinitialisé
 
-    Quand je visite le sous-axe "1.1" du référentiel "eci" de la collectivité "1"
+    Quand je visite le sous-axe "1.1" du référentiel "eci" de la collectivité "2"
     Alors aucun score n'est affiché
 
     Quand j'assigne la valeur "Fait" à l'état d'avancement de la tâche "eci_1.1.1.1"
@@ -44,21 +44,21 @@ Fonctionnalité: Modifier l'état d'avancement et visualiser l'évolution des sc
   Scénario: Modifier l'état d'avancement et visualiser l'historique
     Dans ce scénario, on teste la mise à jour de l'historique lorsqu'on renseigne un nouvel état d'avancement.
 
-    Etant donné que je suis connecté en tant que "yolo"
-    Et que l'état d'avancement de l'action "eci_1.1%" pour la collectivité "1" est réinitialisé
+    Etant donné que je suis connecté en tant que "yili"
+    Et que l'état d'avancement de l'action "eci_1.1%" pour la collectivité "2" est réinitialisé
     Et que l'historique est réinitialisé
 
-    Quand je visite le sous-axe "1.1" du référentiel "eci" de la collectivité "1"
+    Quand je visite le sous-axe "1.1" du référentiel "eci" de la collectivité "2"
     Et que je clique sur l'onglet "Historique"
     Alors aucun historique n'est affiché
 
-    Quand je visite le sous-axe "1.1" du référentiel "eci" de la collectivité "1"
+    Quand je visite le sous-axe "1.1" du référentiel "eci" de la collectivité "2"
     Et que j'assigne la valeur "Fait" à l'état d'avancement de la tâche "eci_1.1.1.1"
     Et que je clique sur l'onglet "Historique"
     Alors l'historique contient 1 entrée
     Et l'entrée 1 de l'historique est affichée avec les valeurs suivantes :
       | Action : statut modifié                                                        |
-      | Par : Yolo Dodo                                                                |
+      | Par : Yili Didi                                                                |
       | Action : 1.1 Définir une stratégie globale de la politique Economie Circulaire |
       | Tâche : 1.1.1.1 Identifier un élu référent                                     |
     Et le détail de l'entrée 1 de l'historique n'est pas affiché
@@ -77,12 +77,12 @@ Fonctionnalité: Modifier l'état d'avancement et visualiser l'évolution des sc
     Alors l'historique contient 2 entrées
     Et l'entrée 1 de l'historique est affichée avec les valeurs suivantes :
       | Action : texte modifié                                                         |
-      | Par : Yolo Dodo                                                                |
+      | Par : Yili Didi                                                                |
       | Action : 1.1 Définir une stratégie globale de la politique Economie Circulaire |
       | Tâche : 1.1.1.1 Identifier un élu référent                                     |
     Et l'entrée 2 de l'historique est affichée avec les valeurs suivantes :
       | Action : statut modifié                                                        |
-      | Par : Yolo Dodo                                                                |
+      | Par : Yili Didi                                                                |
       | Action : 1.1 Définir une stratégie globale de la politique Economie Circulaire |
       | Tâche : 1.1.1.1 Identifier un élu référent                                     |
 

--- a/e2e/cypress/integration/05-modifier-etat-avancement/selectors.js
+++ b/e2e/cypress/integration/05-modifier-etat-avancement/selectors.js
@@ -1,0 +1,14 @@
+export const LocalSelectors = {
+  'état audit action': {
+    selector: '[data-test=action-audit-statut]',
+  },
+  'état audit action lecture seule': {
+    selector: '[data-test=action-audit-statut-ro]',
+  },
+  'avis audit': {
+    selector: '[data-test=avis] textarea',
+  },
+  "ajouter à l'ordre du jour": {
+    selector: '#ordre_du_jour',
+  },
+};

--- a/e2e/cypress/integration/05-modifier-etat-avancement/steps.js
+++ b/e2e/cypress/integration/05-modifier-etat-avancement/steps.js
@@ -1,4 +1,17 @@
 /// <reference types="Cypress" />
+import {LocalSelectors} from './selectors';
+
+// enregistre les définitions locales
+beforeEach(() => {
+  cy.wrap(LocalSelectors).as('LocalSelectors');
+
+  // reset les données d'audit des actions en attendant que le DL fournisse une
+  // fonction générique
+  cy.task('pg_query', {
+    query:
+      "DELETE FROM labellisation.action_audit_state WHERE collectivite_id = 1 AND action_id LIKE 'eci_1.%'",
+  });
+});
 
 When(
   /l'état d'avancement de l'action "([^"]+)" pour la collectivité "(\d+)" est réinitialisé/,
@@ -43,6 +56,22 @@ When(
     ).click();
   }
 );
+
+When("l'état d'avancement des tâches n'est pas éditable", () => {
+  // tous les Select sont désactivés
+  cy.get(`[data-test^="task-"] .MuiInput-root`).should(
+    'have.class',
+    'Mui-disabled'
+  );
+});
+
+When("l'état d'avancement des tâches est éditable", () => {
+  // tous les Select sont activés
+  cy.get(`[data-test^="task-"] .MuiInput-root`).should(
+    'not.have.class',
+    'Mui-disabled'
+  );
+});
 
 const avancementToValue = {
   'Non renseigné': -1,

--- a/e2e/cypress/integration/05-modifier-etat-avancement/steps.js
+++ b/e2e/cypress/integration/05-modifier-etat-avancement/steps.js
@@ -39,7 +39,7 @@ When('tous les scores sont à 0', () => {
 });
 */
 
-When('les scores sont affichés avec les valeurs suivantes :', (dataTable) => {
+When('les scores sont affichés avec les valeurs suivantes :', dataTable => {
   cy.wrap(dataTable.rows()).each(([action, score]) => {
     cy.get(`[data-test="score-${action}"]`).should('have.text', score);
   });
@@ -92,7 +92,7 @@ When(
   }
 );
 
-When(/je clique sur l'onglet "([^"]+)"/, (tabName) => {
+When(/je clique sur l'onglet "([^"]+)"/, tabName => {
   cy.get('.fr-tabs__tab').contains(tabName).click();
 });
 
@@ -101,7 +101,7 @@ When("aucun historique n'est affiché", () => {
   cy.get('[data-test=empty_history]').should('be.visible');
 });
 
-When(/l'historique contient (\d+) entrées?/, (count) => {
+When(/l'historique contient (\d+) entrées?/, count => {
   cy.get('[data-test=empty_history]').should('not.exist');
   cy.get('[data-test=Historique] [data-test=item]').should(
     'have.length',
@@ -116,14 +116,14 @@ When(
       .should('exist')
       .within(() => {
         const lines = dataTable.raw();
-        cy.wrap(lines).each((line) =>
+        cy.wrap(lines).each(line =>
           cy.get('[data-test=desc]').should('contain.text', line[0])
         );
       });
   }
 );
 
-When(/le détail de l'entrée (\d+) de l'historique n'est pas affiché/, (num) => {
+When(/le détail de l'entrée (\d+) de l'historique n'est pas affiché/, num => {
   cy.get(
     `[data-test=Historique] [data-test=item]:nth(${
       num - 1
@@ -152,18 +152,15 @@ When(
   }
 );
 
-When(
-  /je clique sur le bouton "Afficher le détail" de l'entrée (\d+)/,
-  (num) => {
-    cy.get(
-      `[data-test=Historique] [data-test=item]:nth(${
-        num - 1
-      }) [data-test=detail-off] button`
-    ).click();
-  }
-);
+When(/je clique sur le bouton "Afficher le détail" de l'entrée (\d+)/, num => {
+  cy.get(
+    `[data-test=Historique] [data-test=item]:nth(${
+      num - 1
+    }) [data-test=detail-off] button`
+  ).click();
+});
 
-When(/je clique sur le bouton "Masquer le détail" de l'entrée (\d+)/, (num) => {
+When(/je clique sur le bouton "Masquer le détail" de l'entrée (\d+)/, num => {
   cy.get(
     `[data-test=Historique] [data-test=item]:nth(${
       num - 1
@@ -175,5 +172,5 @@ When(/l'historique est réinitialisé/, () => {
   cy.task('pg_query', {
     query: 'TRUNCATE action_commentaire',
   });
-  cy.task('supabase_rpc', { name: 'test_clear_history' });
+  cy.task('supabase_rpc', {name: 'test_clear_history'});
 });

--- a/e2e/cypress/integration/05-modifier-etat-avancement/steps.js
+++ b/e2e/cypress/integration/05-modifier-etat-avancement/steps.js
@@ -5,12 +5,8 @@ import {LocalSelectors} from './selectors';
 beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors');
 
-  // reset les données d'audit des actions en attendant que le DL fournisse une
-  // fonction générique
-  cy.task('pg_query', {
-    query:
-      "DELETE FROM labellisation.action_audit_state WHERE collectivite_id = 1 AND action_id LIKE 'eci_1.%'",
-  });
+  // reset les données d'audit des actions
+  cy.task('supabase_rpc', {name: 'test_reset_audit'});
 });
 
 When(

--- a/e2e/cypress/integration/common/expectations.js
+++ b/e2e/cypress/integration/common/expectations.js
@@ -10,6 +10,8 @@ export const Expectations = {
   désactivé: 'be.disabled',
   désactivée: 'be.disabled',
   vide: 'be.empty',
-  aucun: { cond: 'have.length', value: 0 },
-  plusieurs: { cond: 'have.length.greaterThan', value: 0 },
+  aucun: {cond: 'have.length', value: 0},
+  plusieurs: {cond: 'have.length.greaterThan', value: 0},
+  coché: 'be.checked',
+  décoché: 'not.be.checked',
 };

--- a/e2e/cypress/integration/common/steps.js
+++ b/e2e/cypress/integration/common/steps.js
@@ -33,7 +33,7 @@ Given("j'ouvre le site", () => {
 });
 
 const genUser = userName => {
-  const letter = userName.slice(1, 2);
+  const letter = userName.slice(1, userName.indexOf('l'));
   const dd = `d${letter}d${letter}`;
   return {
     email: `${userName}@${dd}.com`,

--- a/e2e/cypress/integration/common/steps.js
+++ b/e2e/cypress/integration/common/steps.js
@@ -157,6 +157,13 @@ Given(/^je clique sur le bouton "([^"]*)"$/, function (btnName) {
   cy.get(resolveSelector(this, btnName).selector).click();
 });
 
+Given(/^je clique sur la case "([^"]*)"$/, function (checkbox) {
+  cy.get(resolveSelector(this, checkbox).selector)
+    .parent()
+    .should('have.class', 'fr-checkbox-group')
+    .click();
+});
+
 function fillFormWithValues(elem, dataTable) {
   const parent = resolveSelector(this, elem);
   cy.get(parent.selector).within(() => {
@@ -173,6 +180,22 @@ Given(/l'appel à "([^"]*)" va répondre "([^"]*)"/, function (name, reply) {
   assert(r, 'mock non trouvé');
   cy.intercept(...r).as(name);
 });
+
+Given(
+  "je sélectionne l'option {string} dans la liste déroulante {string}",
+  selectDropdownValue
+);
+function selectDropdownValue(value, dropdown) {
+  // ouvre le sélecteur
+  cy.get(resolveSelector(this, dropdown).selector).click();
+  // et sélectionne la valeur voulue
+  cy.get(`#floating-ui-root [data-test="${value}"]`).click();
+}
+
+Given('je saisi la valeur {string} dans le champ {string}', fillInput);
+function fillInput(value, input) {
+  cy.get(resolveSelector(this, input).selector).clear().type(value);
+}
 
 Given('je clique en dehors de la boîte de dialogue', () =>
   cy.get('body').click(10, 10)

--- a/e2e/cypress/integration/common/steps.js
+++ b/e2e/cypress/integration/common/steps.js
@@ -4,8 +4,8 @@
  * Définitions de "steps" communes à tous les tests
  */
 
-import { Selectors } from './selectors';
-import { Expectations } from './expectations';
+import {Selectors} from './selectors';
+import {Expectations} from './expectations';
 
 beforeEach(function () {
   cy.visit('/');
@@ -13,7 +13,7 @@ beforeEach(function () {
 
   // bouchon pour la fonction window.open
   const stub = cy.stub().as('open');
-  cy.on('window:before:load', (win) => {
+  cy.on('window:before:load', win => {
     cy.stub(win, 'open').callsFake(stub);
   });
 });
@@ -23,16 +23,16 @@ beforeEach(function () {
 // `cy.get('@auth')` soit bien résolue une 2ème fois dans le même scénario
 // (utilisée avec le step "je me reconnecte en tant que ...")
 function waitForApp() {
-  cy.window({ log: false }).its('e2e.history').as('history');
-  cy.window({ log: false }).its('e2e.auth').as('auth');
-  cy.window({ log: false }).its('e2e.supabaseClient').as('supabaseClient');
+  cy.window({log: false}).its('e2e.history').as('history');
+  cy.window({log: false}).its('e2e.auth').as('auth');
+  cy.window({log: false}).its('e2e.supabaseClient').as('supabaseClient');
 }
 
 Given("j'ouvre le site", () => {
   cy.get('[data-test=home]').should('be.visible');
 });
 
-const genUser = (userName) => {
+const genUser = userName => {
   const letter = userName.slice(1, 2);
   const dd = `d${letter}d${letter}`;
   return {
@@ -45,7 +45,7 @@ const SignInPage = Selectors['formulaire de connexion'];
 Given(/je suis connecté en tant que "([^"]*)"/, login);
 function login(userName) {
   const u = genUser(userName);
-  cy.get('@auth').then((auth) => auth.connect(u));
+  cy.get('@auth').then(auth => auth.connect(u));
   cy.get(SignInPage.selector).should('not.exist');
   cy.get('[data-test=connectedMenu]').should('be.visible');
 }
@@ -57,18 +57,18 @@ Given('je me reconnecte en tant que {string}', function (userName) {
 });
 
 Given('les droits utilisateur sont réinitialisés', () => {
-  cy.task('supabase_rpc', { name: 'test_reset_droits' });
+  cy.task('supabase_rpc', {name: 'test_reset_droits'});
 });
 
-Given(/l'utilisateur "([^"]*)" est supprimé/, (email) => {
+Given(/l'utilisateur "([^"]*)" est supprimé/, email => {
   cy.task('supabase_rpc', {
     name: 'test_remove_user',
-    params: { email: email },
+    params: {email: email},
   });
 });
 
 Given('les informations des membres sont réinitialisées', () => {
-  cy.task('supabase_rpc', { name: 'test_reset_membres' });
+  cy.task('supabase_rpc', {name: 'test_reset_membres'});
 });
 
 Given('je me déconnecte', logout);
@@ -178,37 +178,35 @@ Given('je clique en dehors de la boîte de dialogue', () =>
   cy.get('body').click(10, 10)
 );
 
-Given('je valide le formulaire', () =>
-cy.get('button[type=submit]').click()
-);
+Given('je valide le formulaire', () => cy.get('button[type=submit]').click());
 
 const transateTypes = {
-  succès: "success",
-  information: "info",
-  erreur: "error",
+  succès: 'success',
+  information: 'info',
+  erreur: 'error',
 };
 Given(
   /une alerte de "([^"]*)" est affichée et contient "([^"]*)"/,
   (type, message) => {
-    cy.get(`.fr-alert--${transateTypes[type]}`).should("be.visible");
-    cy.get(`.fr-alert--${transateTypes[type]}`).should("contain.text", message);
+    cy.get(`.fr-alert--${transateTypes[type]}`).should('be.visible');
+    cy.get(`.fr-alert--${transateTypes[type]}`).should('contain.text', message);
   }
 );
 
-Given("je recharge la page", () => {
+Given('je recharge la page', () => {
   cy.reload();
 });
 
 // Le tableau des membres est utilisé dans plusieurs tests
 // pour valider la modification des informations des membres ou
 // les informations de l'utilisateur courant
-const tableauMembresSelector = Selectors["tableau des membres"];
+const tableauMembresSelector = Selectors['tableau des membres'];
 Given(
-  "le tableau des membres doit contenir les informations suivantes",
-  (dataTable) => {
+  'le tableau des membres doit contenir les informations suivantes',
+  dataTable => {
     cy.get(tableauMembresSelector.selector).within(() => {
       // Attend la disparition du chargement.
-      cy.get("[data-test=Loading]").should("not.exist");
+      cy.get('[data-test=Loading]').should('not.exist');
       cy.wrap(dataTable.rows()).each(
         (
           [
@@ -223,13 +221,13 @@ Given(
           index
         ) => {
           cy.get(`tbody tr:nth(${index})`).within(() => {
-            cy.get("td:first").should("contain.text", nom);
-            cy.get("td:first").should("contain.text", mail);
+            cy.get('td:first').should('contain.text', nom);
+            cy.get('td:first').should('contain.text', mail);
             // cy.get('td:nth(1)').should('contain.text', telephone);
-            cy.get("td:nth(1)").should("contain.text", fonction);
-            cy.get("td:nth(2)").should("contain.text", champ_intervention);
-            cy.get("td:nth(3)").should("contain.text", details_fonction);
-            cy.get("td:nth(4)").should("contain.text", acces);
+            cy.get('td:nth(1)').should('contain.text', fonction);
+            cy.get('td:nth(2)').should('contain.text', champ_intervention);
+            cy.get('td:nth(3)').should('contain.text', details_fonction);
+            cy.get('td:nth(4)').should('contain.text', acces);
           });
         }
       );


### PR DESCRIPTION
- ajoute l'affichage des infos d'audit dans la page Action lorsqu'un audit est en cours
- désactive l'édition du statut d'une action lorsqu'un audit est en cours et que l'utilisateur n'est pas lui-même l'auditeur