### PR TITLE
Améliore le chargement de Sqitch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: sh make_dot_env.sh
 
       - name: Run sqitch revert to latest major version and then deploy to test reversibility
-        run: docker compose run sqitch_revert && docker compose run --no-deps sqitch deploy --verify
+        run: docker compose run sqitch-test
 
   tests:
     needs: sqitch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,6 @@ jobs:
         run: docker compose run sqitch-test
 
   tests:
-    needs: sqitch
     name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -112,17 +112,6 @@ Le `client`, le `data layer` et le `business` peuvent être lancés à partir de
 - le `datalayer` qui est en fait supabase et les modèles/fonctions est démarré avec le container `loader` dont le role
   est de charger les modèles, les fonctions et les données `docker-compose up loader`
 
-_Pro-tip_ pour mettre à jour le datalayer sans le redémarrer lorsque l'on change de branche :
-
-- Avant de changer de branche :
-```sh
-docker compose run --no-deps sqitch_revert
-```
-- Après le changement de branche :
-```sh
-docker compose run --no-deps sqitch
-```
-
 ### Lancer les tests
 
 Les trois services sont des projets indépendants qui peuvent-être testés en local sous reserve que les dépendances de
@@ -133,6 +122,7 @@ Néanmoins, on peut lancer les tests à partir de docker compose :
 - `docker-compose run business-test`
 - `docker-compose run datalayer-test`
 - `docker-compose run datalayer-api-test`
+- `docker-compose run sqitch-test`
 
 ## Déploiement
 

--- a/data_layer/loader/Dockerfile
+++ b/data_layer/loader/Dockerfile
@@ -2,4 +2,5 @@
 
 FROM postgres:14
 RUN apt-get update
-RUN apt-get install -y curl
+RUN apt-get install -y curl build-essential cpanminus perl perl-doc libdbd-pg-perl postgresql-client
+RUN cpanm --quiet --notest App::Sqitch

--- a/data_layer/scripts/try_load.sh
+++ b/data_layer/scripts/try_load.sh
@@ -18,10 +18,8 @@ until psql -v ON_ERROR_STOP=1 --file "$DATALAYER_DIR"/verify/supabase_storage.sq
   sleep 10
 done
 
-until psql -v ON_ERROR_STOP=1 --file "$DATALAYER_DIR"/verify/sqitch.sql; do
-  echo "Waiting for sqitch migration..."
-  sleep 10
-done
+echo "Running Sqitch.."
+sqitch deploy --chdir /sqitch || exit 1
 
 echo "Loading content..."
 for file in "$DATALAYER_DIR"/content/*.sql; do

--- a/data_layer/scripts/wait_for_supabase.sh
+++ b/data_layer/scripts/wait_for_supabase.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# This script waits for the db to be ready
+
+DATALAYER_DIR="./../postgres"
+
+until psql -c "select 1"; do
+  echo "Waiting for supabase-db..."
+  sleep 10
+done
+
+until psql -v ON_ERROR_STOP=1 --file "$DATALAYER_DIR"/verify/supabase_auth.sql; do
+  echo "Waiting for supabase auth migration..."
+  sleep 10
+done
+
+until psql -v ON_ERROR_STOP=1 --file "$DATALAYER_DIR"/verify/supabase_storage.sql; do
+  echo "Waiting for supabase storage migration..."
+  sleep 10
+done
+
+echo "Supabase is loaded!"
+exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,7 +292,7 @@ services:
 
   # Teste la réversibilité du plan.
   sqitch-test:
-    container_name: tet-datalayer-loader
+    container_name: tet-sqitch-test
     build: ./data_layer/loader/.
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -290,23 +290,37 @@ services:
       LANG: fr_FR.UTF-8
       CI: 'true'
 
-  # Sqitch revert
-  sqitch_revert:
-    container_name: tet-sqitch-revert
-    image: sqitch/sqitch
+  # Teste la réversibilité du plan.
+  sqitch-test:
+    container_name: tet-datalayer-loader
+    build: ./data_layer/loader/.
     depends_on:
-      loader:
-        condition: service_completed_successfully
-    profiles:
-      - donotstart
+      - db
+      - auth
+      - storage
+    command:
+      - sh
+      - -c
+      - | 
+        sh /scripts/wait_for_supabase.sh
+        sqitch deploy --chdir /sqitch || exit 1 
+        sqitch revert --to @v1.12.0 --y --chdir /sqitch || exit 1
+        sqitch deploy --chdir /sqitch || exit 1
     environment:
       SQITCH_TARGET: db:pg://db/postgres
       SQITCH_PASSWORD: ${POSTGRES_PASSWORD}
       SQITCH_USERNAME: postgres
-    command: revert --to @v1.12.0 --y
-    working_dir: /data_layer/sqitch
+      SKIP_TEST_DOMAIN: ${LOADER_SKIP_TEST_DOMAIN}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      PGUSER: postgres
+      PGHOST: db
+      SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
+      SUPABASE_URL: ${SUPABASE_URL}
     volumes:
-      - ./data_layer/sqitch:/data_layer/sqitch
+      - ./data_layer/sqitch:/sqitch
+      - ./data_layer/postgres:/postgres
+      - ./data_layer/scripts/wait_for_supabase.sh:/scripts/wait_for_supabase.sh
 
   # Mailhog est utilisé pour tester l'envoi de mails par Gotrue
   mailhog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,55 +148,22 @@ services:
       - ./data_layer/supabase/init:/docker-entrypoint-initdb.d
       - ./data_layer/content:/content
 
-  # When this service is healthy, supabase has been loaded.
-  supabase_loaded:
-    container_name: tet-datalayer-loaded
-    build: ./data_layer/loader/.
-    healthcheck:
-      test: sh /scripts/loaded_supabase.sh
-      interval: 10s
-      timeout: 5s
-      retries: 100
-    depends_on:
-      - db
-      - auth
-      - storage
-    environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      PGPASSWORD: ${POSTGRES_PASSWORD}
-      PGUSER: postgres
-      PGHOST: db
-    volumes:
-      - ./data_layer/scripts/loaded_supabase.sh:/scripts/loaded_supabase.sh
-      - ./data_layer/postgres:/postgres
-
-  # Sqitch
-  sqitch:
-    container_name: tet-sqitch-deploy
-    image: sqitch/sqitch
-    depends_on:
-      supabase_loaded:
-        condition: service_healthy
-    environment:
-      SQITCH_TARGET: db:pg://db/postgres
-      SQITCH_PASSWORD: ${POSTGRES_PASSWORD}
-      SQITCH_USERNAME: postgres
-    command: deploy
-    working_dir: /data_layer/sqitch
-    volumes:
-      - ./data_layer/sqitch:/data_layer/sqitch
-
   # Load contents and fakes once db is ready.
   loader:
     container_name: tet-datalayer-loader
     build: ./data_layer/loader/.
     depends_on:
-      - sqitch
+      - db
+      - auth
+      - storage
       - kong
       - rest
       - business
     command: sh /scripts/try_load.sh
     environment:
+      SQITCH_TARGET: db:pg://db/postgres
+      SQITCH_PASSWORD: ${POSTGRES_PASSWORD}
+      SQITCH_USERNAME: postgres
       SKIP_TEST_DOMAIN: ${LOADER_SKIP_TEST_DOMAIN}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       PGPASSWORD: ${POSTGRES_PASSWORD}
@@ -205,6 +172,7 @@ services:
       SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
       SUPABASE_URL: ${SUPABASE_URL}
     volumes:
+      - ./data_layer/sqitch:/sqitch
       - ./data_layer/postgres:/postgres
       - ./data_layer/scripts/try_load.sh:/scripts/try_load.sh
       - ./data_layer/scripts/loaded_content.sh:/scripts/loaded_content.sh


### PR DESCRIPTION
Sqitch fait désormais partie du container loader, ce qui :

- simplifie la dockerfile
- permet d'utiliser le nouveau format de fonction pg14, le docker Sqitch étant basé sur debian c'était le psql de pg12 qui était utilisé.