### PR TITLE
monte le contenu d'un onglet dans les pages Action et Référentiel

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/Action.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/Action.tsx
@@ -191,27 +191,39 @@ const Action = ({action}: {action: ActionDefinitionSummary}) => {
           </section>
         </Tab>
         <Tab label="Preuves" icon="fr-fi-file-line">
-          <section>
-            <ActionPreuvePanel withSubActions showWarning action={action} />
-            <DownloadDocs action={action} />
-          </section>
+          {activeTab === TABS_INDEX['preuves'] ? (
+            <section>
+              <ActionPreuvePanel withSubActions showWarning action={action} />
+              <DownloadDocs action={action} />
+            </section>
+          ) : (
+            '...'
+          )}
         </Tab>
         <Tab label="Indicateurs" icon="fr-fi-line-chart-fill">
-          <section>
-            {actionLinkedIndicateurDefinitions.length === 0 && (
-              <p>Cette action ne comporte pas d'indicateur</p>
-            )}
+          {activeTab === TABS_INDEX['indicateurs'] ? (
+            <section>
+              {actionLinkedIndicateurDefinitions.length === 0 && (
+                <p>Cette action ne comporte pas d'indicateur</p>
+              )}
 
-            {actionLinkedIndicateurDefinitions.map(definition => (
-              <IndicateurReferentielCard
-                key={definition.id}
-                definition={definition}
-              />
-            ))}
-          </section>
+              {actionLinkedIndicateurDefinitions.map(definition => (
+                <IndicateurReferentielCard
+                  key={definition.id}
+                  definition={definition}
+                />
+              ))}
+            </section>
+          ) : (
+            '...'
+          )}
         </Tab>
         <Tab label="Historique" icon="fr-fi-history-line">
-          <HistoriqueListe actionId={action.id} />
+          {activeTab === TABS_INDEX['historique'] ? (
+            <HistoriqueListe actionId={action.id} />
+          ) : (
+            '...'
+          )}
         </Tab>
       </Tabs>
       <ActionNav actionId={action.id} />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/ReferentielTabs.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/ReferentielTabs.tsx
@@ -71,10 +71,14 @@ const ReferentielTabs = () => {
           <Progression />
         </Tab>
         <Tab label="Aide à la priorisation">
-          <AidePriorisation />
+          {activeTab === TABS_INDEX['priorisation'] ? (
+            <AidePriorisation />
+          ) : (
+            '...'
+          )}
         </Tab>
         <Tab label="Détail des tâches">
-          <DetailTacheTable />
+          {activeTab === TABS_INDEX['detail'] ? <DetailTacheTable /> : '...'}
         </Tab>
       </Tabs>
     </main>


### PR DESCRIPTION
uniquement lorsque l'onglet est visible

(permet de limiter le nombre de requêtes initiales)