### PR TITLE
Amélioration du tracker.

### DIFF
--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -6728,6 +6728,8 @@ export interface Database {
         | "historique"
         | "comparaison"
         | "critere"
+        | "informations"
+        | "commentaires"
       visite_page:
         | "autre"
         | "signin"
@@ -6751,6 +6753,7 @@ export interface Database {
         | "fiche"
         | "plan_axe"
         | "fiches_non_classees"
+        | "synthese_plans"
       visite_tag:
         | "cae"
         | "eci"

--- a/app.territoiresentransitions.react/src/app/Layout/Header/AccesRapide.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/AccesRapide.tsx
@@ -1,5 +1,5 @@
 import {Link, useLocation} from 'react-router-dom';
-import {useTracker} from 'core-logic/hooks/useTracker';
+import {useFonctionTracker} from 'core-logic/hooks/useFonctionTracker';
 import {HeaderPropsWithModalState} from './types';
 import {allCollectivitesPath, signInPath, signUpPath} from 'app/paths';
 import MenuUtilisateur from './MenuUtilisateur';
@@ -65,7 +65,7 @@ export const AccesRapide = (props: HeaderPropsWithModalState) => {
  * Ouvre le lien vers le centre d'aide.
  */
 const Aide = () => {
-  const tracker = useTracker();
+  const tracker = useFonctionTracker();
 
   const onClick = async () => {
     // on utilise un bouton avec ouverture explicite du lien pour ne pas

--- a/app.territoiresentransitions.react/src/app/pages/Profil/RejoindreUneCollectivite/RejoindreUneCollectivite.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/Profil/RejoindreUneCollectivite/RejoindreUneCollectivite.tsx
@@ -17,7 +17,7 @@ import {MembreFonction} from 'generated/dataLayer/membres';
 import {collectiviteFonctionOptions} from './data';
 import CollectiviteSelectionee from './CollectiviteSelectionee';
 import Success from './Success';
-import {useTracker} from 'core-logic/hooks/useTracker';
+import {useFonctionTracker} from 'core-logic/hooks/useFonctionTracker';
 
 /** Schéma de validation du formulaire */
 const formValidation = Yup.object({
@@ -42,7 +42,7 @@ export const RejoindreUneCollectivite = ({
   setSearch,
   getReferentContacts,
 }: RejoindreUneCollectiviteProps) => {
-  const tracker = useTracker();
+  const tracker = useFonctionTracker();
 
   /** Formate la liste des collectivités à afficher dans le select de l'auto complete */
   const listeCollectivites =

--- a/app.territoiresentransitions.react/src/app/pages/ToutesLesCollectivites/components/CollectiviteCarte.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/ToutesLesCollectivites/components/CollectiviteCarte.tsx
@@ -8,7 +8,7 @@ import {Card} from '@material-ui/core';
 import {Link} from 'react-router-dom';
 import {makeCollectiviteTableauBordUrl} from 'app/paths';
 import classNames from 'classnames';
-import {useTracker} from 'core-logic/hooks/useTracker';
+import {useFonctionTracker} from 'core-logic/hooks/useFonctionTracker';
 
 export type TCollectiviteCarteProps = {
   collectivite: CollectiviteCarteRead;
@@ -24,7 +24,7 @@ export type TCollectiviteCarteProps = {
  */
 export const CollectiviteCarte = (props: TCollectiviteCarteProps) => {
   const {collectivite} = props;
-  const tracker = useTracker();
+  const tracker = useFonctionTracker();
 
   return (
     <Link

--- a/app.territoiresentransitions.react/src/app/pages/ToutesLesCollectivites/components/FiltresColonne.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/ToutesLesCollectivites/components/FiltresColonne.tsx
@@ -11,7 +11,7 @@ import type {TCollectivitesFilters} from 'app/pages/ToutesLesCollectivites/filtr
 import {RegionRead} from 'generated/dataLayer/region_read';
 import {DepartementRead} from 'generated/dataLayer/departement_read';
 import {InputSearch} from 'ui/UiSearchBar';
-import {useTracker} from 'core-logic/hooks/useTracker';
+import {useFonctionTracker} from 'core-logic/hooks/useFonctionTracker';
 
 type UpdateFilters = (newFilters: TCollectivitesFilters) => void;
 
@@ -21,7 +21,7 @@ export const FiltresColonne = (props: {
   filters: TCollectivitesFilters;
   setFilters: UpdateFilters;
 }) => {
-  const tracker = useTracker();
+  const tracker = useFonctionTracker();
 
   return (
     <div className="flex flex-col gap-8">
@@ -34,7 +34,7 @@ export const FiltresColonne = (props: {
         }}
       />
       <RegionFiltre
-        onChange={(selected) => {
+        onChange={selected => {
           props.setFilters({...props.filters, regions: selected});
           tracker({fonction: 'filtre_region', action: 'selection'});
         }}
@@ -42,7 +42,7 @@ export const FiltresColonne = (props: {
         regions={props.regions}
       />
       <DepartementFiltre
-        onChange={(selected) => {
+        onChange={selected => {
           props.setFilters({...props.filters, departments: selected});
           tracker({fonction: 'filtre_departement', action: 'selection'});
         }}
@@ -51,35 +51,35 @@ export const FiltresColonne = (props: {
         regionCodes={props.filters.regions}
       />
       <TypeCollectiviteFiltre
-        onChange={(selected) => {
+        onChange={selected => {
           props.setFilters({...props.filters, types: selected});
           tracker({fonction: 'filtre_type', action: 'selection'});
         }}
         selected={props.filters.types}
       />
       <PopulationCollectiviteFiltre
-        onChange={(selected) => {
+        onChange={selected => {
           props.setFilters({...props.filters, population: selected});
           tracker({fonction: 'filtre_population', action: 'selection'});
         }}
         selected={props.filters.population}
       />
       <ReferentielCollectiviteFiltre
-        onChange={(selected) => {
+        onChange={selected => {
           props.setFilters({...props.filters, referentiel: selected});
           tracker({fonction: 'filtre_referentiel', action: 'selection'});
         }}
         selected={props.filters.referentiel}
       />
       <NiveauDeLabellisationCollectiviteFiltre
-        onChange={(selected) => {
+        onChange={selected => {
           props.setFilters({...props.filters, niveauDeLabellisation: selected});
           tracker({fonction: 'filtre_niveau', action: 'selection'});
         }}
         selected={props.filters.niveauDeLabellisation}
       />
       <TauxRemplissageCollectiviteFiltre
-        onChange={(selected) => {
+        onChange={selected => {
           props.setFilters({...props.filters, tauxDeRemplissage: selected});
           tracker({fonction: 'filtre_remplissage', action: 'selection'});
         }}

--- a/app.territoiresentransitions.react/src/app/pages/ToutesLesCollectivites/components/Pagination.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/ToutesLesCollectivites/components/Pagination.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react';
 import useWindowSize from 'utils/useWindowSize';
-import {useTracker} from 'core-logic/hooks/useTracker';
+import {useFonctionTracker} from 'core-logic/hooks/useFonctionTracker';
 
 export type TPaginationProps = {
   selectedPage: number;
@@ -20,7 +20,7 @@ export const Pagination = (props: TPaginationProps) => {
     number[]
   >([]);
 
-  const tracker = useTracker();
+  const tracker = useFonctionTracker();
   const windowSize = useWindowSize();
   const isMobile = windowSize.width < 992;
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/TableauBord/TableauBord.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/TableauBord/TableauBord.tsx
@@ -23,7 +23,7 @@ import {
   LabellisationParNiveauRead,
   useLabellisationParNiveau,
 } from './useLabellisationParNiveau';
-import {useTracker} from 'core-logic/hooks/useTracker';
+import {useFonctionTracker} from 'core-logic/hooks/useFonctionTracker';
 import {TLabellisationParcours} from 'app/pages/collectivite/ParcoursLabellisation/types';
 import ProgressionReferentiel from '../EtatDesLieux/Synthese/ProgressionReferentiel';
 import {useProgressionReferentiel} from '../EtatDesLieux/Synthese/data/useProgressionReferentiel';
@@ -213,7 +213,7 @@ const ReferentielSection = ({
   const repartitionPhases = useRepartitionPhases(referentielId);
 
   const referentielRoot = actions.find(a => a.type === 'referentiel');
-  const tracker = useTracker();
+  const tracker = useFonctionTracker();
   if (!referentielRoot) return null;
 
   const rootScore = scores.find(

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useFonctionTracker.ts
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useFonctionTracker.ts
@@ -29,7 +29,7 @@ const track = async (usage: Usage): Promise<boolean> => {
  * en reprenant la collectivite, l'utilisateur courant
  * et la page en cours de visite.
  */
-export const useTracker = (): (usage: Usage) => Promise<boolean> => {
+export const useFonctionTracker = (): ((usage: Usage) => Promise<boolean>) => {
   const collectivite_id = useCollectiviteId();
   const localisation = useLocalisation();
   const ref = useRef();
@@ -42,10 +42,8 @@ export const useTracker = (): (usage: Usage) => Promise<boolean> => {
 
     const tracker = async (usage: Usage): Promise<boolean> => {
       // on ajoute les valeurs courantes à l'usage
-      if (collectivite_id)
-        usage['collectivite_id'] = collectivite_id;
-      if (user)
-        usage['user_id'] = user.id;
+      if (collectivite_id) usage['collectivite_id'] = collectivite_id;
+      if (user) usage['user_id'] = user.id;
       usage.page = localisation.page;
 
       // on évite d'envoyer un même usage plusieurs fois de suite
@@ -68,9 +66,11 @@ export const useTracker = (): (usage: Usage) => Promise<boolean> => {
 const isEqual = (a: Usage | null, b: Usage | null) => {
   if (!a && !b) return true;
   if (!a || !b) return false;
-  return a.page === b.page
-    && a.action === b.action
-    && a.fonction === b.fonction
-    && a.collectivite_id === b.collectivite_id
-    && a.user_id === b.user_id;
+  return (
+    a.page === b.page &&
+    a.action === b.action &&
+    a.fonction === b.fonction &&
+    a.collectivite_id === b.collectivite_id &&
+    a.user_id === b.user_id
+  );
 };

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useLocalisation.tsx
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useLocalisation.tsx
@@ -77,6 +77,10 @@ const locationFromPath = (path: string): Localisation => {
     page = 'fiche';
   } else if (path.includes('/plan/')) {
     page = 'plan';
+  } else if (path.endsWith('/plans/synthese')) {
+    page = 'synthese_plans';
+  } else if (path.endsWith('/plans/fiches')) {
+    page = 'fiches_non_classees';
   } else if (path.includes('/personnalisation/')) {
     page = 'personnalisation';
     tag = 'thematique';

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useOngletTracker.ts
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useOngletTracker.ts
@@ -1,0 +1,85 @@
+import {Database} from 'types/database.types';
+import {useCollectiviteId} from 'core-logic/hooks/params';
+import {useAuth} from 'core-logic/api/auth/AuthProvider';
+import {supabaseClient} from 'core-logic/api/supabase';
+import {useLocalisation} from 'core-logic/hooks/useLocalisation';
+import {ENV} from 'environmentVariables';
+import {useMemo, useRef} from 'react';
+
+/**
+ * Représente la visite d'une page.
+ */
+type Visite = Database['public']['Tables']['visite']['Insert'];
+
+/**
+ * Les différents onglets possibles.
+ */
+type Onglet = Database['public']['Enums']['visite_onglet'];
+
+/**
+ * Enregistre une visite.
+ *
+ * @param visite
+ * @returns success
+ */
+const track = async (visite: Visite): Promise<boolean> => {
+  const {status} = await supabaseClient.from('visite').insert(visite);
+  return status === 201;
+};
+
+/**
+ * Permet de suivre les ouvertures des onglets qui ne sont pas
+ * prises en compte par le `VisitTracker` car elles ne changent pas l'URL.
+ *
+ * @returns la fonction qui permet d'enregistrer la visite de l'onglet
+ * en reprenant la collectivite, l'utilisateur courant et la page en cours de visite.
+ */
+export const useOngletTracker = (): ((onglet: Onglet) => Promise<boolean>) => {
+  const collectivite_id = useCollectiviteId();
+  const localisation = useLocalisation();
+  const ref = useRef();
+  const {user} = useAuth();
+
+  const factory = () => {
+    // Garde la dernière visite pour éviter d'envoyer
+    // une même visite plusieurs fois de suite.
+    let tracked: Visite | null;
+
+    return async (onglet: Onglet): Promise<boolean> => {
+      if (!user) return false;
+
+      // on ajoute les valeurs courantes à la visite
+      const visite: Visite = {
+        page: localisation.page,
+        tag: localisation.tag,
+        onglet: onglet,
+        user_id: user.id,
+        collectivite_id: collectivite_id,
+      };
+
+      // on évite d'envoyer une même visite plusieurs fois de suite
+      if (isEqual(tracked, visite)) return false;
+      tracked = visite;
+      if (ENV.node_env === 'development') {
+        console.info('\x1B[0;96mtrack visite\x1B[m', 'visite', visite);
+      }
+
+      return track(visite);
+    };
+  };
+
+  // On renvoie un tracker par ref.
+  return useMemo(factory, [ref.current]);
+};
+
+const isEqual = (a: Visite | null, b: Visite | null) => {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return (
+    a.page === b.page &&
+    a.tag === b.tag &&
+    a.onglet === b.onglet &&
+    a.collectivite_id === b.collectivite_id &&
+    a.user_id === b.user_id
+  );
+};

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -6728,6 +6728,8 @@ export interface Database {
         | "historique"
         | "comparaison"
         | "critere"
+        | "informations"
+        | "commentaires"
       visite_page:
         | "autre"
         | "signin"
@@ -6751,6 +6753,7 @@ export interface Database {
         | "fiche"
         | "plan_axe"
         | "fiches_non_classees"
+        | "synthese_plans"
       visite_tag:
         | "cae"
         | "eci"

--- a/app.territoiresentransitions.react/src/ui/charts/CanvasDownloadButton.tsx
+++ b/app.territoiresentransitions.react/src/ui/charts/CanvasDownloadButton.tsx
@@ -1,4 +1,4 @@
-import {useTracker} from "core-logic/hooks/useTracker";
+import {useFonctionTracker} from "core-logic/hooks/useFonctionTracker";
 
 export type TCanvasDownloadButtonProps = {
     fileName: string;
@@ -8,7 +8,7 @@ export type TCanvasDownloadButtonProps = {
 
 export const CanvasDownloadButton = (props: TCanvasDownloadButtonProps) => {
     const linkId = `download_${props.canvasId}`;
-    const tracker = useTracker();
+    const tracker = useFonctionTracker();
     const onClick = () => {
         const canvas = document.getElementById(
             props.canvasId

--- a/app.territoiresentransitions.react/src/ui/charts/ChartCard.tsx
+++ b/app.territoiresentransitions.react/src/ui/charts/ChartCard.tsx
@@ -1,4 +1,4 @@
-import {useTracker} from 'core-logic/hooks/useTracker';
+import {useFonctionTracker} from 'core-logic/hooks/useFonctionTracker';
 import {useRef, useState} from 'react';
 import DownloadButton from 'ui/DownloadButton';
 import Modal from 'ui/shared/floating-ui/Modal';
@@ -45,7 +45,7 @@ const ChartCardModalContent = ({
   chartInfo,
   topElement,
 }: ChartCardModalContentProps) => {
-  const tracker = useTracker();
+  const tracker = useFonctionTracker();
 
   // Référence utilisée pour le téléchargement du graphe
   const chartWrapperRef = useRef<HTMLDivElement>(null);

--- a/data_layer/sqitch/deploy/utilisateur/visite.sql
+++ b/data_layer/sqitch/deploy/utilisateur/visite.sql
@@ -2,9 +2,10 @@
 
 BEGIN;
 
-alter type visite_page
-    add value if not exists 'plan_axe';
-alter type visite_page
-    add value if not exists 'fiches_non_classees';
+alter type visite_onglet
+    add value if not exists 'informations';
+
+alter type visite_onglet
+    add value if not exists 'commentaires';
 
 COMMIT;

--- a/data_layer/sqitch/deploy/utilisateur/visite.sql
+++ b/data_layer/sqitch/deploy/utilisateur/visite.sql
@@ -2,6 +2,9 @@
 
 BEGIN;
 
+alter type visite_page
+    add value if not exists 'synthese_plans';
+
 alter type visite_onglet
     add value if not exists 'informations';
 

--- a/data_layer/sqitch/deploy/utilisateur/visite@v2.28.0.sql
+++ b/data_layer/sqitch/deploy/utilisateur/visite@v2.28.0.sql
@@ -1,0 +1,10 @@
+-- Deploy tet:utilisateur/visite to pg
+
+BEGIN;
+
+alter type visite_page
+    add value if not exists 'plan_axe';
+alter type visite_page
+    add value if not exists 'fiches_non_classees';
+
+COMMIT;

--- a/data_layer/sqitch/revert/utilisateur/visite@v2.28.0.sql
+++ b/data_layer/sqitch/revert/utilisateur/visite@v2.28.0.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
--- on n'enlève pas les enums ajoutés
+-- on ne drop pas les valeurs de l'enum
 
 COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -341,3 +341,5 @@ cron/refresh_retool_plan_action_premier_usage 2023-05-02T13:06:59Z Amandine Jacq
 stats/reporting [stats/reporting@v2.26.0] 2023-04-28T14:16:10Z Florian <florian@derfurth.com> # Ajoute les indicateurs
 stats/vues_BI [stats/vues_BI@v2.26.0] 2023-04-28T14:57:00Z Florian <florian@derfurth.com> # Corrige engagement_collectivite pour ne prendre en compte que les dernières labellisation
 @v2.28.0 2023-05-03T07:30:42Z Florian <florian@derfurth.com> # Ajoute des vues stats
+
+utilisateur/visite [utilisateur/visite@v2.28.0] 2023-05-10T08:22:35Z Florian <florian@derfurth.com> # Ajoute les panneaux comme onglets

--- a/data_layer/sqitch/verify/utilisateur/visite.sql
+++ b/data_layer/sqitch/verify/utilisateur/visite.sql
@@ -2,8 +2,4 @@
 
 BEGIN;
 
-select time, page, tag, onglet, user_id, collectivite_id
-from visite
-where false;
-
 ROLLBACK;

--- a/data_layer/sqitch/verify/utilisateur/visite@v2.28.0.sql
+++ b/data_layer/sqitch/verify/utilisateur/visite@v2.28.0.sql
@@ -1,0 +1,9 @@
+-- Verify tet:utilisateur/visite on pg
+
+BEGIN;
+
+select time, page, tag, onglet, user_id, collectivite_id
+from visite
+where false;
+
+ROLLBACK;

--- a/site/app/database.types.ts
+++ b/site/app/database.types.ts
@@ -6728,6 +6728,8 @@ export interface Database {
         | "historique"
         | "comparaison"
         | "critere"
+        | "informations"
+        | "commentaires"
       visite_page:
         | "autre"
         | "signin"
@@ -6751,6 +6753,7 @@ export interface Database {
         | "fiche"
         | "plan_axe"
         | "fiches_non_classees"
+        | "synthese_plans"
       visite_tag:
         | "cae"
         | "eci"


### PR DESCRIPTION
Ajoute le hook useOngletTracker qui permet de suivre les ouvertures des onglets qui ne sont pas pris en compte par le `VisitTracker` car elles ne changent pas l'URL. 

Renomme le hook useTracker en useFonctionTracker pour mieux le différencier de useOngletTracker.

Ajoute le tracking de synthèse et fiches non classées.

