### PR TITLE
Nouvelle nav plan action

### DIFF
--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -4700,12 +4700,20 @@ export interface Database {
         }
         Returns: string[]
       }
-      flat_axes: {
-        Args: {
-          plan_id: number
-        }
-        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-      }
+      flat_axes:
+        | {
+            Args: {
+              axe: unknown
+            }
+            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+          }
+        | {
+            Args: {
+              plan_id: number
+              max_depth?: number
+            }
+            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+          }
       foreign_tables_are: {
         Args: {
           "": unknown[]
@@ -5774,6 +5782,12 @@ export interface Database {
         }
         Returns: string
       }
+      navigation_plans: {
+        Args: {
+          collectivite_id: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+      }
       no_plan: {
         Args: Record<PropertyKey, never>
         Returns: boolean[]
@@ -6087,12 +6101,6 @@ export interface Database {
       skip:
         | {
             Args: {
-              "": number
-            }
-            Returns: string
-          }
-        | {
-            Args: {
               why: string
               how_many: number
             }
@@ -6101,6 +6109,12 @@ export interface Database {
         | {
             Args: {
               "": string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              "": number
             }
             Returns: string
           }
@@ -6283,27 +6297,6 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
               origin: string
             }
             Returns: string
@@ -6313,6 +6306,27 @@ export interface Database {
               bucket_width: unknown
               ts: string
               origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
             }
             Returns: string
           }

--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -4700,20 +4700,13 @@ export interface Database {
         }
         Returns: string[]
       }
-      flat_axes:
-        | {
-            Args: {
-              axe: unknown
-            }
-            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-          }
-        | {
-            Args: {
-              plan_id: number
-              max_depth?: number
-            }
-            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-          }
+      flat_axes: {
+        Args: {
+          axe_id: number
+          max_depth?: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+      }
       foreign_tables_are: {
         Args: {
           "": unknown[]
@@ -6297,6 +6290,27 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
               origin: string
             }
             Returns: string
@@ -6306,27 +6320,6 @@ export interface Database {
               bucket_width: unknown
               ts: string
               origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
             }
             Returns: string
           }
@@ -6527,13 +6520,13 @@ export interface Database {
       }
       todo_start:
         | {
-            Args: {
-              "": string
-            }
+            Args: Record<PropertyKey, never>
             Returns: boolean[]
           }
         | {
-            Args: Record<PropertyKey, never>
+            Args: {
+              "": string
+            }
             Returns: boolean[]
           }
       types_are: {

--- a/api_tests/tests/plan_action/flat_axes.test.ts
+++ b/api_tests/tests/plan_action/flat_axes.test.ts
@@ -35,7 +35,7 @@ Deno.test("RPC flat_axes", async () => {
   await signIn("yolododo");
 
   const rpcResponse = await supabase.rpc("flat_axes", {
-    plan_id: 1,
+    axe_id: 1,
   });
   assertExists(rpcResponse.data);
   const axes = rpcResponse.data as unknown as flatAxe[];

--- a/api_tests/tests/plan_action/flat_axes.test.ts
+++ b/api_tests/tests/plan_action/flat_axes.test.ts
@@ -14,21 +14,20 @@ type flatAxe = {
 type planNode = flatAxe & { children: planNode[] };
 
 /**
- * Convertit une liste d'axes en arbre.
+ * Convertit une liste d'axes ordonnancée en une liste de plans.
  */
-function buildPlan(axes: flatAxe[]): planNode {
-  let plan = { ...axes[0]!, children: [] };
+function buildPlans(axes: flatAxe[]): planNode[] {
+  let plans: planNode[] = [];
   let nodes = {} as { [key: number]: planNode };
-  nodes[plan.id] = plan;
 
-  if (axes.length > 1) {
-    for (let i = 1; i < axes.length; i++) {
-      let axe: planNode = { ...axes[i], children: [] };
-      nodes[axe.id] = axe;
-      nodes[axe.ancestors[axe.ancestors.length - 1]].children.push(axe);
-    }
+  for (let i = 0; i < axes.length; i++) {
+    let axe: planNode = { ...axes[i], children: [] };
+    nodes[axe.id] = axe;
+    if (axe.depth == 0) plans.push(axe);
+    else nodes[axe.ancestors[axe.ancestors.length - 1]].children.push(axe);
   }
-  return plan;
+
+  return plans;
 }
 
 Deno.test("RPC flat_axes", async () => {
@@ -40,7 +39,7 @@ Deno.test("RPC flat_axes", async () => {
   });
   assertExists(rpcResponse.data);
   const axes = rpcResponse.data as unknown as flatAxe[];
-  const plan = buildPlan(axes);
+  const plan = buildPlans(axes);
 
   console.log(JSON.stringify(plan, null, 2));
 
@@ -48,6 +47,22 @@ Deno.test("RPC flat_axes", async () => {
   // - map sur les axes et leurs `children`
   // - si fiches n'est pas vide, on récupère les fiches :
   //   supabase.from('fiche_resume').select().in('id', axe.fiches);
+
+  await signOut();
+});
+
+Deno.test("RPC navigation_plans", async () => {
+  await testReset();
+  await signIn("yolododo");
+
+  const rpcResponse = await supabase.rpc("navigation_plans", {
+    collectivite_id: 1,
+  });
+  assertExists(rpcResponse.data);
+  const axes = rpcResponse.data as unknown as flatAxe[];
+  const plans = buildPlans(axes);
+
+  console.log(JSON.stringify(plans, null, 2));
 
   await signOut();
 });

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -4700,12 +4700,20 @@ export interface Database {
         }
         Returns: string[]
       }
-      flat_axes: {
-        Args: {
-          plan_id: number
-        }
-        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-      }
+      flat_axes:
+        | {
+            Args: {
+              axe: unknown
+            }
+            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+          }
+        | {
+            Args: {
+              plan_id: number
+              max_depth?: number
+            }
+            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+          }
       foreign_tables_are: {
         Args: {
           "": unknown[]
@@ -5774,6 +5782,12 @@ export interface Database {
         }
         Returns: string
       }
+      navigation_plans: {
+        Args: {
+          collectivite_id: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+      }
       no_plan: {
         Args: Record<PropertyKey, never>
         Returns: boolean[]
@@ -6087,12 +6101,6 @@ export interface Database {
       skip:
         | {
             Args: {
-              "": number
-            }
-            Returns: string
-          }
-        | {
-            Args: {
               why: string
               how_many: number
             }
@@ -6101,6 +6109,12 @@ export interface Database {
         | {
             Args: {
               "": string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              "": number
             }
             Returns: string
           }
@@ -6283,27 +6297,6 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
               origin: string
             }
             Returns: string
@@ -6313,6 +6306,27 @@ export interface Database {
               bucket_width: unknown
               ts: string
               origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
             }
             Returns: string
           }

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -4700,20 +4700,13 @@ export interface Database {
         }
         Returns: string[]
       }
-      flat_axes:
-        | {
-            Args: {
-              axe: unknown
-            }
-            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-          }
-        | {
-            Args: {
-              plan_id: number
-              max_depth?: number
-            }
-            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-          }
+      flat_axes: {
+        Args: {
+          axe_id: number
+          max_depth?: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+      }
       foreign_tables_are: {
         Args: {
           "": unknown[]
@@ -6297,6 +6290,27 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
               origin: string
             }
             Returns: string
@@ -6306,27 +6320,6 @@ export interface Database {
               bucket_width: unknown
               ts: string
               origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
             }
             Returns: string
           }
@@ -6527,13 +6520,13 @@ export interface Database {
       }
       todo_start:
         | {
-            Args: {
-              "": string
-            }
+            Args: Record<PropertyKey, never>
             Returns: boolean[]
           }
         | {
-            Args: Record<PropertyKey, never>
+            Args: {
+              "": string
+            }
             Returns: boolean[]
           }
       types_are: {

--- a/data_layer/sqitch/deploy/plan_action/navigation.sql
+++ b/data_layer/sqitch/deploy/plan_action/navigation.sql
@@ -1,0 +1,65 @@
+-- Deploy tet:plan_action/navigation to pg
+
+BEGIN;
+
+drop function flat_axes;
+create function
+    flat_axes(plan_id integer, max_depth integer default null)
+    returns setof flat_axe_node
+    stable
+begin
+    atomic
+    with recursive
+        parents as (select id,
+                           nom,
+                           collectivite_id,
+                           0                   as depth,
+                           array []::integer[] as ancestors
+                    from axe
+                    where parent is null
+                      and id = plan_id
+                      and can_read_acces_restreint(axe.collectivite_id)
+
+                    union all
+
+                    select a.id,
+                           a.nom,
+                           a.collectivite_id,
+                           depth + 1,
+                           ancestors || a.parent
+                    from parents
+                             join axe a on a.parent = parents.id),
+        fiches as (select a.id,
+                          array_agg(faa.fiche_id) as fiches
+                   from parents a
+                            join fiche_action_axe faa on a.id = faa.axe_id
+                   group by a.id)
+    select id, nom, fiches, ancestors, depth
+    from parents
+             left join fiches using (id)
+    where case
+              when max_depth is not null
+                  then depth <= max_depth
+              else true
+              end
+    order by depth, naturalsort(nom);
+end;
+comment on function flat_axes is
+    'Les axes ordonnancés par profondeur d''un plan donné sous forme de nodes prêtes pour reconstituer un arbre coté client.';
+
+create function
+    navigation_plans(collectivite_id integer)
+    returns setof flat_axe_node
+    stable
+begin
+    atomic
+    select flat.*
+    from axe a
+             join flat_axes(a.id, 1) flat on true
+    where a.collectivite_id = navigation_plans.collectivite_id
+      and a.parent is null;
+end;
+comment on function navigation_plans is
+    'Les axes ordonnancés par profondeur d''une collectivité donnée pour la navigation.';
+
+COMMIT;

--- a/data_layer/sqitch/deploy/plan_action/navigation.sql
+++ b/data_layer/sqitch/deploy/plan_action/navigation.sql
@@ -4,7 +4,7 @@ BEGIN;
 
 drop function flat_axes;
 create function
-    flat_axes(plan_id integer, max_depth integer default null)
+    flat_axes(axe_id integer, max_depth integer default null)
     returns setof flat_axe_node
     stable
 begin
@@ -16,8 +16,7 @@ begin
                            0                   as depth,
                            array []::integer[] as ancestors
                     from axe
-                    where parent is null
-                      and id = plan_id
+                    where id = axe_id
                       and can_read_acces_restreint(axe.collectivite_id)
 
                     union all

--- a/data_layer/sqitch/revert/plan_action/navigation.sql
+++ b/data_layer/sqitch/revert/plan_action/navigation.sql
@@ -1,0 +1,47 @@
+-- Revert tet:plan_action/navigation from pg
+
+BEGIN;
+
+drop function navigation_plans;
+drop function flat_axes;
+
+create function
+    flat_axes(plan_id integer)
+    returns setof flat_axe_node
+    stable
+begin
+    atomic
+    with recursive
+        parents as (select id,
+                           nom,
+                           collectivite_id,
+                           0                   as depth,
+                           array []::integer[] as ancestors
+                    from axe
+                    where parent is null
+                      and id = plan_id
+                      and can_read_acces_restreint(axe.collectivite_id)
+
+                    union all
+
+                    select a.id,
+                           a.nom,
+                           a.collectivite_id,
+                           depth + 1,
+                           ancestors || a.parent
+                    from parents
+                             join axe a on a.parent = parents.id),
+        fiches as (select a.id,
+                          array_agg(faa.fiche_id) as fiches
+                   from parents a
+                            join fiche_action_axe faa on a.id = faa.axe_id
+                   group by a.id)
+    select id, nom, fiches, ancestors, depth
+    from parents
+             left join fiches using (id)
+    order by depth, naturalsort(nom);
+end;
+comment on function flat_axes is
+    'Les axes ordonnancés par profondeur d''un plan donné sous forme de nodes prêtes pour reconstituer un arbre coté client.';
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -346,3 +346,5 @@ utilisateur/visite [utilisateur/visite@v2.28.0] 2023-05-10T08:22:35Z Florian <fl
 stats/amplitude [stats/amplitude@v2.28.0] 2023-05-09T09:26:11Z Florian <florian@derfurth.com> # Améliore l'intégration à Amplitude
 cron/send_to_amplitude 2023-05-09T09:41:49Z Florian <florian@derfurth.com> # Envoie quotidiennement les événements de la veille à Amplitude
 @v2.29.0 2023-05-11T07:32:43Z Florian <florian@derfurth.com> # Améliore les statistiques et le tracking
+
+plan_action/navigation 2023-05-11T09:29:09Z Florian <florian@derfurth.com> # Axes pour la navigation

--- a/data_layer/sqitch/verify/plan_action/navigation.sql
+++ b/data_layer/sqitch/verify/plan_action/navigation.sql
@@ -1,0 +1,7 @@
+-- Verify tet:plan_action/navigation on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;

--- a/site/app/database.types.ts
+++ b/site/app/database.types.ts
@@ -4700,12 +4700,20 @@ export interface Database {
         }
         Returns: string[]
       }
-      flat_axes: {
-        Args: {
-          plan_id: number
-        }
-        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-      }
+      flat_axes:
+        | {
+            Args: {
+              axe: unknown
+            }
+            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+          }
+        | {
+            Args: {
+              plan_id: number
+              max_depth?: number
+            }
+            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+          }
       foreign_tables_are: {
         Args: {
           "": unknown[]
@@ -5774,6 +5782,12 @@ export interface Database {
         }
         Returns: string
       }
+      navigation_plans: {
+        Args: {
+          collectivite_id: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+      }
       no_plan: {
         Args: Record<PropertyKey, never>
         Returns: boolean[]
@@ -6087,12 +6101,6 @@ export interface Database {
       skip:
         | {
             Args: {
-              "": number
-            }
-            Returns: string
-          }
-        | {
-            Args: {
               why: string
               how_many: number
             }
@@ -6101,6 +6109,12 @@ export interface Database {
         | {
             Args: {
               "": string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              "": number
             }
             Returns: string
           }
@@ -6283,27 +6297,6 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
               origin: string
             }
             Returns: string
@@ -6313,6 +6306,27 @@ export interface Database {
               bucket_width: unknown
               ts: string
               origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
             }
             Returns: string
           }

--- a/site/app/database.types.ts
+++ b/site/app/database.types.ts
@@ -4700,20 +4700,13 @@ export interface Database {
         }
         Returns: string[]
       }
-      flat_axes:
-        | {
-            Args: {
-              axe: unknown
-            }
-            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-          }
-        | {
-            Args: {
-              plan_id: number
-              max_depth?: number
-            }
-            Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-          }
+      flat_axes: {
+        Args: {
+          axe_id: number
+          max_depth?: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+      }
       foreign_tables_are: {
         Args: {
           "": unknown[]
@@ -6297,6 +6290,27 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
               origin: string
             }
             Returns: string
@@ -6306,27 +6320,6 @@ export interface Database {
               bucket_width: unknown
               ts: string
               origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
             }
             Returns: string
           }
@@ -6527,13 +6520,13 @@ export interface Database {
       }
       todo_start:
         | {
-            Args: {
-              "": string
-            }
+            Args: Record<PropertyKey, never>
             Returns: boolean[]
           }
         | {
-            Args: Record<PropertyKey, never>
+            Args: {
+              "": string
+            }
             Returns: boolean[]
           }
       types_are: {


### PR DESCRIPTION
La nouvelle RPC `navigation_plans` permet de récupérer la liste des axes (plans et axes) transformée coté TS avec `buildPlans`. qui remplace la fonction précédente `buildPlan`, elle est utilisable dans le cas de la nav comme dans le cas du plan.