### PR TITLE
Évaluation: répartition des points non-concernés et désactivés 

### DIFF
--- a/business/business/evaluation/evaluation/compute_scores.py
+++ b/business/business/evaluation/evaluation/compute_scores.py
@@ -8,7 +8,7 @@ from .action_point_tree import ActionTree
 
 def compute_scores(
         referentiel_tree: ActionPointTree,
-        statuses: List[ActionStatut],
+        statuts: List[ActionStatut],
         personnalisation_consequences: dict[ActionId, ActionPersonnalisationConsequence],
         action_level: int,
 ) -> Dict[ActionId, ActionScore]:
@@ -18,14 +18,15 @@ def compute_scores(
     )
 
     # 1. Première passe, calcule la redistribution des potentiels des actions désactivés ou non concernées
-    action_desactive_ids = compute_actions_desactivees_ids(
+    action_desactive_ids = compute_action_desactive_ids(
         personnalise_tree,
         personnalisation_consequences,
     )
 
-    action_non_concerne_ids = (
-            compute_actions_non_concernes_ids(personnalise_tree, statuses)
-            + action_desactive_ids
+    action_non_concerne_ids = compute_action_non_concerne_ids(
+        personnalise_tree,
+        statuts,
+        action_desactive_ids
     )
 
     # 2. Deuxième et troisième passes, on propage les potentiels
@@ -40,7 +41,7 @@ def compute_scores(
     action_personnalises_ids = list(personnalisation_consequences.keys())
     status_by_action_id: Dict[str, ActionStatut] = {
         action_status.action_id: action_status
-        for action_status in statuses
+        for action_status in statuts
         if action_status.is_renseigne
     }
 

--- a/business/business/evaluation/evaluation/compute_scores.py
+++ b/business/business/evaluation/evaluation/compute_scores.py
@@ -38,8 +38,8 @@ def compute_scores(
         action_level,
     )
 
-    action_personnalises_ids = list(personnalisation_consequences.keys())
-    status_by_action_id: Dict[str, ActionStatut] = {
+    action_personnalise_ids = list(personnalisation_consequences.keys())
+    statuts: Dict[str, ActionStatut] = {
         action_status.action_id: action_status
         for action_status in statuts
         if action_status.is_renseigne
@@ -60,9 +60,9 @@ def compute_scores(
             scores,
             potentiels,
             action_id,
-            status_by_action_id,
+            statuts,
             action_non_concerne_ids,
-            action_personnalises_ids,
+            action_personnalise_ids,
             action_desactive_ids,
         )
     )

--- a/business/tests/e2e/test_yaml_scenarios.py
+++ b/business/tests/e2e/test_yaml_scenarios.py
@@ -1,3 +1,5 @@
+import os
+
 from .fixtures import *
 from pathlib import Path
 import yaml
@@ -7,7 +9,7 @@ from business.utils.models.action_statut import (
 )
 
 yaml_tests_dir = "../markdown/tests"
-yaml_tests_glob = "**/*.test.yml"
+yaml_tests_glob = os.environ.get("YAML_TESTS") or "**/*.test.yml"
 paths = [('/'.join(str(path).split('/')[-2:]), path) for path in list(Path(yaml_tests_dir).glob(yaml_tests_glob))]
 
 

--- a/markdown/tests/propagation/cae_1.1.2.test.yml
+++ b/markdown/tests/propagation/cae_1.1.2.test.yml
@@ -1,0 +1,20 @@
+Test:
+  La 1.1.2.1.5 est désactivée pour les EPCI
+Collectivité:
+  type:
+    - EPCI
+Statuts:
+  cae_1.1.2.1.1: non_concerne
+  cae_1.1.2.1.2: non_concerne
+  cae_1.1.2.1.3: non_concerne
+  cae_1.1.2.1.4: non_concerne
+Scores:
+  cae_1.1.2:
+    test: le point potentiel ne devrait pas changer les points 
+      de la cae_1.1.2.1 devraient être redistribués
+    point_referentiel: 10
+    point_potentiel: 10 # BUG 8
+  cae_1.1.2.1.5:
+    point_referentiel: 0.4
+    point_potentiel: 0.0
+    desactive: yes

--- a/markdown/tests/propagation/cae_1.1.2.test.yml
+++ b/markdown/tests/propagation/cae_1.1.2.test.yml
@@ -13,7 +13,7 @@ Scores:
     test: le point potentiel ne devrait pas changer les points 
       de la cae_1.1.2.1 devraient être redistribués
     point_referentiel: 10
-    point_potentiel: 10 # BUG 8
+    point_potentiel: 10
   cae_1.1.2.1.5:
     point_referentiel: 0.4
     point_potentiel: 0.0


### PR DESCRIPTION
La combinaison de tâches non-concernées et désactivées devrait conduire à une répartition des points de la sous-action.
Attention on suppose que corriger le problème impliquerait le changement de certaines règles.

Le nouveau test "[La 1.1.2.1.5 est désactivée pour les EPCI](https://github.com/betagouv/territoires-en-transitions/blob/9fd421b16dd783736d8695d5628e7d23a48d2561/markdown/tests/propagation/cae_1.1.2.test.yml)" et les autres passent.

- [x] modifier l'algo
- [x] déployer sur sandbox
- [x] tester (les deux sandbox utilisent le même moteur)


 

