### PR TITLE
Cypress IntelliJ

### DIFF
--- a/e2e/cypress/integration/01-se-connecter/steps.js
+++ b/e2e/cypress/integration/01-se-connecter/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 import {LocalSelectors} from './selectors';
 import {LocalMocks} from './mocks';
 
@@ -8,7 +8,7 @@ beforeEach(() => {
   cy.wrap(LocalMocks).as('LocalMocks', {type: 'static'});
 });
 
-defineStep(
+When(
   "j'ouvre le site depuis un lien de réinitialisation du mot de passe",
   () => {
     // génère le lien tel qui sera généré par le back et envoyé par mail (il est
@@ -27,7 +27,7 @@ defineStep(
   }
 );
 
-defineStep('je vais vérifier les données envoyées à la chatbox', () => {
+When('je vais vérifier les données envoyées à la chatbox', () => {
   // attend que le client crisp soit chargé
   cy.window({log: false})
     .its('$crisp')
@@ -35,20 +35,13 @@ defineStep('je vais vérifier les données envoyées à la chatbox', () => {
     .then($crisp => cy.spy($crisp, 'push').as('crisp.push'));
 });
 
-defineStep(
-  'les données suivantes ont été envoyées à la chatbox :',
-  dataTable => {
-    const {nom, prenom, email} = dataTable.rowsHash();
-    // vérifie que l'identité de l'utilisateur est associée à la session crisp
-    cy.get('@crisp.push').should('be.calledWith', [
-      'set',
-      'user:nickname',
-      [`${prenom} ${nom}`],
-    ]);
-    cy.get('@crisp.push').should('be.calledWith', [
-      'set',
-      'user:email',
-      [email],
-    ]);
-  }
-);
+When('les données suivantes ont été envoyées à la chatbox :', dataTable => {
+  const {nom, prenom, email} = dataTable.rowsHash();
+  // vérifie que l'identité de l'utilisateur est associée à la session crisp
+  cy.get('@crisp.push').should('be.calledWith', [
+    'set',
+    'user:nickname',
+    [`${prenom} ${nom}`],
+  ]);
+  cy.get('@crisp.push').should('be.calledWith', ['set', 'user:email', [email]]);
+});

--- a/e2e/cypress/integration/02-associer-une-collectivite-a-mon-compte/steps.js
+++ b/e2e/cypress/integration/02-associer-une-collectivite-a-mon-compte/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 import {LocalSelectors} from './selectors';
 
 // enregistre les définitions locales
@@ -6,19 +6,16 @@ beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors', {type: 'static'});
 });
 
-defineStep(
-  /je sélectionne "([^"]+)" dans le champ "([^"]+)"/,
-  (value, champ) => {
-    cy.get(`[data-test=${champ}]`).select(value);
-  }
-);
+When(/je sélectionne "([^"]+)" dans le champ "([^"]+)"/, (value, champ) => {
+  cy.get(`[data-test=${champ}]`).select(value);
+});
 
-defineStep(/le champ "([^"]+)" doit contenir "([^"]+)"/, (champ, value) => {
+When(/le champ "([^"]+)" doit contenir "([^"]+)"/, (champ, value) => {
   cy.get(`[data-test=${champ}]`).should('have.value', value);
 });
 
 const inputSelector = 'input[name=collectiviteId]';
-defineStep(
+When(
   /je recherche la collectivité "([^"]+)" dans le champ "([^"]+)"/,
   (value, champ) => {
     cy.get('[data-test="formulaire-RejoindreUneCollectivite"]').within(() => {
@@ -32,21 +29,21 @@ defineStep(
   }
 );
 
-defineStep(/une alerte contient le titre "([^"]+)"/, value => {
+When(/une alerte contient le titre "([^"]+)"/, value => {
   cy.get(`.fr-alert`).find('h3').should('have.text', value);
 });
 
-defineStep(/une alerte contient le message "([^"]+)"/, value => {
+When(/une alerte contient le message "([^"]+)"/, value => {
   cy.wait(500); // attente de la requete
   cy.get(`.fr-alert`).find('p').should('have.text', value);
 });
 
 // lien vers tableau de bord
-defineStep(/je clique sur le lien du formulaire/, () => {
+When(/je clique sur le lien du formulaire/, () => {
   cy.get('[data-test="formulaire-RejoindreUneCollectivite"]').find('a').click();
 });
 
-defineStep(
+When(
   /la collectivité "([^"]+)" apparait dans le dropdown de sélection avec les droits d'accès relatifs à ma Fonction/,
   value => {
     cy.get('[data-test="SelectCollectivite"] button b').should(

--- a/e2e/cypress/integration/03-visualiser-les-autres-collectivites/steps.js
+++ b/e2e/cypress/integration/03-visualiser-les-autres-collectivites/steps.js
@@ -1,5 +1,5 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
-defineStep(/la page contient au moins (\d+) collectivités?/, count => {
+When(/la page contient au moins (\d+) collectivités?/, count => {
   cy.get('[data-test=CollectiviteCarte]').should('have.length.gt', count);
 });

--- a/e2e/cypress/integration/04-associer-des-preuves-aux-actions/steps.js
+++ b/e2e/cypress/integration/04-associer-des-preuves-aux-actions/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 import {
@@ -12,7 +12,7 @@ beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors', {type: 'static'});
 });
 
-defineStep(/je déplie le panneau Preuves de l'action "([^"]+)"/, action =>
+When(/je déplie le panneau Preuves de l'action "([^"]+)"/, action =>
   getPreuvePanel(action).within(() => {
     // clic pour déplier le panneau
     cy.root().click();
@@ -21,7 +21,7 @@ defineStep(/je déplie le panneau Preuves de l'action "([^"]+)"/, action =>
   })
 );
 
-defineStep(
+When(
   /la table des preuves complémentaires est initialisée avec les données suivantes/,
   dataTable => {
     cy.get('@supabaseClient').then(client =>
@@ -29,7 +29,7 @@ defineStep(
     );
   }
 );
-defineStep(
+When(
   /la table des preuves réglementaires est initialisée avec les données suivantes/,
   dataTable => {
     cy.get('@supabaseClient').then(client =>
@@ -38,46 +38,46 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /la liste des preuves complémentaires de la sous-action "([^"]+)" est vide/,
   action => {
     noPreuvesComplementaires(getPreuvePanel(action));
   }
 );
 
-defineStep(/la liste des preuves complémentaires de l'action est vide/, () => {
+When(/la liste des preuves complémentaires de l'action est vide/, () => {
   noPreuvesComplementaires(getPreuveTab());
 });
 
-defineStep(
+When(
   /la liste des preuves complémentaires de la sous-action "([^"]+)" contient les lignes suivantes/,
   (action, dataTable) => {
     checkPreuvesComplementaires(getPreuvePanel(action), dataTable);
   }
 );
 
-defineStep(
+When(
   /la liste des preuves complémentaires de l'action contient les lignes suivantes/,
   dataTable => {
     checkPreuvesComplementaires(getPreuveTab(), dataTable);
   }
 );
 
-defineStep(
+When(
   /la liste des preuves attendues de la sous-action "([^"]+)" contient les lignes suivantes/,
   (action, dataTable) => {
     checkPreuvesReglementaires(getPreuvePanel(action), dataTable);
   }
 );
 
-defineStep(
+When(
   /la liste des preuves attendues de l'action contient les lignes suivantes/,
   dataTable => {
     checkPreuvesReglementaires(getPreuveTab(), dataTable);
   }
 );
 
-defineStep(
+When(
   /je clique sur la preuve "([^"]+)" de l'action "([^"]+)"/,
   (preuve, action) => {
     getPreuvePanel(action)
@@ -87,7 +87,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /je clique sur le bouton "([^"]+)" de la preuve "([^"]+)" de l'action "([^"]+)"/,
   (btn, preuve, action) => {
     getPreuvePanel(action)
@@ -110,20 +110,20 @@ const updateCommentOrName = (newValue, preuve, action) => {
     cy.get(inputSelector).should('not.exist');
   });
 };
-defineStep(
+When(
   /je saisi "([^"]+)" comme commentaire de la preuve "([^"]+)" de l'action "([^"]+)"/,
   updateCommentOrName
 );
-defineStep(
+When(
   /je saisi "([^"]+)" comme nom de la preuve "([^"]+)" de l'action "([^"]+)"/,
   updateCommentOrName
 );
 
-defineStep(/l'ouverture du lien "([^"]+)" doit avoir été demandée/, url => {
+When(/l'ouverture du lien "([^"]+)" doit avoir été demandée/, url => {
   cy.get('@open').should('have.been.calledOnceWithExactly', url);
 });
 
-defineStep(
+When(
   /clique sur le bouton "Ajouter une preuve" à l'action "([^"]+)"/,
   action => {
     // utilise le paramètre "force" pour le clic (sinon il ne se produit jamais ?)
@@ -131,7 +131,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /clique sur le (\d)(?:er|ème) bouton "Ajouter une preuve réglementaire" à l'action "([^"]+)"/,
   (num, action) => {
     // utilise le paramètre "force" pour le clic (sinon il ne se produit jamais ?)
@@ -143,7 +143,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /le bouton "Ajouter une preuve" à l'action "([^"]+)" est (visible|absent)/,
   (action, status) => {
     getAddPreuveButton(action).should(
@@ -152,14 +152,14 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   "je clique sur le bouton d'ajout d'une preuve complémentaire à l'action",
   () => {
     getPreuveTab().find('[data-test=AddPreuveComplementaire]').click();
   }
 );
 
-defineStep(
+When(
   /je sélectionne la sous-action "([^"]+)" dans la liste déroulante/,
   value => {
     cy.get('[data-test=SelectSubAction]').should('be.visible').click();
@@ -169,12 +169,12 @@ defineStep(
   }
 );
 
-defineStep(/la liste déroulante des sous-actions est visible/, () => {
+When(/la liste déroulante des sous-actions est visible/, () => {
   cy.get('[data-test=SelectSubAction]').should('be.visible');
 });
 
 let cnt = 1;
-defineStep(
+When(
   "je peux télécharger toutes les preuves sous la forme d'un fichier nommé {string} et contenant les fichiers suivants :",
   (downloadedFile, dataTable) => {
     // chemin du fichier téléchargé
@@ -213,7 +213,7 @@ defineStep(
   }
 );
 
-defineStep('je confirme la suppression de la preuve', () => {
+When('je confirme la suppression de la preuve', () => {
   cy.get('[data-test=ConfirmSupprPreuve]').within(() => {
     cy.root().should('be.visible');
     cy.get('button[data-test=ok]').click();

--- a/e2e/cypress/integration/05-modifier-etat-avancement/steps.js
+++ b/e2e/cypress/integration/05-modifier-etat-avancement/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 import {LocalSelectors} from './selectors';
 
 // enregistre les définitions locales
@@ -6,28 +6,25 @@ beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors', {type: 'static'});
 });
 
-defineStep("aucun score n'est affiché", () => {
+When("aucun score n'est affiché", () => {
   cy.get('[data-test^=score-]').should('not.exist');
 });
 
 /*
-defineStep('tous les scores sont à 0', () => {
+When('tous les scores sont à 0', () => {
   cy.get('[data-test^=score-]').each((el) =>
     cy.wrap(el).should('have.text', '0 %')
   );
 });
 */
 
-defineStep(
-  'les scores sont affichés avec les valeurs suivantes :',
-  dataTable => {
-    cy.wrap(dataTable.rows()).each(([action, score]) => {
-      cy.get(`[data-test="score-${action}"]`).should('contain.text', score);
-    });
-  }
-);
+When('les scores sont affichés avec les valeurs suivantes :', dataTable => {
+  cy.wrap(dataTable.rows()).each(([action, score]) => {
+    cy.get(`[data-test="score-${action}"]`).should('contain.text', score);
+  });
+});
 
-defineStep(
+When(
   /j'assigne la valeur "([^"]+)" à l'état d'avancement de la tâche "([^"]+)"/,
   (avancement, tache) => {
     // ouvre le composant Select
@@ -45,12 +42,12 @@ defineStep(
   }
 );
 
-defineStep("l'état d'avancement des tâches n'est pas éditable", () => {
+When("l'état d'avancement des tâches n'est pas éditable", () => {
   // aucun select n'est affiché
   cy.get('[data-test^="task-"] [data-test=SelectStatut]').should('not.exist');
 });
 
-defineStep("l'état d'avancement des tâches est éditable", () => {
+When("l'état d'avancement des tâches est éditable", () => {
   // récupère le nombre de tâches
   const taches = '[data-test^="task-"]';
   cy.get(taches)
@@ -74,7 +71,7 @@ const avancementToValue = {
   'Non concerné': 'non_concerne',
 };
 
-defineStep(
+When(
   /je saisi "([^"]+)" dans le champ "Précisions" de la tâche "([^"]+)"/,
   (commentaire, tache) => {
     cy.get(`[data-test="comm-${tache}"]`)
@@ -83,12 +80,12 @@ defineStep(
   }
 );
 
-defineStep("aucun historique n'est affiché", () => {
+When("aucun historique n'est affiché", () => {
   cy.get('[data-test^=action-statut-]').should('not.exist');
   cy.get('[data-test=empty_history]').should('be.visible');
 });
 
-defineStep(/l'historique contient (\d+) entrées?/, count => {
+When(/l'historique contient (\d+) entrées?/, count => {
   cy.get('[data-test=empty_history]').should('not.exist');
   cy.get('[data-test=Historique] [data-test=item]').should(
     'have.length',
@@ -96,7 +93,7 @@ defineStep(/l'historique contient (\d+) entrées?/, count => {
   );
 });
 
-defineStep(
+When(
   /l'entrée (\d+) de l'historique est affichée avec les valeurs suivantes/,
   (num, dataTable) => {
     cy.get(`[data-test=Historique] [data-test=item]:nth(${num - 1})`)
@@ -110,18 +107,15 @@ defineStep(
   }
 );
 
-defineStep(
-  /le détail de l'entrée (\d+) de l'historique n'est pas affiché/,
-  num => {
-    cy.get(
-      `[data-test=Historique] [data-test=item]:nth(${
-        num - 1
-      }) [data-test=detail-on]`
-    ).should('not.exist');
-  }
-);
+When(/le détail de l'entrée (\d+) de l'historique n'est pas affiché/, num => {
+  cy.get(
+    `[data-test=Historique] [data-test=item]:nth(${
+      num - 1
+    }) [data-test=detail-on]`
+  ).should('not.exist');
+});
 
-defineStep(
+When(
   /le détail de l'entrée (\d+) est affiché avec les valeurs suivantes/,
   (num, dataTable) => {
     cy.get(
@@ -142,29 +136,23 @@ defineStep(
   }
 );
 
-defineStep(
-  /je clique sur le bouton "Afficher le détail" de l'entrée (\d+)/,
-  num => {
-    cy.get(
-      `[data-test=Historique] [data-test=item]:nth(${
-        num - 1
-      }) [data-test=detail-off] button`
-    ).click();
-  }
-);
+When(/je clique sur le bouton "Afficher le détail" de l'entrée (\d+)/, num => {
+  cy.get(
+    `[data-test=Historique] [data-test=item]:nth(${
+      num - 1
+    }) [data-test=detail-off] button`
+  ).click();
+});
 
-defineStep(
-  /je clique sur le bouton "Masquer le détail" de l'entrée (\d+)/,
-  num => {
-    cy.get(
-      `[data-test=Historique] [data-test=item]:nth(${
-        num - 1
-      }) [data-test=detail-on] button`
-    ).click();
-  }
-);
+When(/je clique sur le bouton "Masquer le détail" de l'entrée (\d+)/, num => {
+  cy.get(
+    `[data-test=Historique] [data-test=item]:nth(${
+      num - 1
+    }) [data-test=detail-on] button`
+  ).click();
+});
 
-defineStep(
+When(
   /je filtre l'historique avec le filtre "([^"]+)" par l'option "([^"]+)"/,
   (filtre, option) => {
     cy.get(`[data-test=filtre-${filtre}]`).click();
@@ -176,10 +164,10 @@ defineStep(
   }
 );
 
-defineStep(/je filtre l'historique avec comme date de fin "([^"]+)"/, date => {
+When(/je filtre l'historique avec comme date de fin "([^"]+)"/, date => {
   cy.get('[data-test=filtre-end-date]').type(date);
 });
 
-defineStep('je désactive tous les filtres', () => {
+When('je désactive tous les filtres', () => {
   cy.get('[data-test=desactiver-les-filtres]').click();
 });

--- a/e2e/cypress/integration/06-personnaliser-le-referentiel/steps.js
+++ b/e2e/cypress/integration/06-personnaliser-le-referentiel/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 
@@ -8,18 +8,15 @@ beforeEach(() => {
 });
 
 /** Vérification des questions/réponse **/
-defineStep(
-  /la liste des questions contient les entrées suivantes/,
-  dataString => {
-    // sélectionne le dialogue
-    cy.get(
-      LocalSelectors['dialogue Personnaliser le potentiel'].selector
-    ).within(() => {
+When(/la liste des questions contient les entrées suivantes/, dataString => {
+  // sélectionne le dialogue
+  cy.get(LocalSelectors['dialogue Personnaliser le potentiel'].selector).within(
+    () => {
       checkQuestionsReponses(dataString);
-    });
-  }
-);
-defineStep(
+    }
+  );
+});
+When(
   'la page thématique contient entre autres les questions suivantes :',
   dataString => {
     cy.get('[data-test=thematique]').within(() => {
@@ -29,26 +26,25 @@ defineStep(
 );
 
 /** Saisie les réponses */
-defineStep(
-  'je complète les questions avec les valeurs suivantes :',
-  dataString => setReponses(dataString)
+When('je complète les questions avec les valeurs suivantes :', dataString =>
+  setReponses(dataString)
 );
 
-defineStep('je clique sur la thématique {string}', thematique => {
+When('je clique sur la thématique {string}', thematique => {
   cy.get('[data-test=personnalisation] a').contains(thematique).click();
 });
 
-defineStep("je clique sur l'avant-dernière thématique", thematique => {
+When("je clique sur l'avant-dernière thématique", thematique => {
   cy.get('[data-test=personnalisation] a:nth(-2)').click();
 });
-defineStep('je clique sur la dernière thématique', thematique => {
+When('je clique sur la dernière thématique', thematique => {
   cy.get('[data-test=personnalisation] a:nth(-1)').click();
 });
 
-defineStep('la page contient plus de {int} thématiques', count =>
+When('la page contient plus de {int} thématiques', count =>
   cy.get('[data-test=personnalisation] a').should('have.length.gt', count)
 );
-defineStep('la page contient moins de {int} thématiques', count =>
+When('la page contient moins de {int} thématiques', count =>
   cy.get('[data-test=personnalisation] a').should('have.length.lt', count)
 );
 

--- a/e2e/cypress/integration/07-ajouter-un-membre/steps.js
+++ b/e2e/cypress/integration/07-ajouter-un-membre/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 
@@ -7,16 +7,16 @@ beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors', {type: 'static'});
 });
 
-defineStep("un formulaire d'invitation est affiché", () => {
+When("un formulaire d'invitation est affiché", () => {
   cy.get(LocalSelectors["formulaire d'invitation"].selector).should(
     'be.visible'
   );
 });
 
-defineStep("un message d'invitation est affiché", () => {
+When("un message d'invitation est affiché", () => {
   cy.get(LocalSelectors["message d'invitation"].selector).should('be.visible');
 });
-defineStep(
+When(
   /je renseigne l'email "([^"]+)" de la personne à inviter en "([^"]+)"/,
   (email, acces) => {
     cy.get('input[name="email"]').type('{selectall}{backspace}' + email);
@@ -24,17 +24,14 @@ defineStep(
   }
 );
 
-defineStep(
-  /le tableau des membres doit contenir l'utilisateur "([^"]+)"/,
-  mail => {
-    cy.get(LocalSelectors['tableau des membres'].selector).should(
-      'contain',
-      mail
-    );
-  }
-);
+When(/le tableau des membres doit contenir l'utilisateur "([^"]+)"/, mail => {
+  cy.get(LocalSelectors['tableau des membres'].selector).should(
+    'contain',
+    mail
+  );
+});
 
-defineStep(
+When(
   /la page contient (?:les|la) collectivités? "([^"]*)"/,
   collectiviteNames => {
     const names = collectiviteNames.split(',').map(s => s.trim());
@@ -44,6 +41,6 @@ defineStep(
   }
 );
 
-defineStep('la page ne contient aucune collectivité', () => {
+When('la page ne contient aucune collectivité', () => {
   cy.get('[data-test=SimpleCollectiviteCard]').should('not.exist');
 });

--- a/e2e/cypress/integration/08-gerer-les-informations-des-membres/steps.js
+++ b/e2e/cypress/integration/08-gerer-les-informations-des-membres/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {Selectors} from '../common/selectors';
 import {LocalSelectors} from './selectors';
@@ -10,14 +10,14 @@ beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors', {type: 'static'});
 });
 
-defineStep('le tableau charge les informations', () => {
+When('le tableau charge les informations', () => {
   cy.get(tableauMembresSelector.selector).within(() => {
     cy.get('[data-test=Loading]').should('be.visible');
     cy.get('[data-test=Loading]').should('not.exist');
   });
 });
 
-defineStep(
+When(
   /le tableau des membres ne doit pas contenir l'utilisateur "([^"]+)"/,
   mail => {
     cy.get(tableauMembresSelector.selector).should('not.contain', mail);
@@ -62,21 +62,21 @@ const clickOnDropdownValue = (champ, email, value) => {
   }
 };
 
-defineStep(
+When(
   /je modifie le champ "([^"]+)" de "([^"]+)" en "([^"]+)"/,
   clickOnDropdownValue
 );
-defineStep(
+When(
   /je clique sur la valeur "([^"]+)" du champ "([^"]+)" de "([^"]+)"/,
   (value, champ, email) => clickOnDropdownValue(champ, email, value)
 );
 
 const getUtilisateurRow = email => cy.get(`[data-test="MembreRow-${email}"]`);
 
-defineStep(/je vois une modale intitulée "([^"]+)"/, titre => {
+When(/je vois une modale intitulée "([^"]+)"/, titre => {
   cy.get(LocalSelectors['modale'].selector).should('contain', titre);
 });
 
-defineStep(/je clique sur le bouton "([^"]+)" de la modale/, ariaLabel => {
+When(/je clique sur le bouton "([^"]+)" de la modale/, ariaLabel => {
   cy.get(`[aria-label="${ariaLabel}"]`).click();
 });

--- a/e2e/cypress/integration/09-creer-un-compte/steps.js
+++ b/e2e/cypress/integration/09-creer-un-compte/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 
@@ -7,6 +7,6 @@ beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors', {type: 'static'});
 });
 
-defineStep(/le bouton compte contient le texte "([^"]+)"/, message => {
+When(/le bouton compte contient le texte "([^"]+)"/, message => {
   cy.get('[data-test="connectedMenu"] button').should('contain', message);
 });

--- a/e2e/cypress/integration/10-flow-invitation/steps.js
+++ b/e2e/cypress/integration/10-flow-invitation/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 
@@ -7,16 +7,16 @@ beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors', {type: 'static'});
 });
 
-defineStep("un formulaire d'invitation est affiché", () => {
+When("un formulaire d'invitation est affiché", () => {
   cy.get(LocalSelectors["formulaire d'invitation"].selector).should(
     'be.visible'
   );
 });
 
-defineStep("un message d'invitation est affiché", () => {
+When("un message d'invitation est affiché", () => {
   cy.get(LocalSelectors["message d'invitation"].selector).should('be.visible');
 });
-defineStep(
+When(
   /je renseigne l'email "([^"]+)" de la personne à inviter en "([^"]+)"/,
   (email, acces) => {
     cy.get('input[name="email"]').type('{selectall}{backspace}' + email);
@@ -24,17 +24,14 @@ defineStep(
   }
 );
 
-defineStep(
-  /le tableau des membres doit contenir l'utilisateur "([^"]+)"/,
-  mail => {
-    cy.get(LocalSelectors['tableau des membres'].selector).should(
-      'contain',
-      mail
-    );
-  }
-);
+When(/le tableau des membres doit contenir l'utilisateur "([^"]+)"/, mail => {
+  cy.get(LocalSelectors['tableau des membres'].selector).should(
+    'contain',
+    mail
+  );
+});
 
-defineStep(
+When(
   /la page contient (?:les|la) collectivités? "([^"]*)"/,
   collectiviteNames => {
     const names = collectiviteNames.split(',').map(s => s.trim());
@@ -44,6 +41,6 @@ defineStep(
   }
 );
 
-defineStep('la page ne contient aucune collectivité', () => {
+When('la page ne contient aucune collectivité', () => {
   cy.get('[data-test=SimpleCollectiviteCard]').should('not.exist');
 });

--- a/e2e/cypress/integration/11-modifier-mes-informations-personnelles/steps.js
+++ b/e2e/cypress/integration/11-modifier-mes-informations-personnelles/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 
@@ -7,23 +7,23 @@ beforeEach(() => {
   cy.wrap(LocalSelectors).as('LocalSelectors', {type: 'static'});
 });
 
-defineStep('un formulaire de modification de compte est affiché', () => {
+When('un formulaire de modification de compte est affiché', () => {
   cy.get(
     LocalSelectors['formulaire de modification de compte'].selector
   ).should('be.visible');
 });
 
-defineStep(/je modifie le champ "([^"]+)" en "([^"]+)"/, (champ, value) => {
+When(/je modifie le champ "([^"]+)" en "([^"]+)"/, (champ, value) => {
   cy.get(`[data-test="${champ}"]`)
     .type('{selectall}{backspace}' + value)
     .blur();
 });
 
-defineStep(/le champ "([^"]+)" doit contenir "([^"]+)"/, (champ, value) => {
+When(/le champ "([^"]+)" doit contenir "([^"]+)"/, (champ, value) => {
   cy.get(`[data-test="${champ}"]`).should('have.value', value);
 });
 
-defineStep("la modale de modification d'email est affichée", () => {
+When("la modale de modification d'email est affichée", () => {
   cy.get(LocalSelectors["modale de modification d'email"].selector).should(
     'be.visible'
   );
@@ -31,7 +31,7 @@ defineStep("la modale de modification d'email est affichée", () => {
 
 const INBUCKET_URL = 'http://localhost:54324/';
 
-defineStep(/je vide la boîte de réception de "([^"]+)"/, email => {
+When(/je vide la boîte de réception de "([^"]+)"/, email => {
   cy.origin(INBUCKET_URL, {args: {email}}, ({email}) => {
     cy.visit(`/m/${email}`);
     cy.get(`.fa-trash`).click();
@@ -40,7 +40,7 @@ defineStep(/je vide la boîte de réception de "([^"]+)"/, email => {
   cy.visit('/');
 });
 
-defineStep(
+When(
   "je clique sur le bouton confirmer de la modale de modification d'email",
   () => {
     cy.get(LocalSelectors["modale de modification d'email"].selector)
@@ -49,7 +49,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /la boîte de réception de "([^"]+)" contient un mail intitulé "([^"]+)"/,
   (email, titre) => {
     cy.origin(INBUCKET_URL, {args: {email, titre}}, ({email, titre}) => {

--- a/e2e/cypress/integration/12-utiliser-la-bibliotheque/steps.js
+++ b/e2e/cypress/integration/12-utiliser-la-bibliotheque/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 import '../04-associer-des-preuves-aux-actions/steps';
 import {
   makeCheckPreuveRows,
@@ -15,10 +15,10 @@ beforeEach(() => {
   });
 });
 
-defineStep("il n'y a pas de documents de labellisation", () => {
+When("il n'y a pas de documents de labellisation", () => {
   getLib().find('[data-test=labellisation]').should('not.exist');
 });
-defineStep(
+When(
   'la liste des documents de labellisation contient les lignes suivantes :',
   dataTable => {
     getLib()
@@ -27,10 +27,10 @@ defineStep(
   }
 );
 
-defineStep('la liste des documents de la page Labellisation est vide', () => {
+When('la liste des documents de la page Labellisation est vide', () => {
   cy.get('[data-test=LabellisationPreuves]').should('not.exist');
 });
-defineStep(
+When(
   'la liste des documents de la page Labellisation contient les lignes suivantes :',
   dataTable => {
     cy.get('[data-test=LabellisationPreuves]').within(
@@ -39,11 +39,11 @@ defineStep(
   }
 );
 
-defineStep("il n'y a pas de rapports de visite annuelle", () => {
+When("il n'y a pas de rapports de visite annuelle", () => {
   getLib().find('[data-test=rapports] [data-test=item]').should('not.exist');
 });
 
-defineStep(
+When(
   'la liste des rapports de visite contient les lignes suivantes :',
   dataTable => {
     getLib()
@@ -52,11 +52,11 @@ defineStep(
   }
 );
 
-defineStep('je saisi comme date de visite {string}', date =>
+When('je saisi comme date de visite {string}', date =>
   cy.get('[data-test=date-visite] input[type=date]').type(date)
 );
 
-defineStep(
+When(
   'je déplie la sous-action {string} du référentiel {string}',
   (actionId, referentiel) => {
     getRefentielIdentifiants(referentiel)
@@ -67,14 +67,14 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   'la liste des preuves complémentaires associées à la sous-action {string} est vide',
   actionId => {
     noPreuvesComplementaires(cy.get(`[data-test="preuves-${actionId}"]`));
   }
 );
 
-defineStep(
+When(
   'la liste des preuves complémentaires associées à la sous-action {string} contient les lignes suivantes :',
   (actionId, dataTable) => {
     checkPreuvesComplementaires(
@@ -84,7 +84,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   'je clique sur le bouton "Ajouter une preuve" de la sous-action {string}',
   actionId => {
     cy.get(

--- a/e2e/cypress/integration/13-action-discussions/steps.js
+++ b/e2e/cypress/integration/13-action-discussions/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 
@@ -11,69 +11,66 @@ beforeEach(() => {
 const getFirstDiscussion = () =>
   cy.get('[data-test=ActionDiscussionsFeed]').first();
 
-defineStep(/le commentaire "([^"]+)" n'est plus visible/, value => {
+When(/le commentaire "([^"]+)" n'est plus visible/, value => {
   getFirstDiscussion().contains(value).should('not.exist');
 });
 
-defineStep(/le commentaire "([^"]+)" est visible/, value => {
+When(/le commentaire "([^"]+)" est visible/, value => {
   getFirstDiscussion().contains(value).should('be.visible');
 });
 
 // Scénario: Consulter les discussions d'une action
-defineStep("je clique sur l'icône commentaires", () => {
+When("je clique sur l'icône commentaires", () => {
   cy.get('[data-test=ActionDiscussionsButton]').click();
 });
 
-defineStep('le panel-action-discussions est visible', () => {
+When('le panel-action-discussions est visible', () => {
   cy.get('[data-test=ActionDiscussionsPanel]').should('be.visible');
 });
 
-defineStep('il affiche les discussions ouvertes', () => {
+When('il affiche les discussions ouvertes', () => {
   cy.get('[data-test=ActionDiscussionsChangeVue]').contains('Ouverts');
 });
 
 // Scénario: Créer une discussion
-defineStep(/je saisis "([^"]+)" dans le champs nouvelle discussion/, value => {
+When(/je saisis "([^"]+)" dans le champs nouvelle discussion/, value => {
   cy.get(`[data-test=ActionDiscussionsNouvelleDiscussion] textarea`).type(
     value
   );
 });
 
-defineStep('je clique sur "publier" une nouvelle discussion', () => {
+When('je clique sur "publier" une nouvelle discussion', () => {
   cy.get('[data-test=ActionDiscussionsNouvelleDiscussion] button').click();
 });
 
 // Scénario: Répondre à un commentaire
-defineStep(
-  /je saisis "([^"]+)" dans le champ répondre d'une discussion/,
-  value => {
-    getFirstDiscussion().find('textarea').first().type(value);
-  }
-);
+When(/je saisis "([^"]+)" dans le champ répondre d'une discussion/, value => {
+  getFirstDiscussion().find('textarea').first().type(value);
+});
 
-defineStep('je clique sur "publier" une nouvelle réponse', () => {
+When('je clique sur "publier" une nouvelle réponse', () => {
   getFirstDiscussion().contains('Publier').click();
 });
 
 // Visualiser les réponses à un commentaire
-defineStep(/un bouton contenant "([^"]+)" est visible/, value => {
+When(/un bouton contenant "([^"]+)" est visible/, value => {
   getFirstDiscussion().contains(value);
 });
 
-defineStep(/je clique sur le bouton "([^"]+)" de la 1ère discussion/, value => {
+When(/je clique sur le bouton "([^"]+)" de la 1ère discussion/, value => {
   getFirstDiscussion().contains(value).click();
 });
 
 // Scénario: Fermer et reouvrir une discussion
-// defineStep('je clique sur "Fermer" dans une discussion', () => {
+// When('je clique sur "Fermer" dans une discussion', () => {
 //   getFirstDiscussion().contains('Fermer').click();
 // });
 
-defineStep(/je clique sur "([^"]+)" dans une discussion/, value => {
+When(/je clique sur "([^"]+)" dans une discussion/, value => {
   getFirstDiscussion().contains(value).click();
 });
 
-defineStep('je change la vue du feed à "Fermés"', () => {
+When('je change la vue du feed à "Fermés"', () => {
   cy.get('[data-test=ActionDiscussionsChangeVue]').contains('Ouverts').click();
   cy.root()
     .get(`[data-test="ActionDiscussionsChangeVueMenu"]`)
@@ -82,7 +79,7 @@ defineStep('je change la vue du feed à "Fermés"', () => {
   cy.wait(100);
 });
 
-defineStep('je change la vue du feed à "Ouverts"', () => {
+When('je change la vue du feed à "Ouverts"', () => {
   cy.get('[data-test=ActionDiscussionsChangeVue]').contains('Fermés').click();
   cy.root()
     .get(`[data-test="ActionDiscussionsChangeVueMenu"]`)
@@ -91,7 +88,7 @@ defineStep('je change la vue du feed à "Ouverts"', () => {
 });
 
 // Scénario: Supprimer un commentaire
-defineStep(
+When(
   /je clique sur "([^"]+)" du commentaire "([^"]+)"/,
   (button, commentaire) => {
     getFirstDiscussion()

--- a/e2e/cypress/integration/14-demander-un-audit/steps.js
+++ b/e2e/cypress/integration/14-demander-un-audit/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 import {LocalSelectors as PreuveSelectors} from '../04-associer-des-preuves-aux-actions/selectors';
@@ -11,11 +11,11 @@ beforeEach(() => {
   });
 });
 
-defineStep(
+When(
   `la liste des documents de labellisation contient le titre {string} sans l'indication {string}`,
   checkDocLabellisation
 );
-defineStep(
+When(
   `la liste des documents de labellisation contient le titre {string} avec l'indication {string}`,
   (titre, indication) => checkDocLabellisation(titre, indication, true)
 );

--- a/e2e/cypress/integration/15-auditer-la-collectivite/steps.js
+++ b/e2e/cypress/integration/15-auditer-la-collectivite/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 import '../05-modifier-etat-avancement/steps';
 import '../12-utiliser-la-bibliotheque/steps';
 import '../14-demander-un-audit/steps';
@@ -20,7 +20,7 @@ beforeEach(() => {
 
 const suiviAuditTable = '[data-test="suivi-audit"]';
 
-defineStep(
+When(
   "le tableau de suivi de l'audit contient les lignes suivantes :",
   dataTable => {
     const rows = dataTable.rows();
@@ -54,7 +54,7 @@ const checkRow = ([identifiant, odj, avancement]) =>
       cy.get('[role=cell]:nth(2)').should('have.text', avancement);
     });
 
-defineStep(
+When(
   "je clique sur la ligne du tableau de suivi de l'audit contenant l'identifiant {string}",
   identifiant =>
     cy
@@ -64,7 +64,7 @@ defineStep(
       .click()
 );
 
-defineStep(
+When(
   "l'état d'avancement n'est pas éditable depuis le tableau de détail des tâches",
   () => {
     cy.get('[data-test=DetailTacheTable]').within(() => {
@@ -76,7 +76,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   "l'état d'avancement est éditable depuis le tableau de détail des tâches",
   () => {
     cy.get('[data-test=DetailTacheTable]').within(() => {
@@ -88,33 +88,33 @@ defineStep(
   }
 );
 
-defineStep("le tableau de suivi de l'audit ne contient pas de résultat", () => {
+When("le tableau de suivi de l'audit ne contient pas de résultat", () => {
   cy.get('[data-test=DetailTacheTable] [role=row] .identifiant').should(
     'have.length.gte',
     0
   );
 });
 
-defineStep("il n'y a pas de rapports d'audit", () => {
+When("il n'y a pas de rapports d'audit", () => {
   cy.get('[data-test=rapports-audit]').should('not.exist');
 });
 
-defineStep(
+When(
   "la liste des rapports d'audit contient les lignes suivantes :",
   dataTable => {
     cy.get('[data-test=rapports-audit]').within(makeCheckPreuveRows(dataTable));
   }
 );
 
-defineStep("l'en-tête contient {string}", text =>
+When("l'en-tête contient {string}", text =>
   cy.get('[data-test=HeaderMessage]').should('contain.text', text)
 );
 
-defineStep("l'en-tête ne contient pas de message", text =>
+When("l'en-tête ne contient pas de message", text =>
   cy.get('[data-test=HeaderMessage]').should('not.exist')
 );
 
-defineStep(
+When(
   'je déplie le sous-axe {string} du tableau de comparaison des scores',
   (actionId, referentiel) => {
     const indexes = actionId.split('.').map(idx => parseInt(idx));
@@ -135,11 +135,11 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   "le potentiel de l'action {string} est de {string} avant audit et {string} pendant l'audit",
   comparePotentiels
 );
-defineStep(
+When(
   "le potentiel de l'action {string} est de {string} avant et pendant l'audit",
   (identifiant, score) => comparePotentiels(identifiant, score, score)
 );
@@ -181,13 +181,13 @@ function comparePotentiels(identifiant, scoreAvant, scorePendant) {
 
 const toFloat = s => parseFloat(s.replace(',', '.'));
 
-defineStep("j'attends que les scores soient calculés", () => {
+When("j'attends que les scores soient calculés", () => {
   // ça peut être très lent en CI :(
   // idéalement il faudrait écouter les màj des scores comme dans l'app mais ce
   // n'est pas évident à faire
   cy.wait(10000);
 });
 
-defineStep('le potentiel de points est {string}', score => {
+When('le potentiel de points est {string}', score => {
   cy.get('[data-test=PointsPotentiels]').should('contain.text', score);
 });

--- a/e2e/cypress/integration/16-plan-action/steps.js
+++ b/e2e/cypress/integration/16-plan-action/steps.js
@@ -1,4 +1,4 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 import {LocalSelectors} from './selectors';
 
@@ -9,11 +9,11 @@ beforeEach(() => {
 
 /** FICHE ACTION */
 
-defineStep(/j'ouvre la section "([^"]+)"/, titre => {
+When(/j'ouvre la section "([^"]+)"/, titre => {
   cy.get(`[data-test=section-${titre}]`).click();
 });
 
-defineStep(
+When(
   /je crée un tag "([^"]*)" avec le sélecteur de tag "([^"]*)"/,
   (tag, selecteur) => {
     cy.get(`[data-test=${selecteur}-input]`).type(
@@ -25,7 +25,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /je sélectionne "([^"]*)" dans la liste déroulante "([^"]*)"/,
   (option, selecteur) => {
     cy.get(`[data-test=${selecteur}]`).click();
@@ -34,7 +34,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /la carte de la fiche créée est présente et affiche le titre "([^"]*)", le pilote "([^"]*)" et le statut "([^"]*)"/,
   (titre, pilote, statut) => {
     cy.get('[data-test=ActionCarte]').contains(titre).should('be.visible');
@@ -43,31 +43,31 @@ defineStep(
   }
 );
 
-defineStep(/je navigue sur la fiche "([^"]*)"/, titre => {
+When(/je navigue sur la fiche "([^"]*)"/, titre => {
   cy.get('[data-test=ActionCarte]').contains(titre).click();
 });
 
-defineStep(/je supprime la fiche/, () => {
+When(/je supprime la fiche/, () => {
   cy.get('[data-test=SupprimerFicheBouton]').click();
   cy.contains('Confirmer').click();
 });
 
-defineStep(/la fiche "([^"]*)" n'est plus présente/, titre => {
+When(/la fiche "([^"]*)" n'est plus présente/, titre => {
   cy.contains(titre).should('not.exist');
 });
 
-defineStep(/je navigue vers "([^"]*)" du fil d'ariane de la fiche/, axe => {
+When(/je navigue vers "([^"]*)" du fil d'ariane de la fiche/, axe => {
   cy.get('[data-test=FicheFilAriane]').contains(axe).click();
 });
 
 /** PLAN D'ACTION */
-defineStep(/je crée le plan "([^"]*)"/, titre => {
+When(/je crée le plan "([^"]*)"/, titre => {
   cy.get('[data-test=CreerPlan]').click();
   cy.get('[data-test=PlanNomInput]').clear().type(titre);
   cy.get('button').contains('Valider').click();
 });
 
-defineStep(
+When(
   /le nom du plan d'action est changé en "([^"]*)" dans la navigation/,
   titre => {
     cy.get('[data-test=PlansActionNavigation]')
@@ -76,18 +76,18 @@ defineStep(
   }
 );
 
-defineStep(/je veux supprimer le plan/, () => {
+When(/je veux supprimer le plan/, () => {
   cy.get('[data-test=SupprimerPlanBouton]').click();
 });
 
-defineStep(/j'ajoute un nouveau titre/, () => {
+When(/j'ajoute un nouveau titre/, () => {
   cy.get('[data-test=AjouterAxe]').click();
   // attends que le dernier axe ajouté (celui avec un titre vide) soit visible
   // autorise un timeout un peu plus long car le back peut être lent à répondre en CI
   cy.get('[data-test=Axe]').first().find('textarea').should('have.text', '');
 });
 
-defineStep(/je le nomme "([^"]*)"/, titre => {
+When(/je le nomme "([^"]*)"/, titre => {
   // sélectionne le dernier axe ajouté
   cy.get('[data-test=Axe]')
     .first()
@@ -99,7 +99,7 @@ defineStep(/je le nomme "([^"]*)"/, titre => {
   cy.get('body').click(10, 10);
 });
 
-defineStep(/j'ajoute une fiche à "([^"]*)"/, titre => {
+When(/j'ajoute une fiche à "([^"]*)"/, titre => {
   // sélectionne l'axe qui contient le titre donné
   cy.get('[data-test=Axe]')
     .contains(titre)
@@ -120,63 +120,60 @@ defineStep(/j'ajoute une fiche à "([^"]*)"/, titre => {
   cy.get('[data-test=FicheAction]').should('be.visible');
 });
 
-defineStep(/je reviens sur le plan d'action "([^"]*)"/, titre => {
+When(/je reviens sur le plan d'action "([^"]*)"/, titre => {
   cy.get('[data-test=PlansActionNavigation]').contains(titre).click();
 });
 
-defineStep(/je veux supprimer le dernier axe créé/, () => {
+When(/je veux supprimer le dernier axe créé/, () => {
   cy.get('[data-test=SupprimerAxeBouton]').first().click({force: true});
 });
 
-defineStep(/le texte "([^"]*)" est visible/, texte => {
+When(/le texte "([^"]*)" est visible/, texte => {
   cy.contains(texte).should('be.visible');
 });
 
-defineStep(/je supprime l'axe depuis la modale/, () => {
+When(/je supprime l'axe depuis la modale/, () => {
   cy.get('[data-test=SupprimerFicheModale]').contains('Confirmer').click();
 });
 
-defineStep(/l'axe "([^"]*)" n'est plus visible/, axe => {
+When(/l'axe "([^"]*)" n'est plus visible/, axe => {
   cy.contains(axe).should('not.exist');
 });
 
-defineStep(/le plan n'est plus présent dans la navigation/, () => {
+When(/le plan n'est plus présent dans la navigation/, () => {
   cy.contains('Plan test').should('not.exist');
 });
 
 /** RANGER FICHE ACTION */
 
-defineStep(/j'ouvre la modale "([^"]*)"/, bouton => {
+When(/j'ouvre la modale "([^"]*)"/, bouton => {
   cy.contains(bouton).click();
 });
 
-defineStep(/j'enlève la fiche du plan/, () => {
+When(/j'enlève la fiche du plan/, () => {
   cy.get('[data-test=EnleverFichePlanBouton]').click({force: true});
 });
 
-defineStep(
+When(
   /le plan "([^"]*)" est visible dans le tableau nouvel emplacement/,
   plan => {
     cy.get('[data-test=TableauAxe]').contains(plan).should('be.visible');
   }
 );
 
-defineStep(/le fil d'ariane de la fiche contient "([^"]*)"/, chemin => {
+When(/le fil d'ariane de la fiche contient "([^"]*)"/, chemin => {
   cy.get('[data-test=FicheFilAriane]').contains(chemin).should('exist');
 });
 
-defineStep(
-  /je clique sur l'axe "([^"]*)" du tableau nouvel emplacement/,
-  axe => {
-    cy.get('[data-test=TableauAxe]').contains(axe).click();
-  }
-);
+When(/je clique sur l'axe "([^"]*)" du tableau nouvel emplacement/, axe => {
+  cy.get('[data-test=TableauAxe]').contains(axe).click();
+});
 
-defineStep(/je valide cet emplacement/, () => {
+When(/je valide cet emplacement/, () => {
   cy.contains('Valider cet emplacement').click();
 });
 
-defineStep(
+When(
   /l'axe "([^"]*)" est visible dans les emplacements sélectionnés pour cette fiche/,
   axe => {
     cy.get('[data-test=PlanChemin]').contains(axe).should('be.visible');
@@ -185,7 +182,7 @@ defineStep(
 
 /** PAGE AXE ET FILTRES */
 
-defineStep(
+When(
   /j'ouvre "([^"]*)" dans la navigation latérale et que je navigue vers "([^"]*)"/,
   (section, axe) => {
     // ouvre la section correspondant au plan donné
@@ -202,11 +199,11 @@ defineStep(
   }
 );
 
-defineStep(/j'ouvre les filtres/, () => {
+When(/j'ouvre les filtres/, () => {
   cy.get('[data-test=FiltrerFiches]').contains('Filtrer').click();
 });
 
-defineStep(
+When(
   /je filtre les fiches par "([^"]*)" du filtre "([^"]*)"/,
   (value, filtre) => {
     cy.get(`[data-test=filtre-${filtre}]`).click();
@@ -215,12 +212,12 @@ defineStep(
   }
 );
 
-defineStep(/aucune fiche n'est présente/, () => {
+When(/aucune fiche n'est présente/, () => {
   cy.root()
     .contains('Aucune fiche ne correspond à votre recherche')
     .should('be.visible');
 });
 
-defineStep(/la fiche contenant "([^"]*)" est visible/, value => {
+When(/la fiche contenant "([^"]*)" est visible/, value => {
   cy.get('[data-test=ActionCarte]').contains(value).should('be.visible');
 });

--- a/e2e/cypress/integration/common/FileManager.js
+++ b/e2e/cypress/integration/common/FileManager.js
@@ -1,7 +1,7 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 import {resolveSelector} from './steps';
 
-defineStep(
+When(
   /je transfère à partir du "([^"]*)" le fichier nommé "([^"]*)" et contenant "([^"]*)"/,
   function (elem, fileName, fileContent) {
     const parent = resolveSelector(this, elem);
@@ -15,7 +15,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /je transfère à partir du "([^"]*)" le fichier nommé "([^"]*)" et d'un poids de "([^"]*)" Mo/,
   function (elem, fileName, fileSize) {
     const parent = resolveSelector(this, elem);
@@ -29,7 +29,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /la liste des fichiers transférés contient les entrées suivantes/,
   dataTable => {
     // dans la liste d'items affichée
@@ -71,10 +71,10 @@ defineStep(
   }
 );
 
-defineStep('tous les transferts sont terminés', () => {
+When('tous les transferts sont terminés', () => {
   cy.get('[data-test*=file-running]', {timeout: 10000}).should('not.exist');
 });
 
-defineStep('le fichier {string} doit avoir été téléchargé', fileName => {
+When('le fichier {string} doit avoir été téléchargé', fileName => {
   cy.verifyDownload(fileName);
 });

--- a/e2e/cypress/integration/common/clipboard.js
+++ b/e2e/cypress/integration/common/clipboard.js
@@ -1,10 +1,10 @@
-const {defineStep} = require('@badeball/cypress-cucumber-preprocessor');
+const {When} = require('@badeball/cypress-cucumber-preprocessor');
 
-defineStep(/le presse-papier contient "([^"]*)"/, message => {
+When(/le presse-papier contient "([^"]*)"/, message => {
   cy.task('getClipboard').should('contain', message);
 });
 
-defineStep('je visite le lien copié', () =>
+When('je visite le lien copié', () =>
   cy.task('getClipboard').then(val => {
     cy.visit({
       url: val,

--- a/e2e/cypress/integration/common/collectivite.js
+++ b/e2e/cypress/integration/common/collectivite.js
@@ -1,12 +1,12 @@
 /**
  * Génère une collectivité et diverses données de test (utilisateur, scores, etc.)
  */
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 import {Views, CollectivitePages} from './views';
 import {waitForApp, logout} from './shared';
 
 // crée une collectivité de test
-defineStep('une collectivité nommée {string}', createCollectivite);
+When('une collectivité nommée {string}', createCollectivite);
 function createCollectivite(nom) {
   cy.task('supabase_rpc', {
     name: 'test_create_collectivite',
@@ -17,7 +17,7 @@ function createCollectivite(nom) {
 }
 
 // passe cette collectivité en COT
-defineStep('avec un COT actif', setCOT);
+When('avec un COT actif', setCOT);
 function setCOT() {
   const {collectivite_id} = this.collectivite;
   cy.task('supabase_rpc', {
@@ -27,7 +27,7 @@ function setCOT() {
 }
 
 // crée un utilisateur de la collectivité
-defineStep('un utilisateur avec les droits en {string}', addUserWithProfile);
+When('un utilisateur avec les droits en {string}', addUserWithProfile);
 function addUserWithProfile(niveau) {
   const {collectivite_id} = this.collectivite;
   addRandomUser(collectivite_id, niveau, `user_${niveau}`);
@@ -44,7 +44,7 @@ function addRandomUser(collectivite_id, niveau, alias) {
 }
 
 // connecte un utilisateur de la collectivité de test
-defineStep('je suis connecté avec les droits en {string}', loginWithProfile);
+When('je suis connecté avec les droits en {string}', loginWithProfile);
 function loginWithProfile(niveau) {
   return loginAs.call(this, `@user_${niveau}`);
 }
@@ -62,22 +62,16 @@ function login({email, password}) {
 }
 
 // ajoute un auditeur et le connecte
-defineStep(
-  "je suis connecté en tant qu'auditeur de la collectivité",
-  function () {
-    addAuditeur.call(this);
-    loginAs.call(this, '@auditeur');
-  }
-);
-defineStep(
-  "je me reconnecte en tant qu'auditeur de la collectivité",
-  function () {
-    logout();
-    waitForApp();
-    addAuditeur.call(this);
-    loginAs.call(this, '@auditeur');
-  }
-);
+When("je suis connecté en tant qu'auditeur de la collectivité", function () {
+  addAuditeur.call(this);
+  loginAs.call(this, '@auditeur');
+});
+When("je me reconnecte en tant qu'auditeur de la collectivité", function () {
+  logout();
+  waitForApp();
+  addAuditeur.call(this);
+  loginAs.call(this, '@auditeur');
+});
 function addAuditeur() {
   const {collectivite_id} = this.collectivite;
   const {id: demande_id} = this.demande_envoyee;
@@ -95,7 +89,7 @@ function setAuditeur(demande_id, user_id) {
     .as('audit_auditeur');
 }
 
-defineStep("l'audit est commencé", commencerAudit);
+When("l'audit est commencé", commencerAudit);
 function commencerAudit() {
   cy.get('@audit_auditeur').then(({audit_id}) => {
     cy.task('supabase_rpc', {
@@ -106,9 +100,9 @@ function commencerAudit() {
 }
 
 // rend la collectivité de test labellisable au niveau voulu
-defineStep("un score permettant d'obtenir la {int}ème étoile", fulfill);
-defineStep("le score permet d'obtenir la {int}ème étoile", fulfill);
-defineStep("le score permet d'obtenir la {int}ère étoile", fulfill);
+When("un score permettant d'obtenir la {int}ème étoile", fulfill);
+When("le score permet d'obtenir la {int}ème étoile", fulfill);
+When("le score permet d'obtenir la {int}ère étoile", fulfill);
 function fulfill(etoile) {
   cy.get('@collectivite').then(({collectivite_id}) =>
     cy.task('supabase_rpc', {
@@ -119,15 +113,15 @@ function fulfill(etoile) {
 }
 
 // envoi une demande d'audit
-defineStep(
+When(
   /je demande un audit de labellisation "(eci|cae)" pour la (1|2|3|4|5)è(?:r|m)e étoile/,
   envoyerDemande
 );
-defineStep(
+When(
   /avec un audit demandé pour la labellisation "(eci|cae)" (1|2|3|4|5)è(?:r|m)e étoile/,
   envoyerDemande
 );
-defineStep('avec un audit COT sans labellisation demandé', referentiel =>
+When('avec un audit COT sans labellisation demandé', referentiel =>
   envoyerDemande('cae', null, 'cot')
 );
 function envoyerDemande(referentiel, etoile, sujet = 'labellisation') {
@@ -167,7 +161,7 @@ function labellisationSubmitDemande(
     .as('demande_envoyee');
 }
 
-defineStep(
+When(
   /avec un audit en cours pour la labellisation "(eci|cae)" (1|2|3|4|5)è(?:r|m)e étoile/,
   function (referentiel, etoile) {
     envoyerDemande(referentiel, etoile).then(function () {
@@ -178,14 +172,8 @@ defineStep(
 );
 
 // visite une page de la collectivité
-defineStep(
-  'je suis sur la page {string} de la collectivité courante',
-  visitPage
-);
-defineStep(
-  'je retourne sur la page {string} de la collectivité courante',
-  visitPage
-);
+When('je suis sur la page {string} de la collectivité courante', visitPage);
+When('je retourne sur la page {string} de la collectivité courante', visitPage);
 function visitPage(page) {
   cy.get('@collectivite').then(({collectivite_id}) => {
     const {route, selector} = CollectivitePages[page];
@@ -194,7 +182,7 @@ function visitPage(page) {
   });
 }
 
-defineStep(
+When(
   /je visite l'onglet "([^"]*)" du référentiel "([^"]*)" de la collectivité courante/,
   function (tabName, referentiel) {
     const {collectivite_id} = this.collectivite;
@@ -204,7 +192,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   "je visite l'action {string} de la collectivité courante",
   function (action) {
     cy.get('@collectivite').then(({collectivite_id}) => {
@@ -217,7 +205,7 @@ defineStep(
   }
 );
 
-defineStep('avec comme réponses initiales :', function (dataTable) {
+When('avec comme réponses initiales :', function (dataTable) {
   const {collectivite_id} = this.collectivite;
 
   cy.wrap(dataTable.rows()).each(([question_id, reponse]) =>
@@ -245,7 +233,7 @@ const transformReponse = reponse => {
   return reponse;
 };
 
-defineStep(
+When(
   'je change la réponse à la question {string} depuis la thématique {string} en {string}',
   function (question_id, thematique, reponse) {
     const {collectivite_id} = this.collectivite;

--- a/e2e/cypress/integration/common/nav.js
+++ b/e2e/cypress/integration/common/nav.js
@@ -1,7 +1,7 @@
 /**
  * Steps dédiés à la navigation
  */
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 import {Views, CollectivitePages} from './views';
 
 export const navigateTo = view => {
@@ -11,15 +11,13 @@ export const navigateTo = view => {
 };
 
 // navigue sur une route sans recharger la page
-defineStep(/visite la vue(?:.*)? "(.*)"/, view => navigateTo(view));
+When(/visite la vue(?:.*)? "(.*)"/, view => navigateTo(view));
 
 // navigue sur une sous-route associée à un item de menu
-defineStep(/j'ouvre le dialogue "(.*)"/, menuItem =>
-  navigateToSubRoute(menuItem)
-);
+When(/j'ouvre le dialogue "(.*)"/, menuItem => navigateToSubRoute(menuItem));
 
 // navigue sur un référentiel
-defineStep(
+When(
   /visite le sous-axe "([^"]*)" du référentiel "([^"]*)" de la collectivité "(\d+)"/,
   (action, referentiel, collectiviteId) => {
     cy.visit(
@@ -30,7 +28,7 @@ defineStep(
 );
 
 // navigue sur un référentiel et un onglet
-defineStep(
+When(
   /je visite l'onglet "([^"]*)" de l'action "([^"]*)" du référentiel "([^"]*)" de la collectivité "([^"]*)"/,
   (tabName, action, referentiel, collectiviteId) => {
     cy.visit(
@@ -40,7 +38,7 @@ defineStep(
   }
 );
 
-defineStep(
+When(
   /je visite l'onglet "([^"]*)" du référentiel "([^"]*)" de la collectivité "([^"]*)"/,
   (tabName, referentiel, collectiviteId) => {
     cy.visit(
@@ -50,7 +48,7 @@ defineStep(
 );
 
 // navigue sur une page d'une collectivité
-defineStep(
+When(
   /je suis sur la page "([^"]*)" de la collectivité "(\d+)"/,
   (page, collectiviteId) => {
     const {route, selector} = CollectivitePages[page];
@@ -64,17 +62,17 @@ const isVisibleView = view => {
   const {selector} = Views[view];
   cy.get(selector).should('be.visible');
 };
-defineStep(/voi[rs] la vue(?: des)? "(.*)"/, isVisibleView);
-defineStep(/la page "([^"]*)" est visible/, isVisibleView);
+When(/voi[rs] la vue(?: des)? "(.*)"/, isVisibleView);
+When(/la page "([^"]*)" est visible/, isVisibleView);
 
 // vérifie qu'on est pas sur une route/vue
-defineStep(/ne vois (?:pas|plus) la vue(?: des)? "(.*)"/, view => {
+When(/ne vois (?:pas|plus) la vue(?: des)? "(.*)"/, view => {
   const {selector} = Views[view];
   cy.get(selector).should('not.exist');
 });
 
 // vérifie qu'une vue est masquée
-defineStep(/la vue(?: des)? "(.*)" est masquée/, view => {
+When(/la vue(?: des)? "(.*)" est masquée/, view => {
   const {selector} = Views[view];
   cy.get(selector).should('be.hidden');
 });

--- a/e2e/cypress/integration/common/steps.js
+++ b/e2e/cypress/integration/common/steps.js
@@ -1,5 +1,3 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
-
 /**
  * Définitions de "steps" communes à tous les tests
  */
@@ -7,6 +5,7 @@ import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
 import {Selectors} from './selectors';
 import {Expectations} from './expectations';
 import {waitForApp, logout} from './shared';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
 function testReset(retry = 0) {
   // réinitialise les données fake
@@ -40,7 +39,7 @@ beforeEach(function () {
   });
 });
 
-defineStep("j'ouvre le site", () => {
+When("j'ouvre le site", () => {
   cy.get('[data-test=home]').should('be.visible');
 });
 
@@ -54,7 +53,7 @@ const genUser = userName => {
 };
 
 const SignInPage = Selectors['formulaire de connexion'];
-defineStep(/je suis connecté en tant que "([^"]*)"/, login);
+When(/je suis connecté en tant que "([^"]*)"/, login);
 function login(userName) {
   const u = genUser(userName);
   cy.get('@auth').then(auth => auth.connect(u));
@@ -62,13 +61,13 @@ function login(userName) {
   cy.get('[data-test=connectedMenu]').should('be.visible');
 }
 
-defineStep('je me reconnecte en tant que {string}', function (userName) {
+When('je me reconnecte en tant que {string}', function (userName) {
   logout();
   waitForApp();
   login(userName);
 });
 
-defineStep(
+When(
   "je suis connecté en tant qu'utilisateur de la collectivité {int} n'ayant pas encore accepté les CGU",
   function (collectivite_id) {
     return cy
@@ -84,30 +83,30 @@ defineStep(
   }
 );
 
-defineStep('les discussions sont réinitialisées', () => {
+When('les discussions sont réinitialisées', () => {
   cy.task('supabase_rpc', {name: 'test_reset_discussion_et_commentaires'});
 });
 
-defineStep('les droits utilisateur sont réinitialisés', () => {
+When('les droits utilisateur sont réinitialisés', () => {
   cy.task('supabase_rpc', {name: 'test_reset_droits'});
 });
 
-defineStep(/l'utilisateur "([^"]*)" est supprimé/, email => {
+When(/l'utilisateur "([^"]*)" est supprimé/, email => {
   cy.task('supabase_rpc', {
     name: 'test_remove_user',
     params: {email: email},
   });
 });
 
-defineStep('les informations des membres sont réinitialisées', () => {
+When('les informations des membres sont réinitialisées', () => {
   cy.task('supabase_rpc', {name: 'test_reset_membres'});
 });
 
-defineStep('je me déconnecte', logout);
+When('je me déconnecte', logout);
 
 // Met en pause le déroulement d'un scénario.
 // Associé avec le tag @focus cela permet de debugger facilement les tests.
-defineStep('pause', () => cy.pause());
+When('pause', () => cy.pause());
 
 // utilitaire pour vérifier quelques attentes d'affichage génériques à partir d'une table de correspondances
 export const checkExpectation = (selector, expectation, value) => {
@@ -137,13 +136,13 @@ export const resolveSelector = (context, elem) => {
 // on utilise "function" (plutôt qu'une arrow function) pour que "this" donne
 // accès au contexte de manière synchrone
 // Ref: https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Sharing-Context
-defineStep(/la page vérifie les conditions suivantes/, function (dataTable) {
+When(/la page vérifie les conditions suivantes/, function (dataTable) {
   const rows = dataTable.rows();
   cy.wrap(rows).each(function ([elem, expectation, value]) {
     checkExpectation(resolveSelector(this, elem).selector, expectation, value);
   });
 });
-defineStep(
+When(
   /le "([^"]*)" vérifie les conditions suivantes/,
   function (parentName, dataTable) {
     const parent = resolveSelector(this, parentName);
@@ -155,21 +154,21 @@ defineStep(
     });
   }
 );
-defineStep(/le "([^"]*)" vérifie la condition "([^"]*)"/, verifyExpectation);
-defineStep(/^le "([^"]*)" est ([^"]*)$/, verifyExpectation);
-defineStep(/"([^"]*)" contient "([^"]*)"$/, function (elem, value) {
+When(/le "([^"]*)" vérifie la condition "([^"]*)"/, verifyExpectation);
+When(/^le "([^"]*)" est ([^"]*)$/, verifyExpectation);
+When(/"([^"]*)" contient "([^"]*)"$/, function (elem, value) {
   checkExpectation(resolveSelector(this, elem).selector, 'contient', value);
 });
-defineStep(/^la case "([^"]*)" est ([^"]*)$/, verifyExpectation);
-defineStep('le bouton {string} est {word}', verifyExpectation);
-defineStep(
+When(/^la case "([^"]*)" est ([^"]*)$/, verifyExpectation);
+When('le bouton {string} est {word}', verifyExpectation);
+When(
   'le bouton {string} est {word} et {word}',
   function (elem, expectation1, expectation2) {
     checkExpectation(resolveSelector(this, elem).selector, expectation1);
     checkExpectation(resolveSelector(this, elem).selector, expectation2);
   }
 );
-defineStep(
+When(
   /^le bouton "([^"]*)" du "([^"]*)" est ([^"]*)$/,
   childrenVerifyExpectation
 );
@@ -186,27 +185,21 @@ function handleClickOnElement(subElement, elem) {
   const parent = resolveSelector(this, elem);
   cy.get(parent.selector).find(parent.children[subElement]).click();
 }
-defineStep(
-  /je clique sur le bouton "([^"]*)" du "([^"]*)"/,
-  handleClickOnElement
-);
-defineStep(
-  /je clique sur l'onglet "([^"]*)" du "([^"]*)"/,
-  handleClickOnElement
-);
-defineStep(
+When(/je clique sur le bouton "([^"]*)" du "([^"]*)"/, handleClickOnElement);
+When(/je clique sur l'onglet "([^"]*)" du "([^"]*)"/, handleClickOnElement);
+When(
   /je clique sur le bouton "([^"]*)" de la page "([^"]*)"/,
   handleClickOnElement
 );
-defineStep(/^je clique sur le bouton "([^"]*)"$/, function (btnName) {
+When(/^je clique sur le bouton "([^"]*)"$/, function (btnName) {
   cy.get(resolveSelector(this, btnName).selector).click();
 });
-defineStep(/^je clique sur le bouton radio "([^"]*)"$/, function (btnName) {
+When(/^je clique sur le bouton radio "([^"]*)"$/, function (btnName) {
   // le bouton radio natif est masqué par la version stylé alors on clique sur le libellé qui le suit immédiatement
   cy.get(resolveSelector(this, btnName).selector + '+label').click();
 });
 
-defineStep(/^je clique sur la case "([^"]*)"$/, function (checkbox) {
+When(/^je clique sur la case "([^"]*)"$/, function (checkbox) {
   cy.get(resolveSelector(this, checkbox).selector)
     .parent()
     .should('have.class', 'fr-checkbox-group')
@@ -222,18 +215,15 @@ function fillFormWithValues(elem, dataTable) {
     });
   });
 }
-defineStep(
-  /je remplis le "([^"]*)" avec les valeurs suivantes/,
-  fillFormWithValues
-);
+When(/je remplis le "([^"]*)" avec les valeurs suivantes/, fillFormWithValues);
 
-defineStep(/l'appel à "([^"]*)" va répondre "([^"]*)"/, function (name, reply) {
+When(/l'appel à "([^"]*)" va répondre "([^"]*)"/, function (name, reply) {
   const r = this.LocalMocks?.[name]?.[reply];
   assert(r, 'mock non trouvé');
   cy.intercept(...r).as(name);
 });
 
-defineStep(
+When(
   "je sélectionne l'option {string} dans la liste déroulante {string}",
   selectDropdownValue
 );
@@ -244,27 +234,25 @@ function selectDropdownValue(value, dropdown) {
   cy.get(`[data-test="${value}"]`).should('be.visible').click();
 }
 
-defineStep('je saisi la valeur {string} dans le champ {string}', fillInput);
+When('je saisi la valeur {string} dans le champ {string}', fillInput);
 function fillInput(value, input) {
   cy.get(resolveSelector(this, input).selector).type(
     '{selectall}{backspace}' + value
   );
 }
 
-defineStep('je clique en dehors de la boîte de dialogue', () =>
+When('je clique en dehors de la boîte de dialogue', () =>
   cy.get('body').click(10, 10)
 );
 
-defineStep('je valide le formulaire', () =>
-  cy.get('button[type=submit]').click()
-);
+When('je valide le formulaire', () => cy.get('button[type=submit]').click());
 
 const transateTypes = {
   succès: 'success',
   information: 'info',
   erreur: 'error',
 };
-defineStep(
+When(
   /une alerte de "([^"]*)" est affichée et contient "([^"]*)"/,
   (type, message) => {
     cy.get(`.fr-alert--${transateTypes[type]}`).should('be.visible');
@@ -272,7 +260,7 @@ defineStep(
   }
 );
 
-defineStep('je recharge la page', () => {
+When('je recharge la page', () => {
   cy.reload();
 });
 
@@ -280,7 +268,7 @@ defineStep('je recharge la page', () => {
 // pour valider la modification des informations des membres ou
 // les informations de l'utilisateur courant
 const tableauMembresSelector = Selectors['tableau des membres'];
-defineStep(
+When(
   'le tableau des membres doit contenir les informations suivantes',
   dataTable => {
     cy.get(tableauMembresSelector.selector).within(() => {
@@ -314,18 +302,18 @@ defineStep(
   }
 );
 
-defineStep(/je clique sur l'onglet "([^"]+)"$/, tabName => {
+When(/je clique sur l'onglet "([^"]+)"$/, tabName => {
   cy.get('.fr-tabs__tab').contains(tabName).click();
 });
 
-defineStep(/je vois (\d+) onglets?/, count =>
+When(/je vois (\d+) onglets?/, count =>
   cy.get('.fr-tabs__tab').should('have.length', count)
 );
-defineStep('je ne vois aucun onglet', () =>
+When('je ne vois aucun onglet', () =>
   cy.get('.fr-tabs__tab').should('have.length', 0)
 );
 
-defineStep(/l'onglet "([^"]+)" est sélectionné/, tabName =>
+When(/l'onglet "([^"]+)" est sélectionné/, tabName =>
   cy
     .get('.fr-tabs__tab')
     .contains(tabName)

--- a/e2e/cypress/integration/common/suiviAction.js
+++ b/e2e/cypress/integration/common/suiviAction.js
@@ -1,13 +1,13 @@
-import {defineStep} from '@badeball/cypress-cucumber-preprocessor';
+import {When} from '@badeball/cypress-cucumber-preprocessor';
 
-defineStep("je déplie la sous-action {string} du suivi de l'action", action =>
+When("je déplie la sous-action {string} du suivi de l'action", action =>
   getSousAction(action).within(() => {
     // clic pour déplier le panneau
     cy.root().click();
   })
 );
 
-defineStep('je déplie le panneau Tâches de la sous-action {string}', action =>
+When('je déplie le panneau Tâches de la sous-action {string}', action =>
   getTachesPanel(action).within(() => {
     // click pour déplier le panneau
     cy.root().click();


### PR DESCRIPTION
Permet de
- passer de Gherkin aux steps JS
- créer les sélecteurs à partir depuis la webview de l'IDE

<img width="1918" alt="image" src="https://github.com/betagouv/territoires-en-transitions/assets/1872471/cb8e821b-a985-4df2-bf10-047597093391">
