### PR TITLE
Plan action synthese interaction graphique

### DIFF
--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -223,14 +223,6 @@ export interface Database {
       }
       audit_evaluation_payload: {
         Args: {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> a342e9c9a (update types)
-=======
->>>>>>> 40ccc466c (Mise à jours des types)
           audit: unknown
           pre_audit: boolean
         }
@@ -244,38 +236,6 @@ export interface Database {
         }
         Returns: Json
       }
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
-          audit: unknown;
-        };
-        Returns: Record<string, unknown>;
-      };
-      audit_personnalisation_payload: {
-        Args: {
-          audit_id: number;
-          scores_table: string;
-        };
-        Returns: Json;
-      };
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-=======
-          audit: unknown
-        }
-        Returns: Record<string, unknown>
-      }
-      audit_personnalisation_payload: {
-        Args: {
-          audit_id: number
-          scores_table: string
-        }
-        Returns: Json
-      }
->>>>>>> d8b0e10a9 (update types)
->>>>>>> a342e9c9a (update types)
-=======
->>>>>>> 40ccc466c (Mise à jours des types)
       critere_action: {
         Args: {
           collectivite_id: number
@@ -344,14 +304,6 @@ export interface Database {
       }
       evaluate_audit_statuts: {
         Args: {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> a342e9c9a (update types)
-=======
->>>>>>> 40ccc466c (Mise à jours des types)
           audit_id: number
           pre_audit: boolean
           scores_table: string
@@ -373,40 +325,6 @@ export interface Database {
         }
         Returns: Json
       }
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
-          audit_id: number;
-          scores_table: string;
-        };
-        Returns: number;
-      };
-=======
->>>>>>> d8b0e10a9 (update types)
-      pre_audit_reponses: {
-        Args: {
-          audit: unknown
-        }
-        Returns: Json
-      }
-      pre_audit_service_statuts: {
-        Args: {
-<<<<<<< HEAD
-          audit_id: number;
-        };
-        Returns: Json;
-      };
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-=======
-          audit_id: number
-        }
-        Returns: Json
-      }
->>>>>>> d8b0e10a9 (update types)
->>>>>>> a342e9c9a (update types)
-=======
->>>>>>> 40ccc466c (Mise à jours des types)
       referentiel_score: {
         Args: {
           collectivite_id: number
@@ -1340,505 +1258,6 @@ export interface Database {
           nom: string
         }
         Update: {
-<<<<<<< HEAD
-          collectivite_id?: number;
-          id?: number;
-          nom?: string;
-        };
-      };
-      indicateur_action: {
-        Row: {
-          action_id: string;
-          indicateur_id: string;
-          modified_at: string;
-        };
-        Insert: {
-          action_id: string;
-          indicateur_id: string;
-          modified_at?: string;
-        };
-        Update: {
-          action_id?: string;
-          indicateur_id?: string;
-          modified_at?: string;
-        };
-      };
-      indicateur_commentaire: {
-        Row: {
-          collectivite_id: number;
-          commentaire: string;
-          indicateur_id: string;
-          modified_at: string;
-          modified_by: string;
-        };
-        Insert: {
-          collectivite_id: number;
-          commentaire: string;
-          indicateur_id: string;
-          modified_at?: string;
-          modified_by?: string;
-        };
-        Update: {
-          collectivite_id?: number;
-          commentaire?: string;
-          indicateur_id?: string;
-          modified_at?: string;
-          modified_by?: string;
-        };
-      };
-      indicateur_definition: {
-        Row: {
-          description: string;
-          id: string;
-          identifiant: string;
-          indicateur_group: Database["public"]["Enums"]["indicateur_group"];
-          modified_at: string;
-          nom: string;
-          obligation_eci: boolean;
-          parent: number | null;
-          unite: string;
-          valeur_indicateur: string | null;
-        };
-        Insert: {
-          description: string;
-          id: string;
-          identifiant: string;
-          indicateur_group: Database["public"]["Enums"]["indicateur_group"];
-          modified_at?: string;
-          nom: string;
-          obligation_eci: boolean;
-          parent?: number | null;
-          unite: string;
-          valeur_indicateur?: string | null;
-        };
-        Update: {
-          description?: string;
-          id?: string;
-          identifiant?: string;
-          indicateur_group?: Database["public"]["Enums"]["indicateur_group"];
-          modified_at?: string;
-          nom?: string;
-          obligation_eci?: boolean;
-          parent?: number | null;
-          unite?: string;
-          valeur_indicateur?: string | null;
-        };
-      };
-      indicateur_objectif: {
-        Row: {
-          annee: number;
-          collectivite_id: number;
-          indicateur_id: string;
-          modified_at: string;
-          valeur: number | null;
-        };
-        Insert: {
-          annee: number;
-          collectivite_id: number;
-          indicateur_id: string;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-        Update: {
-          annee?: number;
-          collectivite_id?: number;
-          indicateur_id?: string;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-      };
-      indicateur_parent: {
-        Row: {
-          id: number;
-          nom: string;
-          numero: string;
-        };
-        Insert: {
-          id?: number;
-          nom: string;
-          numero: string;
-        };
-        Update: {
-          id?: number;
-          nom?: string;
-          numero?: string;
-        };
-      };
-      indicateur_personnalise_definition: {
-        Row: {
-          collectivite_id: number | null;
-          commentaire: string;
-          description: string;
-          id: number;
-          modified_at: string;
-          modified_by: string;
-          titre: string;
-          unite: string;
-        };
-        Insert: {
-          collectivite_id?: number | null;
-          commentaire: string;
-          description: string;
-          id?: number;
-          modified_at?: string;
-          modified_by?: string;
-          titre: string;
-          unite: string;
-        };
-        Update: {
-          collectivite_id?: number | null;
-          commentaire?: string;
-          description?: string;
-          id?: number;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          unite?: string;
-        };
-      };
-      indicateur_personnalise_objectif: {
-        Row: {
-          annee: number;
-          collectivite_id: number;
-          indicateur_id: number;
-          modified_at: string;
-          valeur: number | null;
-        };
-        Insert: {
-          annee: number;
-          collectivite_id: number;
-          indicateur_id: number;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-        Update: {
-          annee?: number;
-          collectivite_id?: number;
-          indicateur_id?: number;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-      };
-      indicateur_personnalise_resultat: {
-        Row: {
-          annee: number;
-          collectivite_id: number;
-          indicateur_id: number;
-          modified_at: string;
-          valeur: number | null;
-        };
-        Insert: {
-          annee: number;
-          collectivite_id: number;
-          indicateur_id: number;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-        Update: {
-          annee?: number;
-          collectivite_id?: number;
-          indicateur_id?: number;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-      };
-      indicateur_resultat: {
-        Row: {
-          annee: number;
-          collectivite_id: number;
-          indicateur_id: string;
-          modified_at: string;
-          valeur: number | null;
-        };
-        Insert: {
-          annee: number;
-          collectivite_id: number;
-          indicateur_id: string;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-        Update: {
-          annee?: number;
-          collectivite_id?: number;
-          indicateur_id?: string;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-      };
-      indicateur_terristory_json: {
-        Row: {
-          created_at: string;
-          indicateurs: Json;
-        };
-        Insert: {
-          created_at?: string;
-          indicateurs: Json;
-        };
-        Update: {
-          created_at?: string;
-          indicateurs?: Json;
-        };
-      };
-      indicateurs_json: {
-        Row: {
-          created_at: string;
-          indicateurs: Json;
-        };
-        Insert: {
-          created_at?: string;
-          indicateurs: Json;
-        };
-        Update: {
-          created_at?: string;
-          indicateurs?: Json;
-        };
-      };
-      justification: {
-        Row: {
-          collectivite_id: number;
-          modified_at: string;
-          modified_by: string;
-          question_id: string;
-          texte: string;
-        };
-        Insert: {
-          collectivite_id: number;
-          modified_at: string;
-          modified_by?: string;
-          question_id: string;
-          texte: string;
-        };
-        Update: {
-          collectivite_id?: number;
-          modified_at?: string;
-          modified_by?: string;
-          question_id?: string;
-          texte?: string;
-        };
-      };
-      labellisation: {
-        Row: {
-          annee: number | null;
-          collectivite_id: number | null;
-          etoiles: number;
-          id: number;
-          obtenue_le: string;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          score_programme: number | null;
-          score_realise: number | null;
-        };
-        Insert: {
-          annee?: number | null;
-          collectivite_id?: number | null;
-          etoiles: number;
-          id?: number;
-          obtenue_le: string;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          score_programme?: number | null;
-          score_realise?: number | null;
-        };
-        Update: {
-          annee?: number | null;
-          collectivite_id?: number | null;
-          etoiles?: number;
-          id?: number;
-          obtenue_le?: string;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-          score_programme?: number | null;
-          score_realise?: number | null;
-        };
-      };
-      labellisation_action_critere: {
-        Row: {
-          action_id: string;
-          etoile: Database["labellisation"]["Enums"]["etoile"];
-          formulation: string;
-          min_programme_percentage: number | null;
-          min_programme_score: number | null;
-          min_realise_percentage: number | null;
-          min_realise_score: number | null;
-          prio: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Insert: {
-          action_id: string;
-          etoile: Database["labellisation"]["Enums"]["etoile"];
-          formulation: string;
-          min_programme_percentage?: number | null;
-          min_programme_score?: number | null;
-          min_realise_percentage?: number | null;
-          min_realise_score?: number | null;
-          prio: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Update: {
-          action_id?: string;
-          etoile?: Database["labellisation"]["Enums"]["etoile"];
-          formulation?: string;
-          min_programme_percentage?: number | null;
-          min_programme_score?: number | null;
-          min_realise_percentage?: number | null;
-          min_realise_score?: number | null;
-          prio?: number;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-        };
-      };
-      labellisation_calendrier: {
-        Row: {
-          information: string;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Insert: {
-          information: string;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Update: {
-          information?: string;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-        };
-      };
-      labellisation_fichier_critere: {
-        Row: {
-          description: string;
-          etoile: Database["labellisation"]["Enums"]["etoile"];
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Insert: {
-          description: string;
-          etoile: Database["labellisation"]["Enums"]["etoile"];
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Update: {
-          description?: string;
-          etoile?: Database["labellisation"]["Enums"]["etoile"];
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-        };
-      };
-      maintenance: {
-        Row: {
-          begins_at: string;
-          ends_at: string;
-          id: number;
-        };
-        Insert: {
-          begins_at: string;
-          ends_at: string;
-          id?: number;
-        };
-        Update: {
-          begins_at?: string;
-          ends_at?: string;
-          id?: number;
-        };
-      };
-      partenaire_tag: {
-        Row: {
-          collectivite_id: number;
-          id: number;
-          nom: string;
-        };
-        Insert: {
-          collectivite_id: number;
-          id?: number;
-          nom: string;
-        };
-        Update: {
-          collectivite_id?: number;
-          id?: number;
-          nom?: string;
-        };
-      };
-      personnalisation: {
-        Row: {
-          action_id: string;
-          description: string;
-          titre: string;
-        };
-        Insert: {
-          action_id: string;
-          description: string;
-          titre: string;
-        };
-        Update: {
-          action_id?: string;
-          description?: string;
-          titre?: string;
-        };
-      };
-      personnalisation_consequence: {
-        Row: {
-          collectivite_id: number;
-          consequences: Json;
-          modified_at: string;
-          payload_timestamp: string | null;
-        };
-        Insert: {
-          collectivite_id: number;
-          consequences: Json;
-          modified_at?: string;
-          payload_timestamp?: string | null;
-        };
-        Update: {
-          collectivite_id?: number;
-          consequences?: Json;
-          modified_at?: string;
-          payload_timestamp?: string | null;
-        };
-      };
-      personnalisation_regle: {
-        Row: {
-          action_id: string;
-          description: string;
-          formule: string;
-          modified_at: string;
-          type: Database["public"]["Enums"]["regle_type"];
-        };
-        Insert: {
-          action_id: string;
-          description: string;
-          formule: string;
-          modified_at?: string;
-          type: Database["public"]["Enums"]["regle_type"];
-        };
-        Update: {
-          action_id?: string;
-          description?: string;
-          formule?: string;
-          modified_at?: string;
-          type?: Database["public"]["Enums"]["regle_type"];
-        };
-      };
-      personnalisations_json: {
-        Row: {
-          created_at: string;
-          questions: Json;
-          regles: Json;
-        };
-        Insert: {
-          created_at?: string;
-          questions: Json;
-          regles: Json;
-        };
-        Update: {
-          created_at?: string;
-          questions?: Json;
-          regles?: Json;
-        };
-      };
-      personne_tag: {
-        Row: {
-          collectivite_id: number;
-          id: number;
-          nom: string;
-        };
-        Insert: {
-          collectivite_id: number;
-          id?: number;
-          nom: string;
-        };
-        Update: {
-=======
->>>>>>> a342e9c9a (update types)
           collectivite_id?: number
           id?: number
           nom?: string
@@ -2366,21 +1785,6 @@ export interface Database {
           scores?: Json
         }
       }
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
-          collectivite_id?: number;
-          id?: number;
-          nom?: string;
-        };
-      };
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-=======
->>>>>>> d8b0e10a9 (update types)
->>>>>>> a342e9c9a (update types)
-=======
->>>>>>> 40ccc466c (Mise à jours des types)
       pre_audit_scores: {
         Row: {
           audit_id: number
@@ -3438,16 +2842,6 @@ export interface Database {
           region_code?: string | null
         }
         Update: {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d8b0e10a9 (update types)
->>>>>>> a342e9c9a (update types)
-=======
->>>>>>> 40ccc466c (Mise à jours des types)
           code?: string | null
           libelle?: string | null
           region_code?: string | null
@@ -3469,21 +2863,6 @@ export interface Database {
           signataire: string | null
         }
       }
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
-          code?: string | null;
-          libelle?: string | null;
-          region_code?: string | null;
-        };
-      };
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-=======
->>>>>>> d8b0e10a9 (update types)
->>>>>>> a342e9c9a (update types)
-=======
->>>>>>> 40ccc466c (Mise à jours des types)
       fiche_action_personne_pilote: {
         Row: {
           collectivite_id: number | null
@@ -7090,36 +6469,6 @@ export interface Database {
       time_bucket:
         | {
             Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -7201,6 +6550,36 @@ export interface Database {
             Args: {
               bucket_width: number
               ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
             }
             Returns: number
           }
@@ -7509,10 +6888,6 @@ export interface Database {
         | "reglementaire"
         | "labellisation"
         | "audit"
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> a342e9c9a (update types)
         | "rapport"
       question_type: "choix" | "binaire" | "proportion"
       referentiel: "eci" | "cae"
@@ -7520,7 +6895,6 @@ export interface Database {
       role_name: "agent" | "referent" | "conseiller" | "auditeur" | "aucun"
       thematique_completude: "complete" | "a_completer"
       type_collectivite: "EPCI" | "commune" | "syndicat"
-<<<<<<< HEAD
       usage_action:
         | "clic"
         | "vue"
@@ -7528,19 +6902,6 @@ export interface Database {
         | "saisie"
         | "selection"
         | "agrandissement"
-=======
-        | "rapport";
-      question_type: "choix" | "binaire" | "proportion";
-      referentiel: "eci" | "cae";
-      regle_type: "score" | "desactivation" | "reduction";
-      role_name: "agent" | "referent" | "conseiller" | "auditeur" | "aucun";
-      thematique_completude: "complete" | "a_completer";
-      type_collectivite: "EPCI" | "commune" | "syndicat";
-      usage_action: "clic" | "vue" | "telechargement" | "saisie" | "selection";
->>>>>>> d1c38935a (MAJ database.types.ts)
-=======
-      usage_action: "clic" | "vue" | "telechargement" | "saisie" | "selection"
->>>>>>> a342e9c9a (update types)
       usage_fonction:
         | "aide"
         | "preuve"
@@ -7562,19 +6923,11 @@ export interface Database {
         | "modele_import"
         | "cta_plan"
         | "cta_indicateur"
-<<<<<<< HEAD
-<<<<<<< HEAD
         | "cta_labellisation"
         | "cta_plan_creation"
         | "cta_plan_maj"
         | "cta_edl_commencer"
         | "cta_edl_personnaliser"
-=======
-        | "cta_labellisation";
->>>>>>> d1c38935a (MAJ database.types.ts)
-=======
-        | "cta_labellisation"
->>>>>>> a342e9c9a (update types)
       visite_onglet:
         | "progression"
         | "priorisation"

--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -4,229 +4,230 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json }
-  | Json[];
+  | Json[]
 
 export interface Database {
   labellisation: {
     Tables: {
       action_audit_state: {
         Row: {
-          action_id: string;
-          audit_id: number | null;
-          avis: string;
-          collectivite_id: number;
-          id: number;
-          modified_at: string;
-          modified_by: string;
-          ordre_du_jour: boolean;
-          statut: Database["public"]["Enums"]["audit_statut"];
-        };
+          action_id: string
+          audit_id: number | null
+          avis: string
+          collectivite_id: number
+          id: number
+          modified_at: string
+          modified_by: string
+          ordre_du_jour: boolean
+          statut: Database["public"]["Enums"]["audit_statut"]
+        }
         Insert: {
-          action_id: string;
-          audit_id?: number | null;
-          avis?: string;
-          collectivite_id: number;
-          id?: number;
-          modified_at?: string;
-          modified_by?: string;
-          ordre_du_jour?: boolean;
-          statut?: Database["public"]["Enums"]["audit_statut"];
-        };
+          action_id: string
+          audit_id?: number | null
+          avis?: string
+          collectivite_id: number
+          id?: number
+          modified_at?: string
+          modified_by?: string
+          ordre_du_jour?: boolean
+          statut?: Database["public"]["Enums"]["audit_statut"]
+        }
         Update: {
-          action_id?: string;
-          audit_id?: number | null;
-          avis?: string;
-          collectivite_id?: number;
-          id?: number;
-          modified_at?: string;
-          modified_by?: string;
-          ordre_du_jour?: boolean;
-          statut?: Database["public"]["Enums"]["audit_statut"];
-        };
-      };
+          action_id?: string
+          audit_id?: number | null
+          avis?: string
+          collectivite_id?: number
+          id?: number
+          modified_at?: string
+          modified_by?: string
+          ordre_du_jour?: boolean
+          statut?: Database["public"]["Enums"]["audit_statut"]
+        }
+      }
       audit: {
         Row: {
-          collectivite_id: number;
-          date_debut: string | null;
-          date_fin: string | null;
-          demande_id: number | null;
-          id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          valide: boolean;
-        };
+          collectivite_id: number
+          date_debut: string | null
+          date_fin: string | null
+          demande_id: number | null
+          id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          valide: boolean
+        }
         Insert: {
-          collectivite_id: number;
-          date_debut?: string | null;
-          date_fin?: string | null;
-          demande_id?: number | null;
-          id?: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          valide?: boolean;
-        };
+          collectivite_id: number
+          date_debut?: string | null
+          date_fin?: string | null
+          demande_id?: number | null
+          id?: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          valide?: boolean
+        }
         Update: {
-          collectivite_id?: number;
-          date_debut?: string | null;
-          date_fin?: string | null;
-          demande_id?: number | null;
-          id?: number;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-          valide?: boolean;
-        };
-      };
+          collectivite_id?: number
+          date_debut?: string | null
+          date_fin?: string | null
+          demande_id?: number | null
+          id?: number
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+          valide?: boolean
+        }
+      }
       bibliotheque_fichier: {
         Row: {
-          collectivite_id: number | null;
-          filename: string | null;
-          hash: string | null;
-          id: number;
-        };
+          collectivite_id: number | null
+          filename: string | null
+          hash: string | null
+          id: number
+        }
         Insert: {
-          collectivite_id?: number | null;
-          filename?: string | null;
-          hash?: string | null;
-          id?: number;
-        };
+          collectivite_id?: number | null
+          filename?: string | null
+          hash?: string | null
+          id?: number
+        }
         Update: {
-          collectivite_id?: number | null;
-          filename?: string | null;
-          hash?: string | null;
-          id?: number;
-        };
-      };
+          collectivite_id?: number | null
+          filename?: string | null
+          hash?: string | null
+          id?: number
+        }
+      }
       demande: {
         Row: {
-          collectivite_id: number;
-          date: string;
-          demandeur: string | null;
-          en_cours: boolean;
-          envoyee_le: string | null;
-          etoiles: Database["labellisation"]["Enums"]["etoile"] | null;
-          id: number;
-          modified_at: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"];
-        };
+          collectivite_id: number
+          date: string
+          demandeur: string | null
+          en_cours: boolean
+          envoyee_le: string | null
+          etoiles: Database["labellisation"]["Enums"]["etoile"] | null
+          id: number
+          modified_at: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"]
+        }
         Insert: {
-          collectivite_id: number;
-          date?: string;
-          demandeur?: string | null;
-          en_cours?: boolean;
-          envoyee_le?: string | null;
-          etoiles?: Database["labellisation"]["Enums"]["etoile"] | null;
-          id?: number;
-          modified_at?: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          sujet?: Database["labellisation"]["Enums"]["sujet_demande"];
-        };
+          collectivite_id: number
+          date?: string
+          demandeur?: string | null
+          en_cours?: boolean
+          envoyee_le?: string | null
+          etoiles?: Database["labellisation"]["Enums"]["etoile"] | null
+          id?: number
+          modified_at?: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          sujet?: Database["labellisation"]["Enums"]["sujet_demande"]
+        }
         Update: {
-          collectivite_id?: number;
-          date?: string;
-          demandeur?: string | null;
-          en_cours?: boolean;
-          envoyee_le?: string | null;
-          etoiles?: Database["labellisation"]["Enums"]["etoile"] | null;
-          id?: number;
-          modified_at?: string | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-          sujet?: Database["labellisation"]["Enums"]["sujet_demande"];
-        };
-      };
+          collectivite_id?: number
+          date?: string
+          demandeur?: string | null
+          en_cours?: boolean
+          envoyee_le?: string | null
+          etoiles?: Database["labellisation"]["Enums"]["etoile"] | null
+          id?: number
+          modified_at?: string | null
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+          sujet?: Database["labellisation"]["Enums"]["sujet_demande"]
+        }
+      }
       etoile_meta: {
         Row: {
-          etoile: Database["labellisation"]["Enums"]["etoile"];
-          long_label: string;
-          min_realise_percentage: number;
-          min_realise_score: number | null;
-          prochaine_etoile: Database["labellisation"]["Enums"]["etoile"] | null;
-          short_label: string;
-        };
+          etoile: Database["labellisation"]["Enums"]["etoile"]
+          long_label: string
+          min_realise_percentage: number
+          min_realise_score: number | null
+          prochaine_etoile: Database["labellisation"]["Enums"]["etoile"] | null
+          short_label: string
+        }
         Insert: {
-          etoile: Database["labellisation"]["Enums"]["etoile"];
-          long_label: string;
-          min_realise_percentage: number;
-          min_realise_score?: number | null;
-          prochaine_etoile?:
-            | Database["labellisation"]["Enums"]["etoile"]
-            | null;
-          short_label: string;
-        };
+          etoile: Database["labellisation"]["Enums"]["etoile"]
+          long_label: string
+          min_realise_percentage: number
+          min_realise_score?: number | null
+          prochaine_etoile?: Database["labellisation"]["Enums"]["etoile"] | null
+          short_label: string
+        }
         Update: {
-          etoile?: Database["labellisation"]["Enums"]["etoile"];
-          long_label?: string;
-          min_realise_percentage?: number;
-          min_realise_score?: number | null;
-          prochaine_etoile?:
-            | Database["labellisation"]["Enums"]["etoile"]
-            | null;
-          short_label?: string;
-        };
-      };
+          etoile?: Database["labellisation"]["Enums"]["etoile"]
+          long_label?: string
+          min_realise_percentage?: number
+          min_realise_score?: number | null
+          prochaine_etoile?: Database["labellisation"]["Enums"]["etoile"] | null
+          short_label?: string
+        }
+      }
       preuve_base: {
         Row: {
-          collectivite_id: number;
-          commentaire: string;
-          fichier_id: number | null;
-          lien: Json | null;
-          modified_at: string;
-          modified_by: string;
-          titre: string;
-          url: string | null;
-        };
+          collectivite_id: number
+          commentaire: string
+          fichier_id: number | null
+          lien: Json | null
+          modified_at: string
+          modified_by: string
+          titre: string
+          url: string | null
+        }
         Insert: {
-          collectivite_id: number;
-          commentaire?: string;
-          fichier_id?: number | null;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
+          collectivite_id: number
+          commentaire?: string
+          fichier_id?: number | null
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
         Update: {
-          collectivite_id?: number;
-          commentaire?: string;
-          fichier_id?: number | null;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-      };
-    };
+          collectivite_id?: number
+          commentaire?: string
+          fichier_id?: number | null
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+      }
+    }
     Views: {
       action_snippet: {
         Row: {
-          action_id: string | null;
-          collectivite_id: number | null;
-          snippet: Json | null;
-        };
-      };
+          action_id: string | null
+          collectivite_id: number | null
+          snippet: Json | null
+        }
+      }
       bibliotheque_fichier_snippet: {
         Row: {
-          id: number | null;
-          snippet: Json | null;
-        };
-      };
-    };
+          id: number | null
+          snippet: Json | null
+        }
+      }
+    }
     Functions: {
       active_audit: {
         Args: {
-          collectivite_id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
+          collectivite_id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
         Returns: {
-          collectivite_id: number;
-          date_debut: string | null;
-          date_fin: string | null;
-          demande_id: number | null;
-          id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          valide: boolean;
-        };
-      };
+          collectivite_id: number
+          date_debut: string | null
+          date_fin: string | null
+          demande_id: number | null
+          id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          valide: boolean
+        }
+      }
       audit_evaluation_payload: {
         Args: {
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+>>>>>>> a342e9c9a (update types)
           audit: unknown
           pre_audit: boolean
         }
@@ -240,80 +241,118 @@ export interface Database {
         }
         Returns: Json
       }
-      critere_action: {
-        Args: {
-          collectivite_id: number;
+<<<<<<< HEAD
+=======
+=======
+          audit: unknown;
         };
-        Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          etoiles: Database["labellisation"]["Enums"]["etoile"];
-          action_id: unknown;
-          formulation: string;
-          score_realise: number;
-          min_score_realise: number;
-          score_programme: number;
-          min_score_programme: number;
-          atteint: boolean;
-          prio: number;
-        }[];
+        Returns: Record<string, unknown>;
       };
-      critere_fichier: {
+      audit_personnalisation_payload: {
         Args: {
-          collectivite_id: number;
+          audit_id: number;
+          scores_table: string;
         };
-        Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          preuve_nombre: number;
-          atteint: boolean;
-        }[];
+        Returns: Json;
       };
-      critere_score_global: {
-        Args: {
-          collectivite_id: number;
-        };
-        Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          etoile_objectif: Database["labellisation"]["Enums"]["etoile"];
-          score_a_realiser: number;
-          score_fait: number;
-          atteint: boolean;
-        }[];
-      };
-      current_audit: {
-        Args: {
-          col: number;
-          ref: Database["public"]["Enums"]["referentiel"];
-        };
-        Returns: {
-          collectivite_id: number;
-          date_debut: string | null;
-          date_fin: string | null;
-          demande_id: number | null;
-          id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          valide: boolean;
-        };
-      };
-      etoiles: {
-        Args: {
-          collectivite_id: number;
-        };
-        Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          etoile_labellise: Database["labellisation"]["Enums"]["etoile"];
-          prochaine_etoile_labellisation: Database["labellisation"]["Enums"]["etoile"];
-          etoile_score_possible: Database["labellisation"]["Enums"]["etoile"];
-          etoile_objectif: Database["labellisation"]["Enums"]["etoile"];
-        }[];
-      };
-      evaluate_audit_statuts: {
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
+=======
+          audit: unknown
+        }
+        Returns: Record<string, unknown>
+      }
+      audit_personnalisation_payload: {
         Args: {
           audit_id: number
+          scores_table: string
+        }
+        Returns: Json
+      }
+>>>>>>> d8b0e10a9 (update types)
+>>>>>>> a342e9c9a (update types)
+      critere_action: {
+        Args: {
+          collectivite_id: number
+        }
+        Returns: {
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          etoiles: Database["labellisation"]["Enums"]["etoile"]
+          action_id: unknown
+          formulation: string
+          score_realise: number
+          min_score_realise: number
+          score_programme: number
+          min_score_programme: number
+          atteint: boolean
+          prio: number
+        }[]
+      }
+      critere_fichier: {
+        Args: {
+          collectivite_id: number
+        }
+        Returns: {
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          preuve_nombre: number
+          atteint: boolean
+        }[]
+      }
+      critere_score_global: {
+        Args: {
+          collectivite_id: number
+        }
+        Returns: {
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          etoile_objectif: Database["labellisation"]["Enums"]["etoile"]
+          score_a_realiser: number
+          score_fait: number
+          atteint: boolean
+        }[]
+      }
+      current_audit: {
+        Args: {
+          col: number
+          ref: Database["public"]["Enums"]["referentiel"]
+        }
+        Returns: {
+          collectivite_id: number
+          date_debut: string | null
+          date_fin: string | null
+          demande_id: number | null
+          id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          valide: boolean
+        }
+      }
+      etoiles: {
+        Args: {
+          collectivite_id: number
+        }
+        Returns: {
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          etoile_labellise: Database["labellisation"]["Enums"]["etoile"]
+          prochaine_etoile_labellisation: Database["labellisation"]["Enums"]["etoile"]
+          etoile_score_possible: Database["labellisation"]["Enums"]["etoile"]
+          etoile_objectif: Database["labellisation"]["Enums"]["etoile"]
+        }[]
+      }
+      evaluate_audit_statuts: {
+        Args: {
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+>>>>>>> a342e9c9a (update types)
+          audit_id: number
           pre_audit: boolean
+=======
+          audit_id: number
+>>>>>>> d8b0e10a9 (update types)
           scores_table: string
         }
         Returns: number
       }
+<<<<<<< HEAD
       json_action_statuts_at: {
         Args: {
           collectivite_id: number
@@ -329,939 +368,971 @@ export interface Database {
         }
         Returns: Json
       }
+<<<<<<< HEAD
+=======
+=======
+          audit_id: number;
+          scores_table: string;
+        };
+        Returns: number;
+      };
+=======
+>>>>>>> d8b0e10a9 (update types)
+      pre_audit_reponses: {
+        Args: {
+          audit: unknown
+        }
+        Returns: Json
+      }
+      pre_audit_service_statuts: {
+        Args: {
+<<<<<<< HEAD
+          audit_id: number;
+        };
+        Returns: Json;
+      };
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
+=======
+          audit_id: number
+        }
+        Returns: Json
+      }
+>>>>>>> d8b0e10a9 (update types)
+>>>>>>> a342e9c9a (update types)
       referentiel_score: {
         Args: {
-          collectivite_id: number;
-        };
+          collectivite_id: number
+        }
         Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          score_fait: number;
-          score_programme: number;
-          completude: number;
-          complet: boolean;
-        }[];
-      };
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          score_fait: number
+          score_programme: number
+          completude: number
+          complet: boolean
+        }[]
+      }
       upsert_preuves_reglementaire: {
         Args: {
-          preuves: Json;
-        };
-        Returns: undefined;
-      };
-    };
+          preuves: Json
+        }
+        Returns: undefined
+      }
+    }
     Enums: {
-      etoile: "1" | "2" | "3" | "4" | "5";
-      sujet_demande: "labellisation" | "labellisation_cot" | "cot";
-    };
+      etoile: "1" | "2" | "3" | "4" | "5"
+      sujet_demande: "labellisation" | "labellisation_cot" | "cot"
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       abstract_any_indicateur_value: {
         Row: {
-          annee: number;
-          modified_at: string;
-          valeur: number | null;
-        };
+          annee: number
+          modified_at: string
+          valeur: number | null
+        }
         Insert: {
-          annee: number;
-          modified_at?: string;
-          valeur?: number | null;
-        };
+          annee: number
+          modified_at?: string
+          valeur?: number | null
+        }
         Update: {
-          annee?: number;
-          modified_at?: string;
-          valeur?: number | null;
-        };
-      };
+          annee?: number
+          modified_at?: string
+          valeur?: number | null
+        }
+      }
       abstract_modified_at: {
         Row: {
-          modified_at: string;
-        };
+          modified_at: string
+        }
         Insert: {
-          modified_at?: string;
-        };
+          modified_at?: string
+        }
         Update: {
-          modified_at?: string;
-        };
-      };
+          modified_at?: string
+        }
+      }
       action_commentaire: {
         Row: {
-          action_id: string;
-          collectivite_id: number;
-          commentaire: string;
-          modified_at: string;
-          modified_by: string;
-        };
+          action_id: string
+          collectivite_id: number
+          commentaire: string
+          modified_at: string
+          modified_by: string
+        }
         Insert: {
-          action_id: string;
-          collectivite_id: number;
-          commentaire: string;
-          modified_at?: string;
-          modified_by?: string;
-        };
+          action_id: string
+          collectivite_id: number
+          commentaire: string
+          modified_at?: string
+          modified_by?: string
+        }
         Update: {
-          action_id?: string;
-          collectivite_id?: number;
-          commentaire?: string;
-          modified_at?: string;
-          modified_by?: string;
-        };
-      };
+          action_id?: string
+          collectivite_id?: number
+          commentaire?: string
+          modified_at?: string
+          modified_by?: string
+        }
+      }
       action_computed_points: {
         Row: {
-          action_id: string;
-          modified_at: string;
-          value: number;
-        };
+          action_id: string
+          modified_at: string
+          value: number
+        }
         Insert: {
-          action_id: string;
-          modified_at?: string;
-          value: number;
-        };
+          action_id: string
+          modified_at?: string
+          value: number
+        }
         Update: {
-          action_id?: string;
-          modified_at?: string;
-          value?: number;
-        };
-      };
+          action_id?: string
+          modified_at?: string
+          value?: number
+        }
+      }
       action_definition: {
         Row: {
-          action_id: string;
-          categorie: Database["public"]["Enums"]["action_categorie"] | null;
-          contexte: string;
-          description: string;
-          exemples: string;
-          identifiant: string;
-          modified_at: string;
-          nom: string;
-          perimetre_evaluation: string;
-          points: number | null;
-          pourcentage: number | null;
-          preuve: string | null;
-          reduction_potentiel: string;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          ressources: string;
-        };
+          action_id: string
+          categorie: Database["public"]["Enums"]["action_categorie"] | null
+          contexte: string
+          description: string
+          exemples: string
+          identifiant: string
+          modified_at: string
+          nom: string
+          perimetre_evaluation: string
+          points: number | null
+          pourcentage: number | null
+          preuve: string | null
+          reduction_potentiel: string
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          ressources: string
+        }
         Insert: {
-          action_id: string;
-          categorie?: Database["public"]["Enums"]["action_categorie"] | null;
-          contexte: string;
-          description: string;
-          exemples: string;
-          identifiant: string;
-          modified_at?: string;
-          nom: string;
-          perimetre_evaluation: string;
-          points?: number | null;
-          pourcentage?: number | null;
-          preuve?: string | null;
-          reduction_potentiel: string;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          ressources: string;
-        };
+          action_id: string
+          categorie?: Database["public"]["Enums"]["action_categorie"] | null
+          contexte: string
+          description: string
+          exemples: string
+          identifiant: string
+          modified_at?: string
+          nom: string
+          perimetre_evaluation: string
+          points?: number | null
+          pourcentage?: number | null
+          preuve?: string | null
+          reduction_potentiel: string
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          ressources: string
+        }
         Update: {
-          action_id?: string;
-          categorie?: Database["public"]["Enums"]["action_categorie"] | null;
-          contexte?: string;
-          description?: string;
-          exemples?: string;
-          identifiant?: string;
-          modified_at?: string;
-          nom?: string;
-          perimetre_evaluation?: string;
-          points?: number | null;
-          pourcentage?: number | null;
-          preuve?: string | null;
-          reduction_potentiel?: string;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-          ressources?: string;
-        };
-      };
+          action_id?: string
+          categorie?: Database["public"]["Enums"]["action_categorie"] | null
+          contexte?: string
+          description?: string
+          exemples?: string
+          identifiant?: string
+          modified_at?: string
+          nom?: string
+          perimetre_evaluation?: string
+          points?: number | null
+          pourcentage?: number | null
+          preuve?: string | null
+          reduction_potentiel?: string
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+          ressources?: string
+        }
+      }
       action_discussion: {
         Row: {
-          action_id: string;
-          collectivite_id: number;
-          created_at: string;
-          created_by: string;
-          id: number;
-          modified_at: string;
-          status: Database["public"]["Enums"]["action_discussion_statut"];
-        };
+          action_id: string
+          collectivite_id: number
+          created_at: string
+          created_by: string
+          id: number
+          modified_at: string
+          status: Database["public"]["Enums"]["action_discussion_statut"]
+        }
         Insert: {
-          action_id: string;
-          collectivite_id: number;
-          created_at?: string;
-          created_by?: string;
-          id?: number;
-          modified_at?: string;
-          status?: Database["public"]["Enums"]["action_discussion_statut"];
-        };
+          action_id: string
+          collectivite_id: number
+          created_at?: string
+          created_by?: string
+          id?: number
+          modified_at?: string
+          status?: Database["public"]["Enums"]["action_discussion_statut"]
+        }
         Update: {
-          action_id?: string;
-          collectivite_id?: number;
-          created_at?: string;
-          created_by?: string;
-          id?: number;
-          modified_at?: string;
-          status?: Database["public"]["Enums"]["action_discussion_statut"];
-        };
-      };
+          action_id?: string
+          collectivite_id?: number
+          created_at?: string
+          created_by?: string
+          id?: number
+          modified_at?: string
+          status?: Database["public"]["Enums"]["action_discussion_statut"]
+        }
+      }
       action_discussion_commentaire: {
         Row: {
-          created_at: string;
-          created_by: string;
-          discussion_id: number;
-          id: number;
-          message: string;
-        };
+          created_at: string
+          created_by: string
+          discussion_id: number
+          id: number
+          message: string
+        }
         Insert: {
-          created_at?: string;
-          created_by?: string;
-          discussion_id: number;
-          id?: number;
-          message: string;
-        };
+          created_at?: string
+          created_by?: string
+          discussion_id: number
+          id?: number
+          message: string
+        }
         Update: {
-          created_at?: string;
-          created_by?: string;
-          discussion_id?: number;
-          id?: number;
-          message?: string;
-        };
-      };
+          created_at?: string
+          created_by?: string
+          discussion_id?: number
+          id?: number
+          message?: string
+        }
+      }
       action_relation: {
         Row: {
-          id: string;
-          parent: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
+          id: string
+          parent: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
         Insert: {
-          id: string;
-          parent?: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
+          id: string
+          parent?: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
         Update: {
-          id?: string;
-          parent?: string | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-        };
-      };
+          id?: string
+          parent?: string | null
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+        }
+      }
       action_statut: {
         Row: {
-          action_id: string;
-          avancement: Database["public"]["Enums"]["avancement"];
-          avancement_detaille: number[] | null;
-          collectivite_id: number;
-          concerne: boolean;
-          modified_at: string;
-          modified_by: string;
-        };
+          action_id: string
+          avancement: Database["public"]["Enums"]["avancement"]
+          avancement_detaille: number[] | null
+          collectivite_id: number
+          concerne: boolean
+          modified_at: string
+          modified_by: string
+        }
         Insert: {
-          action_id: string;
-          avancement: Database["public"]["Enums"]["avancement"];
-          avancement_detaille?: number[] | null;
-          collectivite_id: number;
-          concerne: boolean;
-          modified_at?: string;
-          modified_by?: string;
-        };
+          action_id: string
+          avancement: Database["public"]["Enums"]["avancement"]
+          avancement_detaille?: number[] | null
+          collectivite_id: number
+          concerne: boolean
+          modified_at?: string
+          modified_by?: string
+        }
         Update: {
-          action_id?: string;
-          avancement?: Database["public"]["Enums"]["avancement"];
-          avancement_detaille?: number[] | null;
-          collectivite_id?: number;
-          concerne?: boolean;
-          modified_at?: string;
-          modified_by?: string;
-        };
-      };
+          action_id?: string
+          avancement?: Database["public"]["Enums"]["avancement"]
+          avancement_detaille?: number[] | null
+          collectivite_id?: number
+          concerne?: boolean
+          modified_at?: string
+          modified_by?: string
+        }
+      }
       annexe: {
         Row: {
-          collectivite_id: number;
-          commentaire: string;
-          fiche_id: number;
-          fichier_id: number | null;
-          id: number;
-          lien: Json | null;
-          modified_at: string;
-          modified_by: string;
-          titre: string;
-          url: string | null;
-        };
+          collectivite_id: number
+          commentaire: string
+          fiche_id: number
+          fichier_id: number | null
+          id: number
+          lien: Json | null
+          modified_at: string
+          modified_by: string
+          titre: string
+          url: string | null
+        }
         Insert: {
-          collectivite_id: number;
-          commentaire?: string;
-          fiche_id: number;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
+          collectivite_id: number
+          commentaire?: string
+          fiche_id: number
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
         Update: {
-          collectivite_id?: number;
-          commentaire?: string;
-          fiche_id?: number;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-      };
+          collectivite_id?: number
+          commentaire?: string
+          fiche_id?: number
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+      }
       audit_auditeur: {
         Row: {
-          audit_id: number;
-          auditeur: string;
-          created_at: string | null;
-        };
+          audit_id: number
+          auditeur: string
+          created_at: string | null
+        }
         Insert: {
-          audit_id: number;
-          auditeur: string;
-          created_at?: string | null;
-        };
+          audit_id: number
+          auditeur: string
+          created_at?: string | null
+        }
         Update: {
-          audit_id?: number;
-          auditeur?: string;
-          created_at?: string | null;
-        };
-      };
+          audit_id?: number
+          auditeur?: string
+          created_at?: string | null
+        }
+      }
       axe: {
         Row: {
-          collectivite_id: number;
-          created_at: string;
-          id: number;
-          modified_at: string;
-          modified_by: string | null;
-          nom: string | null;
-          parent: number | null;
-        };
+          collectivite_id: number
+          created_at: string
+          id: number
+          modified_at: string
+          modified_by: string | null
+          nom: string | null
+          parent: number | null
+        }
         Insert: {
-          collectivite_id: number;
-          created_at?: string;
-          id?: number;
-          modified_at?: string;
-          modified_by?: string | null;
-          nom?: string | null;
-          parent?: number | null;
-        };
+          collectivite_id: number
+          created_at?: string
+          id?: number
+          modified_at?: string
+          modified_by?: string | null
+          nom?: string | null
+          parent?: number | null
+        }
         Update: {
-          collectivite_id?: number;
-          created_at?: string;
-          id?: number;
-          modified_at?: string;
-          modified_by?: string | null;
-          nom?: string | null;
-          parent?: number | null;
-        };
-      };
+          collectivite_id?: number
+          created_at?: string
+          id?: number
+          modified_at?: string
+          modified_by?: string | null
+          nom?: string | null
+          parent?: number | null
+        }
+      }
       client_scores: {
         Row: {
-          collectivite_id: number;
-          modified_at: string;
-          payload_timestamp: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          scores: Json;
-        };
+          collectivite_id: number
+          modified_at: string
+          payload_timestamp: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          scores: Json
+        }
         Insert: {
-          collectivite_id: number;
-          modified_at: string;
-          payload_timestamp?: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          scores: Json;
-        };
+          collectivite_id: number
+          modified_at: string
+          payload_timestamp?: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          scores: Json
+        }
         Update: {
-          collectivite_id?: number;
-          modified_at?: string;
-          payload_timestamp?: string | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-          scores?: Json;
-        };
-      };
+          collectivite_id?: number
+          modified_at?: string
+          payload_timestamp?: string | null
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+          scores?: Json
+        }
+      }
       client_scores_update: {
         Row: {
-          collectivite_id: number;
-          modified_at: string;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
+          collectivite_id: number
+          modified_at: string
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
         Insert: {
-          collectivite_id: number;
-          modified_at: string;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
+          collectivite_id: number
+          modified_at: string
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
         Update: {
-          collectivite_id?: number;
-          modified_at?: string;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-        };
-      };
+          collectivite_id?: number
+          modified_at?: string
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+        }
+      }
       collectivite: {
         Row: {
-          access_restreint: boolean;
-          created_at: string;
-          id: number;
-          modified_at: string;
-        };
+          access_restreint: boolean
+          created_at: string
+          id: number
+          modified_at: string
+        }
         Insert: {
-          access_restreint?: boolean;
-          created_at?: string;
-          id?: number;
-          modified_at?: string;
-        };
+          access_restreint?: boolean
+          created_at?: string
+          id?: number
+          modified_at?: string
+        }
         Update: {
-          access_restreint?: boolean;
-          created_at?: string;
-          id?: number;
-          modified_at?: string;
-        };
-      };
+          access_restreint?: boolean
+          created_at?: string
+          id?: number
+          modified_at?: string
+        }
+      }
       collectivite_bucket: {
         Row: {
-          bucket_id: string;
-          collectivite_id: number;
-        };
+          bucket_id: string
+          collectivite_id: number
+        }
         Insert: {
-          bucket_id: string;
-          collectivite_id: number;
-        };
+          bucket_id: string
+          collectivite_id: number
+        }
         Update: {
-          bucket_id?: string;
-          collectivite_id?: number;
-        };
-      };
+          bucket_id?: string
+          collectivite_id?: number
+        }
+      }
       collectivite_test: {
         Row: {
-          collectivite_id: number | null;
-          id: number;
-          nom: string;
-        };
+          collectivite_id: number | null
+          id: number
+          nom: string
+        }
         Insert: {
-          collectivite_id?: number | null;
-          id?: number;
-          nom: string;
-        };
+          collectivite_id?: number | null
+          id?: number
+          nom: string
+        }
         Update: {
-          collectivite_id?: number | null;
-          id?: number;
-          nom?: string;
-        };
-      };
+          collectivite_id?: number | null
+          id?: number
+          nom?: string
+        }
+      }
       commune: {
         Row: {
-          code: string;
-          collectivite_id: number | null;
-          id: number;
-          nom: string;
-        };
+          code: string
+          collectivite_id: number | null
+          id: number
+          nom: string
+        }
         Insert: {
-          code: string;
-          collectivite_id?: number | null;
-          id?: number;
-          nom: string;
-        };
+          code: string
+          collectivite_id?: number | null
+          id?: number
+          nom: string
+        }
         Update: {
-          code?: string;
-          collectivite_id?: number | null;
-          id?: number;
-          nom?: string;
-        };
-      };
+          code?: string
+          collectivite_id?: number | null
+          id?: number
+          nom?: string
+        }
+      }
       cot: {
         Row: {
-          actif: boolean;
-          collectivite_id: number;
-          signataire: number | null;
-        };
+          actif: boolean
+          collectivite_id: number
+          signataire: number | null
+        }
         Insert: {
-          actif: boolean;
-          collectivite_id: number;
-          signataire?: number | null;
-        };
+          actif: boolean
+          collectivite_id: number
+          signataire?: number | null
+        }
         Update: {
-          actif?: boolean;
-          collectivite_id?: number;
-          signataire?: number | null;
-        };
-      };
+          actif?: boolean
+          collectivite_id?: number
+          signataire?: number | null
+        }
+      }
       dcp: {
         Row: {
-          cgu_acceptees_le: string | null;
-          created_at: string;
-          deleted: boolean;
-          email: string;
-          limited: boolean;
-          modified_at: string;
-          nom: string;
-          prenom: string;
-          telephone: string | null;
-          user_id: string;
-        };
+          cgu_acceptees_le: string | null
+          created_at: string
+          deleted: boolean
+          email: string
+          limited: boolean
+          modified_at: string
+          nom: string
+          prenom: string
+          telephone: string | null
+          user_id: string
+        }
         Insert: {
-          cgu_acceptees_le?: string | null;
-          created_at?: string;
-          deleted?: boolean;
-          email: string;
-          limited?: boolean;
-          modified_at?: string;
-          nom: string;
-          prenom: string;
-          telephone?: string | null;
-          user_id: string;
-        };
+          cgu_acceptees_le?: string | null
+          created_at?: string
+          deleted?: boolean
+          email: string
+          limited?: boolean
+          modified_at?: string
+          nom: string
+          prenom: string
+          telephone?: string | null
+          user_id: string
+        }
         Update: {
-          cgu_acceptees_le?: string | null;
-          created_at?: string;
-          deleted?: boolean;
-          email?: string;
-          limited?: boolean;
-          modified_at?: string;
-          nom?: string;
-          prenom?: string;
-          telephone?: string | null;
-          user_id?: string;
-        };
-      };
+          cgu_acceptees_le?: string | null
+          created_at?: string
+          deleted?: boolean
+          email?: string
+          limited?: boolean
+          modified_at?: string
+          nom?: string
+          prenom?: string
+          telephone?: string | null
+          user_id?: string
+        }
+      }
       epci: {
         Row: {
-          collectivite_id: number | null;
-          id: number;
-          nature: Database["public"]["Enums"]["nature"];
-          nom: string;
-          siren: string;
-        };
+          collectivite_id: number | null
+          id: number
+          nature: Database["public"]["Enums"]["nature"]
+          nom: string
+          siren: string
+        }
         Insert: {
-          collectivite_id?: number | null;
-          id?: number;
-          nature: Database["public"]["Enums"]["nature"];
-          nom: string;
-          siren: string;
-        };
+          collectivite_id?: number | null
+          id?: number
+          nature: Database["public"]["Enums"]["nature"]
+          nom: string
+          siren: string
+        }
         Update: {
-          collectivite_id?: number | null;
-          id?: number;
-          nature?: Database["public"]["Enums"]["nature"];
-          nom?: string;
-          siren?: string;
-        };
-      };
+          collectivite_id?: number | null
+          id?: number
+          nature?: Database["public"]["Enums"]["nature"]
+          nom?: string
+          siren?: string
+        }
+      }
       fiche_action: {
         Row: {
-          amelioration_continue: boolean | null;
-          budget_previsionnel: number | null;
-          calendrier: string | null;
-          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null;
-          collectivite_id: number;
-          created_at: string;
-          date_debut: string | null;
-          date_fin_provisoire: string | null;
-          description: string | null;
-          financements: string | null;
-          id: number;
-          maj_termine: boolean | null;
-          modified_at: string;
-          modified_by: string | null;
+          amelioration_continue: boolean | null
+          budget_previsionnel: number | null
+          calendrier: string | null
+          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null
+          collectivite_id: number
+          created_at: string
+          date_debut: string | null
+          date_fin_provisoire: string | null
+          description: string | null
+          financements: string | null
+          id: number
+          maj_termine: boolean | null
+          modified_at: string
+          modified_by: string | null
           niveau_priorite:
             | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null;
-          notes_complementaires: string | null;
-          objectifs: string | null;
+            | null
+          notes_complementaires: string | null
+          objectifs: string | null
           piliers_eci:
             | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null;
-          ressources: string | null;
+            | null
+          ressources: string | null
           resultats_attendus:
             | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null;
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
-          titre: string | null;
-        };
+            | null
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
+          titre: string | null
+        }
         Insert: {
-          amelioration_continue?: boolean | null;
-          budget_previsionnel?: number | null;
-          calendrier?: string | null;
-          cibles?: Database["public"]["Enums"]["fiche_action_cibles"][] | null;
-          collectivite_id: number;
-          created_at?: string;
-          date_debut?: string | null;
-          date_fin_provisoire?: string | null;
-          description?: string | null;
-          financements?: string | null;
-          id?: number;
-          maj_termine?: boolean | null;
-          modified_at?: string;
-          modified_by?: string | null;
+          amelioration_continue?: boolean | null
+          budget_previsionnel?: number | null
+          calendrier?: string | null
+          cibles?: Database["public"]["Enums"]["fiche_action_cibles"][] | null
+          collectivite_id: number
+          created_at?: string
+          date_debut?: string | null
+          date_fin_provisoire?: string | null
+          description?: string | null
+          financements?: string | null
+          id?: number
+          maj_termine?: boolean | null
+          modified_at?: string
+          modified_by?: string | null
           niveau_priorite?:
             | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null;
-          notes_complementaires?: string | null;
-          objectifs?: string | null;
+            | null
+          notes_complementaires?: string | null
+          objectifs?: string | null
           piliers_eci?:
             | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null;
-          ressources?: string | null;
+            | null
+          ressources?: string | null
           resultats_attendus?:
             | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null;
-          statut?: Database["public"]["Enums"]["fiche_action_statuts"] | null;
-          titre?: string | null;
-        };
+            | null
+          statut?: Database["public"]["Enums"]["fiche_action_statuts"] | null
+          titre?: string | null
+        }
         Update: {
-          amelioration_continue?: boolean | null;
-          budget_previsionnel?: number | null;
-          calendrier?: string | null;
-          cibles?: Database["public"]["Enums"]["fiche_action_cibles"][] | null;
-          collectivite_id?: number;
-          created_at?: string;
-          date_debut?: string | null;
-          date_fin_provisoire?: string | null;
-          description?: string | null;
-          financements?: string | null;
-          id?: number;
-          maj_termine?: boolean | null;
-          modified_at?: string;
-          modified_by?: string | null;
+          amelioration_continue?: boolean | null
+          budget_previsionnel?: number | null
+          calendrier?: string | null
+          cibles?: Database["public"]["Enums"]["fiche_action_cibles"][] | null
+          collectivite_id?: number
+          created_at?: string
+          date_debut?: string | null
+          date_fin_provisoire?: string | null
+          description?: string | null
+          financements?: string | null
+          id?: number
+          maj_termine?: boolean | null
+          modified_at?: string
+          modified_by?: string | null
           niveau_priorite?:
             | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null;
-          notes_complementaires?: string | null;
-          objectifs?: string | null;
+            | null
+          notes_complementaires?: string | null
+          objectifs?: string | null
           piliers_eci?:
             | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null;
-          ressources?: string | null;
+            | null
+          ressources?: string | null
           resultats_attendus?:
             | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null;
-          statut?: Database["public"]["Enums"]["fiche_action_statuts"] | null;
-          titre?: string | null;
-        };
-      };
+            | null
+          statut?: Database["public"]["Enums"]["fiche_action_statuts"] | null
+          titre?: string | null
+        }
+      }
       fiche_action_action: {
         Row: {
-          action_id: string;
-          fiche_id: number;
-          fiche_resume: unknown | null;
-        };
+          action_id: string
+          fiche_id: number
+          fiche_resume: unknown | null
+        }
         Insert: {
-          action_id: string;
-          fiche_id: number;
-        };
+          action_id: string
+          fiche_id: number
+        }
         Update: {
-          action_id?: string;
-          fiche_id?: number;
-        };
-      };
+          action_id?: string
+          fiche_id?: number
+        }
+      }
       fiche_action_axe: {
         Row: {
-          axe_id: number;
-          fiche_id: number;
-        };
+          axe_id: number
+          fiche_id: number
+        }
         Insert: {
-          axe_id: number;
-          fiche_id: number;
-        };
+          axe_id: number
+          fiche_id: number
+        }
         Update: {
-          axe_id?: number;
-          fiche_id?: number;
-        };
-      };
+          axe_id?: number
+          fiche_id?: number
+        }
+      }
       fiche_action_financeur_tag: {
         Row: {
-          fiche_id: number;
-          financeur_tag_id: number;
-          id: number;
-          montant_ttc: number | null;
-        };
+          fiche_id: number
+          financeur_tag_id: number
+          id: number
+          montant_ttc: number | null
+        }
         Insert: {
-          fiche_id: number;
-          financeur_tag_id: number;
-          id?: number;
-          montant_ttc?: number | null;
-        };
+          fiche_id: number
+          financeur_tag_id: number
+          id?: number
+          montant_ttc?: number | null
+        }
         Update: {
-          fiche_id?: number;
-          financeur_tag_id?: number;
-          id?: number;
-          montant_ttc?: number | null;
-        };
-      };
+          fiche_id?: number
+          financeur_tag_id?: number
+          id?: number
+          montant_ttc?: number | null
+        }
+      }
       fiche_action_import_csv: {
         Row: {
-          amelioration_continue: string | null;
-          axe: string | null;
-          budget: string | null;
-          calendrier: string | null;
-          cibles: string | null;
-          collectivite_id: string | null;
-          date_debut: string | null;
-          date_fin: string | null;
-          description: string | null;
-          elu_referent: string | null;
-          financements: string | null;
-          financeur_deux: string | null;
-          financeur_trois: string | null;
-          financeur_un: string | null;
-          montant_deux: string | null;
-          montant_trois: string | null;
-          montant_un: string | null;
-          moyens: string | null;
-          notes: string | null;
-          num_action: string | null;
-          objectifs: string | null;
-          partenaires: string | null;
-          personne_referente: string | null;
-          plan_nom: string | null;
-          priorite: string | null;
-          resultats_attendus: string | null;
-          service: string | null;
-          sous_axe: string | null;
-          sous_sous_axe: string | null;
-          statut: string | null;
-          structure_pilote: string | null;
-          titre: string | null;
-        };
+          amelioration_continue: string | null
+          axe: string | null
+          budget: string | null
+          calendrier: string | null
+          cibles: string | null
+          collectivite_id: string | null
+          date_debut: string | null
+          date_fin: string | null
+          description: string | null
+          elu_referent: string | null
+          financements: string | null
+          financeur_deux: string | null
+          financeur_trois: string | null
+          financeur_un: string | null
+          montant_deux: string | null
+          montant_trois: string | null
+          montant_un: string | null
+          moyens: string | null
+          notes: string | null
+          num_action: string | null
+          objectifs: string | null
+          partenaires: string | null
+          personne_referente: string | null
+          plan_nom: string | null
+          priorite: string | null
+          resultats_attendus: string | null
+          service: string | null
+          sous_axe: string | null
+          sous_sous_axe: string | null
+          statut: string | null
+          structure_pilote: string | null
+          titre: string | null
+        }
         Insert: {
-          amelioration_continue?: string | null;
-          axe?: string | null;
-          budget?: string | null;
-          calendrier?: string | null;
-          cibles?: string | null;
-          collectivite_id?: string | null;
-          date_debut?: string | null;
-          date_fin?: string | null;
-          description?: string | null;
-          elu_referent?: string | null;
-          financements?: string | null;
-          financeur_deux?: string | null;
-          financeur_trois?: string | null;
-          financeur_un?: string | null;
-          montant_deux?: string | null;
-          montant_trois?: string | null;
-          montant_un?: string | null;
-          moyens?: string | null;
-          notes?: string | null;
-          num_action?: string | null;
-          objectifs?: string | null;
-          partenaires?: string | null;
-          personne_referente?: string | null;
-          plan_nom?: string | null;
-          priorite?: string | null;
-          resultats_attendus?: string | null;
-          service?: string | null;
-          sous_axe?: string | null;
-          sous_sous_axe?: string | null;
-          statut?: string | null;
-          structure_pilote?: string | null;
-          titre?: string | null;
-        };
+          amelioration_continue?: string | null
+          axe?: string | null
+          budget?: string | null
+          calendrier?: string | null
+          cibles?: string | null
+          collectivite_id?: string | null
+          date_debut?: string | null
+          date_fin?: string | null
+          description?: string | null
+          elu_referent?: string | null
+          financements?: string | null
+          financeur_deux?: string | null
+          financeur_trois?: string | null
+          financeur_un?: string | null
+          montant_deux?: string | null
+          montant_trois?: string | null
+          montant_un?: string | null
+          moyens?: string | null
+          notes?: string | null
+          num_action?: string | null
+          objectifs?: string | null
+          partenaires?: string | null
+          personne_referente?: string | null
+          plan_nom?: string | null
+          priorite?: string | null
+          resultats_attendus?: string | null
+          service?: string | null
+          sous_axe?: string | null
+          sous_sous_axe?: string | null
+          statut?: string | null
+          structure_pilote?: string | null
+          titre?: string | null
+        }
         Update: {
-          amelioration_continue?: string | null;
-          axe?: string | null;
-          budget?: string | null;
-          calendrier?: string | null;
-          cibles?: string | null;
-          collectivite_id?: string | null;
-          date_debut?: string | null;
-          date_fin?: string | null;
-          description?: string | null;
-          elu_referent?: string | null;
-          financements?: string | null;
-          financeur_deux?: string | null;
-          financeur_trois?: string | null;
-          financeur_un?: string | null;
-          montant_deux?: string | null;
-          montant_trois?: string | null;
-          montant_un?: string | null;
-          moyens?: string | null;
-          notes?: string | null;
-          num_action?: string | null;
-          objectifs?: string | null;
-          partenaires?: string | null;
-          personne_referente?: string | null;
-          plan_nom?: string | null;
-          priorite?: string | null;
-          resultats_attendus?: string | null;
-          service?: string | null;
-          sous_axe?: string | null;
-          sous_sous_axe?: string | null;
-          statut?: string | null;
-          structure_pilote?: string | null;
-          titre?: string | null;
-        };
-      };
+          amelioration_continue?: string | null
+          axe?: string | null
+          budget?: string | null
+          calendrier?: string | null
+          cibles?: string | null
+          collectivite_id?: string | null
+          date_debut?: string | null
+          date_fin?: string | null
+          description?: string | null
+          elu_referent?: string | null
+          financements?: string | null
+          financeur_deux?: string | null
+          financeur_trois?: string | null
+          financeur_un?: string | null
+          montant_deux?: string | null
+          montant_trois?: string | null
+          montant_un?: string | null
+          moyens?: string | null
+          notes?: string | null
+          num_action?: string | null
+          objectifs?: string | null
+          partenaires?: string | null
+          personne_referente?: string | null
+          plan_nom?: string | null
+          priorite?: string | null
+          resultats_attendus?: string | null
+          service?: string | null
+          sous_axe?: string | null
+          sous_sous_axe?: string | null
+          statut?: string | null
+          structure_pilote?: string | null
+          titre?: string | null
+        }
+      }
       fiche_action_indicateur: {
         Row: {
-          fiche_id: number;
-          indicateur_id: string | null;
-          indicateur_personnalise_id: number | null;
-        };
+          fiche_id: number
+          indicateur_id: string | null
+          indicateur_personnalise_id: number | null
+        }
         Insert: {
-          fiche_id: number;
-          indicateur_id?: string | null;
-          indicateur_personnalise_id?: number | null;
-        };
+          fiche_id: number
+          indicateur_id?: string | null
+          indicateur_personnalise_id?: number | null
+        }
         Update: {
-          fiche_id?: number;
-          indicateur_id?: string | null;
-          indicateur_personnalise_id?: number | null;
-        };
-      };
+          fiche_id?: number
+          indicateur_id?: string | null
+          indicateur_personnalise_id?: number | null
+        }
+      }
       fiche_action_lien: {
         Row: {
-          fiche_deux: number;
-          fiche_une: number;
-        };
+          fiche_deux: number
+          fiche_une: number
+        }
         Insert: {
-          fiche_deux: number;
-          fiche_une: number;
-        };
+          fiche_deux: number
+          fiche_une: number
+        }
         Update: {
-          fiche_deux?: number;
-          fiche_une?: number;
-        };
-      };
+          fiche_deux?: number
+          fiche_une?: number
+        }
+      }
       fiche_action_partenaire_tag: {
         Row: {
-          fiche_id: number;
-          partenaire_tag_id: number;
-        };
+          fiche_id: number
+          partenaire_tag_id: number
+        }
         Insert: {
-          fiche_id: number;
-          partenaire_tag_id: number;
-        };
+          fiche_id: number
+          partenaire_tag_id: number
+        }
         Update: {
-          fiche_id?: number;
-          partenaire_tag_id?: number;
-        };
-      };
+          fiche_id?: number
+          partenaire_tag_id?: number
+        }
+      }
       fiche_action_pilote: {
         Row: {
-          fiche_id: number;
-          tag_id: number | null;
-          user_id: string | null;
-        };
+          fiche_id: number
+          tag_id: number | null
+          user_id: string | null
+        }
         Insert: {
-          fiche_id: number;
-          tag_id?: number | null;
-          user_id?: string | null;
-        };
+          fiche_id: number
+          tag_id?: number | null
+          user_id?: string | null
+        }
         Update: {
-          fiche_id?: number;
-          tag_id?: number | null;
-          user_id?: string | null;
-        };
-      };
+          fiche_id?: number
+          tag_id?: number | null
+          user_id?: string | null
+        }
+      }
       fiche_action_referent: {
         Row: {
-          fiche_id: number;
-          tag_id: number | null;
-          user_id: string | null;
-        };
+          fiche_id: number
+          tag_id: number | null
+          user_id: string | null
+        }
         Insert: {
-          fiche_id: number;
-          tag_id?: number | null;
-          user_id?: string | null;
-        };
+          fiche_id: number
+          tag_id?: number | null
+          user_id?: string | null
+        }
         Update: {
-          fiche_id?: number;
-          tag_id?: number | null;
-          user_id?: string | null;
-        };
-      };
+          fiche_id?: number
+          tag_id?: number | null
+          user_id?: string | null
+        }
+      }
       fiche_action_service_tag: {
         Row: {
-          fiche_id: number;
-          service_tag_id: number;
-        };
+          fiche_id: number
+          service_tag_id: number
+        }
         Insert: {
-          fiche_id: number;
-          service_tag_id: number;
-        };
+          fiche_id: number
+          service_tag_id: number
+        }
         Update: {
-          fiche_id?: number;
-          service_tag_id?: number;
-        };
-      };
+          fiche_id?: number
+          service_tag_id?: number
+        }
+      }
       fiche_action_sous_thematique: {
         Row: {
-          fiche_id: number;
-          thematique_id: number;
-        };
+          fiche_id: number
+          thematique_id: number
+        }
         Insert: {
-          fiche_id: number;
-          thematique_id: number;
-        };
+          fiche_id: number
+          thematique_id: number
+        }
         Update: {
-          fiche_id?: number;
-          thematique_id?: number;
-        };
-      };
+          fiche_id?: number
+          thematique_id?: number
+        }
+      }
       fiche_action_structure_tag: {
         Row: {
-          fiche_id: number;
-          structure_tag_id: number;
-        };
+          fiche_id: number
+          structure_tag_id: number
+        }
         Insert: {
-          fiche_id: number;
-          structure_tag_id: number;
-        };
+          fiche_id: number
+          structure_tag_id: number
+        }
         Update: {
-          fiche_id?: number;
-          structure_tag_id?: number;
-        };
-      };
+          fiche_id?: number
+          structure_tag_id?: number
+        }
+      }
       fiche_action_thematique: {
         Row: {
-          fiche_id: number;
-          thematique: string;
-        };
+          fiche_id: number
+          thematique: string
+        }
         Insert: {
-          fiche_id: number;
-          thematique: string;
-        };
+          fiche_id: number
+          thematique: string
+        }
         Update: {
-          fiche_id?: number;
-          thematique?: string;
-        };
-      };
+          fiche_id?: number
+          thematique?: string
+        }
+      }
       filtre_intervalle: {
         Row: {
-          id: string;
-          intervalle: unknown;
-          libelle: string;
-          type: Database["public"]["Enums"]["collectivite_filtre_type"];
-        };
+          id: string
+          intervalle: unknown
+          libelle: string
+          type: Database["public"]["Enums"]["collectivite_filtre_type"]
+        }
         Insert: {
-          id: string;
-          intervalle: unknown;
-          libelle: string;
-          type: Database["public"]["Enums"]["collectivite_filtre_type"];
-        };
+          id: string
+          intervalle: unknown
+          libelle: string
+          type: Database["public"]["Enums"]["collectivite_filtre_type"]
+        }
         Update: {
-          id?: string;
-          intervalle?: unknown;
-          libelle?: string;
-          type?: Database["public"]["Enums"]["collectivite_filtre_type"];
-        };
-      };
+          id?: string
+          intervalle?: unknown
+          libelle?: string
+          type?: Database["public"]["Enums"]["collectivite_filtre_type"]
+        }
+      }
       financeur_tag: {
         Row: {
-          collectivite_id: number;
-          id: number;
-          nom: string;
-        };
+          collectivite_id: number
+          id: number
+          nom: string
+        }
         Insert: {
-          collectivite_id: number;
-          id?: number;
-          nom: string;
-        };
+          collectivite_id: number
+          id?: number
+          nom: string
+        }
         Update: {
+<<<<<<< HEAD
           collectivite_id?: number;
           id?: number;
           nom?: string;
@@ -1758,11 +1829,514 @@ export interface Database {
           nom: string;
         };
         Update: {
+=======
+>>>>>>> a342e9c9a (update types)
           collectivite_id?: number
           id?: number
           nom?: string
         }
       }
+      indicateur_action: {
+        Row: {
+          action_id: string
+          indicateur_id: string
+          modified_at: string
+        }
+        Insert: {
+          action_id: string
+          indicateur_id: string
+          modified_at?: string
+        }
+        Update: {
+          action_id?: string
+          indicateur_id?: string
+          modified_at?: string
+        }
+      }
+      indicateur_commentaire: {
+        Row: {
+          collectivite_id: number
+          commentaire: string
+          indicateur_id: string
+          modified_at: string
+          modified_by: string
+        }
+        Insert: {
+          collectivite_id: number
+          commentaire: string
+          indicateur_id: string
+          modified_at?: string
+          modified_by?: string
+        }
+        Update: {
+          collectivite_id?: number
+          commentaire?: string
+          indicateur_id?: string
+          modified_at?: string
+          modified_by?: string
+        }
+      }
+      indicateur_definition: {
+        Row: {
+          description: string
+          id: string
+          identifiant: string
+          indicateur_group: Database["public"]["Enums"]["indicateur_group"]
+          modified_at: string
+          nom: string
+          obligation_eci: boolean
+          parent: number | null
+          unite: string
+          valeur_indicateur: string | null
+        }
+        Insert: {
+          description: string
+          id: string
+          identifiant: string
+          indicateur_group: Database["public"]["Enums"]["indicateur_group"]
+          modified_at?: string
+          nom: string
+          obligation_eci: boolean
+          parent?: number | null
+          unite: string
+          valeur_indicateur?: string | null
+        }
+        Update: {
+          description?: string
+          id?: string
+          identifiant?: string
+          indicateur_group?: Database["public"]["Enums"]["indicateur_group"]
+          modified_at?: string
+          nom?: string
+          obligation_eci?: boolean
+          parent?: number | null
+          unite?: string
+          valeur_indicateur?: string | null
+        }
+      }
+      indicateur_objectif: {
+        Row: {
+          annee: number
+          collectivite_id: number
+          indicateur_id: string
+          modified_at: string
+          valeur: number | null
+        }
+        Insert: {
+          annee: number
+          collectivite_id: number
+          indicateur_id: string
+          modified_at?: string
+          valeur?: number | null
+        }
+        Update: {
+          annee?: number
+          collectivite_id?: number
+          indicateur_id?: string
+          modified_at?: string
+          valeur?: number | null
+        }
+      }
+      indicateur_parent: {
+        Row: {
+          id: number
+          nom: string
+          numero: string
+        }
+        Insert: {
+          id?: number
+          nom: string
+          numero: string
+        }
+        Update: {
+          id?: number
+          nom?: string
+          numero?: string
+        }
+      }
+      indicateur_personnalise_definition: {
+        Row: {
+          collectivite_id: number | null
+          commentaire: string
+          description: string
+          id: number
+          modified_at: string
+          modified_by: string
+          titre: string
+          unite: string
+        }
+        Insert: {
+          collectivite_id?: number | null
+          commentaire: string
+          description: string
+          id?: number
+          modified_at?: string
+          modified_by?: string
+          titre: string
+          unite: string
+        }
+        Update: {
+          collectivite_id?: number | null
+          commentaire?: string
+          description?: string
+          id?: number
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          unite?: string
+        }
+      }
+      indicateur_personnalise_objectif: {
+        Row: {
+          annee: number
+          collectivite_id: number
+          indicateur_id: number
+          modified_at: string
+          valeur: number | null
+        }
+        Insert: {
+          annee: number
+          collectivite_id: number
+          indicateur_id: number
+          modified_at?: string
+          valeur?: number | null
+        }
+        Update: {
+          annee?: number
+          collectivite_id?: number
+          indicateur_id?: number
+          modified_at?: string
+          valeur?: number | null
+        }
+      }
+      indicateur_personnalise_resultat: {
+        Row: {
+          annee: number
+          collectivite_id: number
+          indicateur_id: number
+          modified_at: string
+          valeur: number | null
+        }
+        Insert: {
+          annee: number
+          collectivite_id: number
+          indicateur_id: number
+          modified_at?: string
+          valeur?: number | null
+        }
+        Update: {
+          annee?: number
+          collectivite_id?: number
+          indicateur_id?: number
+          modified_at?: string
+          valeur?: number | null
+        }
+      }
+      indicateur_resultat: {
+        Row: {
+          annee: number
+          collectivite_id: number
+          indicateur_id: string
+          modified_at: string
+          valeur: number | null
+        }
+        Insert: {
+          annee: number
+          collectivite_id: number
+          indicateur_id: string
+          modified_at?: string
+          valeur?: number | null
+        }
+        Update: {
+          annee?: number
+          collectivite_id?: number
+          indicateur_id?: string
+          modified_at?: string
+          valeur?: number | null
+        }
+      }
+      indicateur_terristory_json: {
+        Row: {
+          created_at: string
+          indicateurs: Json
+        }
+        Insert: {
+          created_at?: string
+          indicateurs: Json
+        }
+        Update: {
+          created_at?: string
+          indicateurs?: Json
+        }
+      }
+      indicateurs_json: {
+        Row: {
+          created_at: string
+          indicateurs: Json
+        }
+        Insert: {
+          created_at?: string
+          indicateurs: Json
+        }
+        Update: {
+          created_at?: string
+          indicateurs?: Json
+        }
+      }
+      justification: {
+        Row: {
+          collectivite_id: number
+          modified_at: string
+          modified_by: string
+          question_id: string
+          texte: string
+        }
+        Insert: {
+          collectivite_id: number
+          modified_at: string
+          modified_by?: string
+          question_id: string
+          texte: string
+        }
+        Update: {
+          collectivite_id?: number
+          modified_at?: string
+          modified_by?: string
+          question_id?: string
+          texte?: string
+        }
+      }
+      labellisation: {
+        Row: {
+          annee: number | null
+          collectivite_id: number | null
+          etoiles: number
+          id: number
+          obtenue_le: string
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          score_programme: number | null
+          score_realise: number | null
+        }
+        Insert: {
+          annee?: number | null
+          collectivite_id?: number | null
+          etoiles: number
+          id?: number
+          obtenue_le: string
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          score_programme?: number | null
+          score_realise?: number | null
+        }
+        Update: {
+          annee?: number | null
+          collectivite_id?: number | null
+          etoiles?: number
+          id?: number
+          obtenue_le?: string
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+          score_programme?: number | null
+          score_realise?: number | null
+        }
+      }
+      labellisation_action_critere: {
+        Row: {
+          action_id: string
+          etoile: Database["labellisation"]["Enums"]["etoile"]
+          formulation: string
+          min_programme_percentage: number | null
+          min_programme_score: number | null
+          min_realise_percentage: number | null
+          min_realise_score: number | null
+          prio: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Insert: {
+          action_id: string
+          etoile: Database["labellisation"]["Enums"]["etoile"]
+          formulation: string
+          min_programme_percentage?: number | null
+          min_programme_score?: number | null
+          min_realise_percentage?: number | null
+          min_realise_score?: number | null
+          prio: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Update: {
+          action_id?: string
+          etoile?: Database["labellisation"]["Enums"]["etoile"]
+          formulation?: string
+          min_programme_percentage?: number | null
+          min_programme_score?: number | null
+          min_realise_percentage?: number | null
+          min_realise_score?: number | null
+          prio?: number
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+        }
+      }
+      labellisation_calendrier: {
+        Row: {
+          information: string
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Insert: {
+          information: string
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Update: {
+          information?: string
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+        }
+      }
+      labellisation_fichier_critere: {
+        Row: {
+          description: string
+          etoile: Database["labellisation"]["Enums"]["etoile"]
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Insert: {
+          description: string
+          etoile: Database["labellisation"]["Enums"]["etoile"]
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Update: {
+          description?: string
+          etoile?: Database["labellisation"]["Enums"]["etoile"]
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+        }
+      }
+      maintenance: {
+        Row: {
+          begins_at: string
+          ends_at: string
+          id: number
+        }
+        Insert: {
+          begins_at: string
+          ends_at: string
+          id?: number
+        }
+        Update: {
+          begins_at?: string
+          ends_at?: string
+          id?: number
+        }
+      }
+      partenaire_tag: {
+        Row: {
+          collectivite_id: number
+          id: number
+          nom: string
+        }
+        Insert: {
+          collectivite_id: number
+          id?: number
+          nom: string
+        }
+        Update: {
+          collectivite_id?: number
+          id?: number
+          nom?: string
+        }
+      }
+      personnalisation: {
+        Row: {
+          action_id: string
+          description: string
+          titre: string
+        }
+        Insert: {
+          action_id: string
+          description: string
+          titre: string
+        }
+        Update: {
+          action_id?: string
+          description?: string
+          titre?: string
+        }
+      }
+      personnalisation_consequence: {
+        Row: {
+          collectivite_id: number
+          consequences: Json
+          modified_at: string
+          payload_timestamp: string | null
+        }
+        Insert: {
+          collectivite_id: number
+          consequences: Json
+          modified_at?: string
+          payload_timestamp?: string | null
+        }
+        Update: {
+          collectivite_id?: number
+          consequences?: Json
+          modified_at?: string
+          payload_timestamp?: string | null
+        }
+      }
+      personnalisation_regle: {
+        Row: {
+          action_id: string
+          description: string
+          formule: string
+          modified_at: string
+          type: Database["public"]["Enums"]["regle_type"]
+        }
+        Insert: {
+          action_id: string
+          description: string
+          formule: string
+          modified_at?: string
+          type: Database["public"]["Enums"]["regle_type"]
+        }
+        Update: {
+          action_id?: string
+          description?: string
+          formule?: string
+          modified_at?: string
+          type?: Database["public"]["Enums"]["regle_type"]
+        }
+      }
+      personnalisations_json: {
+        Row: {
+          created_at: string
+          questions: Json
+          regles: Json
+        }
+        Insert: {
+          created_at?: string
+          questions: Json
+          regles: Json
+        }
+        Update: {
+          created_at?: string
+          questions?: Json
+          regles?: Json
+        }
+      }
+      personne_tag: {
+        Row: {
+          collectivite_id: number
+          id: number
+          nom: string
+        }
+        Insert: {
+          collectivite_id: number
+          id?: number
+          nom: string
+        }
+        Update: {
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> d8b0e10a9 (update types)
+          collectivite_id?: number
+          id?: number
+          nom?: string
+        }
+      }
+<<<<<<< HEAD
       post_audit_scores: {
         Row: {
           audit_id: number
@@ -1789,1070 +2363,1088 @@ export interface Database {
           scores?: Json
         }
       }
-      pre_audit_scores: {
-        Row: {
-          audit_id: number;
-          collectivite_id: number;
-          modified_at: string;
-          payload_timestamp: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          scores: Json;
-        };
-        Insert: {
-          audit_id: number;
-          collectivite_id: number;
-          modified_at: string;
-          payload_timestamp?: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          scores: Json;
-        };
-        Update: {
-          audit_id?: number;
+<<<<<<< HEAD
+=======
+=======
           collectivite_id?: number;
-          modified_at?: string;
-          payload_timestamp?: string | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"];
-          scores?: Json;
-        };
-      };
-      preuve_action: {
-        Row: {
-          action_id: string;
-          preuve_id: string;
-        };
-        Insert: {
-          action_id: string;
-          preuve_id: string;
-        };
-        Update: {
-          action_id?: string;
-          preuve_id?: string;
-        };
-      };
-      preuve_audit: {
-        Row: {
-          audit_id: number;
-          collectivite_id: number;
-          commentaire: string;
-          fichier_id: number | null;
-          id: number;
-          lien: Json | null;
-          modified_at: string;
-          modified_by: string;
-          titre: string;
-          url: string | null;
-        };
-        Insert: {
-          audit_id: number;
-          collectivite_id: number;
-          commentaire?: string;
-          fichier_id?: number | null;
           id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-        Update: {
-          audit_id?: number;
-          collectivite_id?: number;
-          commentaire?: string;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-      };
-      preuve_complementaire: {
-        Row: {
-          action_id: string;
-          collectivite_id: number;
-          commentaire: string;
-          fichier_id: number | null;
-          id: number;
-          lien: Json | null;
-          modified_at: string;
-          modified_by: string;
-          titre: string;
-          url: string | null;
-        };
-        Insert: {
-          action_id: string;
-          collectivite_id: number;
-          commentaire?: string;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-        Update: {
-          action_id?: string;
-          collectivite_id?: number;
-          commentaire?: string;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-      };
-      preuve_labellisation: {
-        Row: {
-          collectivite_id: number;
-          commentaire: string;
-          demande_id: number;
-          fichier_id: number | null;
-          id: number;
-          lien: Json | null;
-          modified_at: string;
-          modified_by: string;
-          titre: string;
-          url: string | null;
-        };
-        Insert: {
-          collectivite_id: number;
-          commentaire?: string;
-          demande_id: number;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-        Update: {
-          collectivite_id?: number;
-          commentaire?: string;
-          demande_id?: number;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-      };
-      preuve_rapport: {
-        Row: {
-          collectivite_id: number;
-          commentaire: string;
-          date: string;
-          fichier_id: number | null;
-          id: number;
-          lien: Json | null;
-          modified_at: string;
-          modified_by: string;
-          titre: string;
-          url: string | null;
-        };
-        Insert: {
-          collectivite_id: number;
-          commentaire?: string;
-          date: string;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-        Update: {
-          collectivite_id?: number;
-          commentaire?: string;
-          date?: string;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          titre?: string;
-          url?: string | null;
-        };
-      };
-      preuve_reglementaire: {
-        Row: {
-          collectivite_id: number;
-          commentaire: string;
-          fichier_id: number | null;
-          id: number;
-          lien: Json | null;
-          modified_at: string;
-          modified_by: string;
-          preuve_id: string;
-          titre: string;
-          url: string | null;
-        };
-        Insert: {
-          collectivite_id: number;
-          commentaire?: string;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          preuve_id: string;
-          titre?: string;
-          url?: string | null;
-        };
-        Update: {
-          collectivite_id?: number;
-          commentaire?: string;
-          fichier_id?: number | null;
-          id?: number;
-          lien?: Json | null;
-          modified_at?: string;
-          modified_by?: string;
-          preuve_id?: string;
-          titre?: string;
-          url?: string | null;
-        };
-      };
-      preuve_reglementaire_definition: {
-        Row: {
-          description: string;
-          id: string;
-          nom: string;
-        };
-        Insert: {
-          description: string;
-          id: string;
-          nom: string;
-        };
-        Update: {
-          description?: string;
-          id?: string;
           nom?: string;
         };
       };
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
+=======
+>>>>>>> d8b0e10a9 (update types)
+>>>>>>> a342e9c9a (update types)
+      pre_audit_scores: {
+        Row: {
+          audit_id: number
+          collectivite_id: number
+          modified_at: string
+          payload_timestamp: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          scores: Json
+        }
+        Insert: {
+          audit_id: number
+          collectivite_id: number
+          modified_at: string
+          payload_timestamp?: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          scores: Json
+        }
+        Update: {
+          audit_id?: number
+          collectivite_id?: number
+          modified_at?: string
+          payload_timestamp?: string | null
+          referentiel?: Database["public"]["Enums"]["referentiel"]
+          scores?: Json
+        }
+      }
+      preuve_action: {
+        Row: {
+          action_id: string
+          preuve_id: string
+        }
+        Insert: {
+          action_id: string
+          preuve_id: string
+        }
+        Update: {
+          action_id?: string
+          preuve_id?: string
+        }
+      }
+      preuve_audit: {
+        Row: {
+          audit_id: number
+          collectivite_id: number
+          commentaire: string
+          fichier_id: number | null
+          id: number
+          lien: Json | null
+          modified_at: string
+          modified_by: string
+          titre: string
+          url: string | null
+        }
+        Insert: {
+          audit_id: number
+          collectivite_id: number
+          commentaire?: string
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+        Update: {
+          audit_id?: number
+          collectivite_id?: number
+          commentaire?: string
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+      }
+      preuve_complementaire: {
+        Row: {
+          action_id: string
+          collectivite_id: number
+          commentaire: string
+          fichier_id: number | null
+          id: number
+          lien: Json | null
+          modified_at: string
+          modified_by: string
+          titre: string
+          url: string | null
+        }
+        Insert: {
+          action_id: string
+          collectivite_id: number
+          commentaire?: string
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+        Update: {
+          action_id?: string
+          collectivite_id?: number
+          commentaire?: string
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+      }
+      preuve_labellisation: {
+        Row: {
+          collectivite_id: number
+          commentaire: string
+          demande_id: number
+          fichier_id: number | null
+          id: number
+          lien: Json | null
+          modified_at: string
+          modified_by: string
+          titre: string
+          url: string | null
+        }
+        Insert: {
+          collectivite_id: number
+          commentaire?: string
+          demande_id: number
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+        Update: {
+          collectivite_id?: number
+          commentaire?: string
+          demande_id?: number
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+      }
+      preuve_rapport: {
+        Row: {
+          collectivite_id: number
+          commentaire: string
+          date: string
+          fichier_id: number | null
+          id: number
+          lien: Json | null
+          modified_at: string
+          modified_by: string
+          titre: string
+          url: string | null
+        }
+        Insert: {
+          collectivite_id: number
+          commentaire?: string
+          date: string
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+        Update: {
+          collectivite_id?: number
+          commentaire?: string
+          date?: string
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          titre?: string
+          url?: string | null
+        }
+      }
+      preuve_reglementaire: {
+        Row: {
+          collectivite_id: number
+          commentaire: string
+          fichier_id: number | null
+          id: number
+          lien: Json | null
+          modified_at: string
+          modified_by: string
+          preuve_id: string
+          titre: string
+          url: string | null
+        }
+        Insert: {
+          collectivite_id: number
+          commentaire?: string
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          preuve_id: string
+          titre?: string
+          url?: string | null
+        }
+        Update: {
+          collectivite_id?: number
+          commentaire?: string
+          fichier_id?: number | null
+          id?: number
+          lien?: Json | null
+          modified_at?: string
+          modified_by?: string
+          preuve_id?: string
+          titre?: string
+          url?: string | null
+        }
+      }
+      preuve_reglementaire_definition: {
+        Row: {
+          description: string
+          id: string
+          nom: string
+        }
+        Insert: {
+          description: string
+          id: string
+          nom: string
+        }
+        Update: {
+          description?: string
+          id?: string
+          nom?: string
+        }
+      }
       preuve_reglementaire_json: {
         Row: {
-          created_at: string;
-          preuves: Json;
-        };
+          created_at: string
+          preuves: Json
+        }
         Insert: {
-          created_at?: string;
-          preuves: Json;
-        };
+          created_at?: string
+          preuves: Json
+        }
         Update: {
-          created_at?: string;
-          preuves?: Json;
-        };
-      };
+          created_at?: string
+          preuves?: Json
+        }
+      }
       private_collectivite_membre: {
         Row: {
           champ_intervention:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
-          collectivite_id: number;
-          created_at: string;
-          details_fonction: string | null;
-          fonction: Database["public"]["Enums"]["membre_fonction"] | null;
-          modified_at: string;
-          user_id: string;
-        };
+            | null
+          collectivite_id: number
+          created_at: string
+          details_fonction: string | null
+          fonction: Database["public"]["Enums"]["membre_fonction"] | null
+          modified_at: string
+          user_id: string
+        }
         Insert: {
           champ_intervention?:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
-          collectivite_id: number;
-          created_at?: string;
-          details_fonction?: string | null;
-          fonction?: Database["public"]["Enums"]["membre_fonction"] | null;
-          modified_at?: string;
-          user_id: string;
-        };
+            | null
+          collectivite_id: number
+          created_at?: string
+          details_fonction?: string | null
+          fonction?: Database["public"]["Enums"]["membre_fonction"] | null
+          modified_at?: string
+          user_id: string
+        }
         Update: {
           champ_intervention?:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
-          collectivite_id?: number;
-          created_at?: string;
-          details_fonction?: string | null;
-          fonction?: Database["public"]["Enums"]["membre_fonction"] | null;
-          modified_at?: string;
-          user_id?: string;
-        };
-      };
+            | null
+          collectivite_id?: number
+          created_at?: string
+          details_fonction?: string | null
+          fonction?: Database["public"]["Enums"]["membre_fonction"] | null
+          modified_at?: string
+          user_id?: string
+        }
+      }
       private_utilisateur_droit: {
         Row: {
-          active: boolean;
-          collectivite_id: number;
-          created_at: string;
-          id: number;
-          invitation_id: string | null;
-          modified_at: string;
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"];
-          user_id: string;
-        };
+          active: boolean
+          collectivite_id: number
+          created_at: string
+          id: number
+          invitation_id: string | null
+          modified_at: string
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"]
+          user_id: string
+        }
         Insert: {
-          active: boolean;
-          collectivite_id: number;
-          created_at?: string;
-          id?: number;
-          invitation_id?: string | null;
-          modified_at?: string;
-          niveau_acces?: Database["public"]["Enums"]["niveau_acces"];
-          user_id: string;
-        };
+          active: boolean
+          collectivite_id: number
+          created_at?: string
+          id?: number
+          invitation_id?: string | null
+          modified_at?: string
+          niveau_acces?: Database["public"]["Enums"]["niveau_acces"]
+          user_id: string
+        }
         Update: {
-          active?: boolean;
-          collectivite_id?: number;
-          created_at?: string;
-          id?: number;
-          invitation_id?: string | null;
-          modified_at?: string;
-          niveau_acces?: Database["public"]["Enums"]["niveau_acces"];
-          user_id?: string;
-        };
-      };
+          active?: boolean
+          collectivite_id?: number
+          created_at?: string
+          id?: number
+          invitation_id?: string | null
+          modified_at?: string
+          niveau_acces?: Database["public"]["Enums"]["niveau_acces"]
+          user_id?: string
+        }
+      }
       question: {
         Row: {
-          description: string;
-          formulation: string;
-          id: string;
-          ordonnancement: number | null;
-          thematique_id: string | null;
-          type: Database["public"]["Enums"]["question_type"];
+          description: string
+          formulation: string
+          id: string
+          ordonnancement: number | null
+          thematique_id: string | null
+          type: Database["public"]["Enums"]["question_type"]
           types_collectivites_concernees:
             | Database["public"]["Enums"]["type_collectivite"][]
-            | null;
-        };
+            | null
+        }
         Insert: {
-          description: string;
-          formulation: string;
-          id: string;
-          ordonnancement?: number | null;
-          thematique_id?: string | null;
-          type: Database["public"]["Enums"]["question_type"];
+          description: string
+          formulation: string
+          id: string
+          ordonnancement?: number | null
+          thematique_id?: string | null
+          type: Database["public"]["Enums"]["question_type"]
           types_collectivites_concernees?:
             | Database["public"]["Enums"]["type_collectivite"][]
-            | null;
-        };
+            | null
+        }
         Update: {
-          description?: string;
-          formulation?: string;
-          id?: string;
-          ordonnancement?: number | null;
-          thematique_id?: string | null;
-          type?: Database["public"]["Enums"]["question_type"];
+          description?: string
+          formulation?: string
+          id?: string
+          ordonnancement?: number | null
+          thematique_id?: string | null
+          type?: Database["public"]["Enums"]["question_type"]
           types_collectivites_concernees?:
             | Database["public"]["Enums"]["type_collectivite"][]
-            | null;
-        };
-      };
+            | null
+        }
+      }
       question_action: {
         Row: {
-          action_id: string;
-          question_id: string;
-        };
+          action_id: string
+          question_id: string
+        }
         Insert: {
-          action_id: string;
-          question_id: string;
-        };
+          action_id: string
+          question_id: string
+        }
         Update: {
-          action_id?: string;
-          question_id?: string;
-        };
-      };
+          action_id?: string
+          question_id?: string
+        }
+      }
       question_choix: {
         Row: {
-          formulation: string | null;
-          id: string;
-          ordonnancement: number | null;
-          question_id: string | null;
-        };
+          formulation: string | null
+          id: string
+          ordonnancement: number | null
+          question_id: string | null
+        }
         Insert: {
-          formulation?: string | null;
-          id: string;
-          ordonnancement?: number | null;
-          question_id?: string | null;
-        };
+          formulation?: string | null
+          id: string
+          ordonnancement?: number | null
+          question_id?: string | null
+        }
         Update: {
-          formulation?: string | null;
-          id?: string;
-          ordonnancement?: number | null;
-          question_id?: string | null;
-        };
-      };
+          formulation?: string | null
+          id?: string
+          ordonnancement?: number | null
+          question_id?: string | null
+        }
+      }
       question_thematique: {
         Row: {
-          id: string;
-          nom: string | null;
-        };
+          id: string
+          nom: string | null
+        }
         Insert: {
-          id: string;
-          nom?: string | null;
-        };
+          id: string
+          nom?: string | null
+        }
         Update: {
-          id?: string;
-          nom?: string | null;
-        };
-      };
+          id?: string
+          nom?: string | null
+        }
+      }
       referentiel_json: {
         Row: {
-          children: Json;
-          created_at: string;
-          definitions: Json;
-        };
+          children: Json
+          created_at: string
+          definitions: Json
+        }
         Insert: {
-          children: Json;
-          created_at?: string;
-          definitions: Json;
-        };
+          children: Json
+          created_at?: string
+          definitions: Json
+        }
         Update: {
-          children?: Json;
-          created_at?: string;
-          definitions?: Json;
-        };
-      };
+          children?: Json
+          created_at?: string
+          definitions?: Json
+        }
+      }
       reponse_binaire: {
         Row: {
-          collectivite_id: number;
-          modified_at: string;
-          question_id: string;
-          reponse: boolean | null;
-        };
+          collectivite_id: number
+          modified_at: string
+          question_id: string
+          reponse: boolean | null
+        }
         Insert: {
-          collectivite_id: number;
-          modified_at?: string;
-          question_id: string;
-          reponse?: boolean | null;
-        };
+          collectivite_id: number
+          modified_at?: string
+          question_id: string
+          reponse?: boolean | null
+        }
         Update: {
-          collectivite_id?: number;
-          modified_at?: string;
-          question_id?: string;
-          reponse?: boolean | null;
-        };
-      };
+          collectivite_id?: number
+          modified_at?: string
+          question_id?: string
+          reponse?: boolean | null
+        }
+      }
       reponse_choix: {
         Row: {
-          collectivite_id: number;
-          modified_at: string;
-          question_id: string;
-          reponse: string | null;
-        };
+          collectivite_id: number
+          modified_at: string
+          question_id: string
+          reponse: string | null
+        }
         Insert: {
-          collectivite_id: number;
-          modified_at?: string;
-          question_id: string;
-          reponse?: string | null;
-        };
+          collectivite_id: number
+          modified_at?: string
+          question_id: string
+          reponse?: string | null
+        }
         Update: {
-          collectivite_id?: number;
-          modified_at?: string;
-          question_id?: string;
-          reponse?: string | null;
-        };
-      };
+          collectivite_id?: number
+          modified_at?: string
+          question_id?: string
+          reponse?: string | null
+        }
+      }
       reponse_proportion: {
         Row: {
-          collectivite_id: number;
-          modified_at: string;
-          question_id: string;
-          reponse: number | null;
-        };
+          collectivite_id: number
+          modified_at: string
+          question_id: string
+          reponse: number | null
+        }
         Insert: {
-          collectivite_id: number;
-          modified_at?: string;
-          question_id: string;
-          reponse?: number | null;
-        };
+          collectivite_id: number
+          modified_at?: string
+          question_id: string
+          reponse?: number | null
+        }
         Update: {
-          collectivite_id?: number;
-          modified_at?: string;
-          question_id?: string;
-          reponse?: number | null;
-        };
-      };
+          collectivite_id?: number
+          modified_at?: string
+          question_id?: string
+          reponse?: number | null
+        }
+      }
       service_tag: {
         Row: {
-          collectivite_id: number;
-          id: number;
-          nom: string;
-        };
+          collectivite_id: number
+          id: number
+          nom: string
+        }
         Insert: {
-          collectivite_id: number;
-          id?: number;
-          nom: string;
-        };
+          collectivite_id: number
+          id?: number
+          nom: string
+        }
         Update: {
-          collectivite_id?: number;
-          id?: number;
-          nom?: string;
-        };
-      };
+          collectivite_id?: number
+          id?: number
+          nom?: string
+        }
+      }
       sous_thematique: {
         Row: {
-          id: number;
-          sous_thematique: string;
-          thematique: string;
-        };
+          id: number
+          sous_thematique: string
+          thematique: string
+        }
         Insert: {
-          id?: number;
-          sous_thematique: string;
-          thematique: string;
-        };
+          id?: number
+          sous_thematique: string
+          thematique: string
+        }
         Update: {
-          id?: number;
-          sous_thematique?: string;
-          thematique?: string;
-        };
-      };
+          id?: number
+          sous_thematique?: string
+          thematique?: string
+        }
+      }
       structure_tag: {
         Row: {
-          collectivite_id: number;
-          id: number;
-          nom: string;
-        };
+          collectivite_id: number
+          id: number
+          nom: string
+        }
         Insert: {
-          collectivite_id: number;
-          id?: number;
-          nom: string;
-        };
+          collectivite_id: number
+          id?: number
+          nom: string
+        }
         Update: {
-          collectivite_id?: number;
-          id?: number;
-          nom?: string;
-        };
-      };
+          collectivite_id?: number
+          id?: number
+          nom?: string
+        }
+      }
       thematique: {
         Row: {
-          thematique: string;
-        };
+          thematique: string
+        }
         Insert: {
-          thematique: string;
-        };
+          thematique: string
+        }
         Update: {
-          thematique?: string;
-        };
-      };
+          thematique?: string
+        }
+      }
       type_tabular_score: {
         Row: {
-          action_id: string | null;
-          avancement: Database["public"]["Enums"]["avancement"] | null;
-          concerne: boolean | null;
-          desactive: boolean | null;
-          points_max_personnalises: number | null;
-          points_max_referentiel: number | null;
-          points_programmes: number | null;
-          points_realises: number | null;
-          points_restants: number | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          score_non_renseigne: number | null;
-          score_pas_fait: number | null;
-          score_programme: number | null;
-          score_realise: number | null;
-          score_realise_plus_programme: number | null;
-        };
+          action_id: string | null
+          avancement: Database["public"]["Enums"]["avancement"] | null
+          concerne: boolean | null
+          desactive: boolean | null
+          points_max_personnalises: number | null
+          points_max_referentiel: number | null
+          points_programmes: number | null
+          points_realises: number | null
+          points_restants: number | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          score_non_renseigne: number | null
+          score_pas_fait: number | null
+          score_programme: number | null
+          score_realise: number | null
+          score_realise_plus_programme: number | null
+        }
         Insert: {
-          action_id?: string | null;
-          avancement?: Database["public"]["Enums"]["avancement"] | null;
-          concerne?: boolean | null;
-          desactive?: boolean | null;
-          points_max_personnalises?: number | null;
-          points_max_referentiel?: number | null;
-          points_programmes?: number | null;
-          points_realises?: number | null;
-          points_restants?: number | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
-          score_non_renseigne?: number | null;
-          score_pas_fait?: number | null;
-          score_programme?: number | null;
-          score_realise?: number | null;
-          score_realise_plus_programme?: number | null;
-        };
+          action_id?: string | null
+          avancement?: Database["public"]["Enums"]["avancement"] | null
+          concerne?: boolean | null
+          desactive?: boolean | null
+          points_max_personnalises?: number | null
+          points_max_referentiel?: number | null
+          points_programmes?: number | null
+          points_realises?: number | null
+          points_restants?: number | null
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null
+          score_non_renseigne?: number | null
+          score_pas_fait?: number | null
+          score_programme?: number | null
+          score_realise?: number | null
+          score_realise_plus_programme?: number | null
+        }
         Update: {
-          action_id?: string | null;
-          avancement?: Database["public"]["Enums"]["avancement"] | null;
-          concerne?: boolean | null;
-          desactive?: boolean | null;
-          points_max_personnalises?: number | null;
-          points_max_referentiel?: number | null;
-          points_programmes?: number | null;
-          points_realises?: number | null;
-          points_restants?: number | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
-          score_non_renseigne?: number | null;
-          score_pas_fait?: number | null;
-          score_programme?: number | null;
-          score_realise?: number | null;
-          score_realise_plus_programme?: number | null;
-        };
-      };
+          action_id?: string | null
+          avancement?: Database["public"]["Enums"]["avancement"] | null
+          concerne?: boolean | null
+          desactive?: boolean | null
+          points_max_personnalises?: number | null
+          points_max_referentiel?: number | null
+          points_programmes?: number | null
+          points_realises?: number | null
+          points_restants?: number | null
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null
+          score_non_renseigne?: number | null
+          score_pas_fait?: number | null
+          score_programme?: number | null
+          score_realise?: number | null
+          score_realise_plus_programme?: number | null
+        }
+      }
       usage: {
         Row: {
-          action: Database["public"]["Enums"]["usage_action"];
-          collectivite_id: number | null;
-          fonction: Database["public"]["Enums"]["usage_fonction"];
-          page: Database["public"]["Enums"]["visite_page"] | null;
-          time: string;
-          user_id: string | null;
-        };
+          action: Database["public"]["Enums"]["usage_action"]
+          collectivite_id: number | null
+          fonction: Database["public"]["Enums"]["usage_fonction"]
+          page: Database["public"]["Enums"]["visite_page"] | null
+          time: string
+          user_id: string | null
+        }
         Insert: {
-          action: Database["public"]["Enums"]["usage_action"];
-          collectivite_id?: number | null;
-          fonction: Database["public"]["Enums"]["usage_fonction"];
-          page?: Database["public"]["Enums"]["visite_page"] | null;
-          time?: string;
-          user_id?: string | null;
-        };
+          action: Database["public"]["Enums"]["usage_action"]
+          collectivite_id?: number | null
+          fonction: Database["public"]["Enums"]["usage_fonction"]
+          page?: Database["public"]["Enums"]["visite_page"] | null
+          time?: string
+          user_id?: string | null
+        }
         Update: {
-          action?: Database["public"]["Enums"]["usage_action"];
-          collectivite_id?: number | null;
-          fonction?: Database["public"]["Enums"]["usage_fonction"];
-          page?: Database["public"]["Enums"]["visite_page"] | null;
-          time?: string;
-          user_id?: string | null;
-        };
-      };
+          action?: Database["public"]["Enums"]["usage_action"]
+          collectivite_id?: number | null
+          fonction?: Database["public"]["Enums"]["usage_fonction"]
+          page?: Database["public"]["Enums"]["visite_page"] | null
+          time?: string
+          user_id?: string | null
+        }
+      }
       visite: {
         Row: {
-          collectivite_id: number | null;
-          onglet: Database["public"]["Enums"]["visite_onglet"] | null;
-          page: Database["public"]["Enums"]["visite_page"];
-          tag: Database["public"]["Enums"]["visite_tag"] | null;
-          time: string;
-          user_id: string | null;
-        };
+          collectivite_id: number | null
+          onglet: Database["public"]["Enums"]["visite_onglet"] | null
+          page: Database["public"]["Enums"]["visite_page"]
+          tag: Database["public"]["Enums"]["visite_tag"] | null
+          time: string
+          user_id: string | null
+        }
         Insert: {
-          collectivite_id?: number | null;
-          onglet?: Database["public"]["Enums"]["visite_onglet"] | null;
-          page: Database["public"]["Enums"]["visite_page"];
-          tag?: Database["public"]["Enums"]["visite_tag"] | null;
-          time?: string;
-          user_id?: string | null;
-        };
+          collectivite_id?: number | null
+          onglet?: Database["public"]["Enums"]["visite_onglet"] | null
+          page: Database["public"]["Enums"]["visite_page"]
+          tag?: Database["public"]["Enums"]["visite_tag"] | null
+          time?: string
+          user_id?: string | null
+        }
         Update: {
-          collectivite_id?: number | null;
-          onglet?: Database["public"]["Enums"]["visite_onglet"] | null;
-          page?: Database["public"]["Enums"]["visite_page"];
-          tag?: Database["public"]["Enums"]["visite_tag"] | null;
-          time?: string;
-          user_id?: string | null;
-        };
-      };
-    };
+          collectivite_id?: number | null
+          onglet?: Database["public"]["Enums"]["visite_onglet"] | null
+          page?: Database["public"]["Enums"]["visite_page"]
+          tag?: Database["public"]["Enums"]["visite_tag"] | null
+          time?: string
+          user_id?: string | null
+        }
+      }
+    }
     Views: {
       action_audit_state: {
         Row: {
-          action_id: string | null;
-          audit_id: number | null;
-          avis: string | null;
-          collectivite_id: number | null;
-          ordre_du_jour: boolean | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          state_id: number | null;
-          statut: Database["public"]["Enums"]["audit_statut"] | null;
-        };
-      };
+          action_id: string | null
+          audit_id: number | null
+          avis: string | null
+          collectivite_id: number | null
+          ordre_du_jour: boolean | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          state_id: number | null
+          statut: Database["public"]["Enums"]["audit_statut"] | null
+        }
+      }
       action_children: {
         Row: {
-          children: unknown[] | null;
-          depth: number | null;
-          id: string | null;
-        };
-      };
+          children: unknown[] | null
+          depth: number | null
+          id: string | null
+        }
+      }
       action_definition_summary: {
         Row: {
-          children: unknown[] | null;
-          depth: number | null;
-          description: string | null;
-          have_contexte: boolean | null;
-          have_exemples: boolean | null;
-          have_perimetre_evaluation: boolean | null;
-          have_preuve: boolean | null;
-          have_questions: boolean | null;
-          have_reduction_potentiel: boolean | null;
-          have_ressources: boolean | null;
-          id: string | null;
-          identifiant: string | null;
-          nom: string | null;
-          phase: Database["public"]["Enums"]["action_categorie"] | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          type: Database["public"]["Enums"]["action_type"] | null;
-        };
-      };
+          children: unknown[] | null
+          depth: number | null
+          description: string | null
+          have_contexte: boolean | null
+          have_exemples: boolean | null
+          have_perimetre_evaluation: boolean | null
+          have_preuve: boolean | null
+          have_questions: boolean | null
+          have_reduction_potentiel: boolean | null
+          have_ressources: boolean | null
+          id: string | null
+          identifiant: string | null
+          nom: string | null
+          phase: Database["public"]["Enums"]["action_categorie"] | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          type: Database["public"]["Enums"]["action_type"] | null
+        }
+      }
       action_discussion_feed: {
         Row: {
-          action_id: string | null;
-          collectivite_id: number | null;
-          commentaires: Json[] | null;
-          created_at: string | null;
-          created_by: string | null;
-          id: number | null;
-          modified_at: string | null;
-          status:
-            | Database["public"]["Enums"]["action_discussion_statut"]
-            | null;
-        };
-      };
+          action_id: string | null
+          collectivite_id: number | null
+          commentaires: Json[] | null
+          created_at: string | null
+          created_by: string | null
+          id: number | null
+          modified_at: string | null
+          status: Database["public"]["Enums"]["action_discussion_statut"] | null
+        }
+      }
       action_statuts: {
         Row: {
-          action_id: string | null;
-          ascendants: unknown[] | null;
-          avancement: Database["public"]["Enums"]["avancement"] | null;
+          action_id: string | null
+          ascendants: unknown[] | null
+          avancement: Database["public"]["Enums"]["avancement"] | null
           avancement_descendants:
             | Database["public"]["Enums"]["avancement"][]
-            | null;
-          avancement_detaille: number[] | null;
-          collectivite_id: number | null;
-          concerne: boolean | null;
-          depth: number | null;
-          desactive: boolean | null;
-          descendants: unknown[] | null;
-          description: string | null;
-          have_children: boolean | null;
-          have_contexte: boolean | null;
-          have_exemples: boolean | null;
-          have_perimetre_evaluation: boolean | null;
-          have_preuve: boolean | null;
-          have_reduction_potentiel: boolean | null;
-          have_ressources: boolean | null;
-          identifiant: string | null;
-          nom: string | null;
-          non_concerne: boolean | null;
-          phase: Database["public"]["Enums"]["action_categorie"] | null;
-          points_max_personnalises: number | null;
-          points_max_referentiel: number | null;
-          points_programmes: number | null;
-          points_realises: number | null;
-          points_restants: number | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          score_non_renseigne: number | null;
-          score_pas_fait: number | null;
-          score_programme: number | null;
-          score_realise: number | null;
-          score_realise_plus_programme: number | null;
-          type: Database["public"]["Enums"]["action_type"] | null;
-        };
-      };
+            | null
+          avancement_detaille: number[] | null
+          collectivite_id: number | null
+          concerne: boolean | null
+          depth: number | null
+          desactive: boolean | null
+          descendants: unknown[] | null
+          description: string | null
+          have_children: boolean | null
+          have_contexte: boolean | null
+          have_exemples: boolean | null
+          have_perimetre_evaluation: boolean | null
+          have_preuve: boolean | null
+          have_reduction_potentiel: boolean | null
+          have_ressources: boolean | null
+          identifiant: string | null
+          nom: string | null
+          non_concerne: boolean | null
+          phase: Database["public"]["Enums"]["action_categorie"] | null
+          points_max_personnalises: number | null
+          points_max_referentiel: number | null
+          points_programmes: number | null
+          points_realises: number | null
+          points_restants: number | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          score_non_renseigne: number | null
+          score_pas_fait: number | null
+          score_programme: number | null
+          score_realise: number | null
+          score_realise_plus_programme: number | null
+          type: Database["public"]["Enums"]["action_type"] | null
+        }
+      }
       action_title: {
         Row: {
-          children: unknown[] | null;
-          id: string | null;
-          identifiant: string | null;
-          nom: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          type: Database["public"]["Enums"]["action_type"] | null;
-        };
-      };
+          children: unknown[] | null
+          id: string | null
+          identifiant: string | null
+          nom: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          type: Database["public"]["Enums"]["action_type"] | null
+        }
+      }
       active_collectivite: {
         Row: {
-          collectivite_id: number | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          nom: string | null
+        }
+      }
       audit: {
         Row: {
-          collectivite_id: number | null;
-          date_debut: string | null;
-          date_fin: string | null;
-          demande_id: number | null;
-          id: number | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          valide: boolean | null;
-        };
+          collectivite_id: number | null
+          date_debut: string | null
+          date_fin: string | null
+          demande_id: number | null
+          id: number | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          valide: boolean | null
+        }
         Insert: {
-          collectivite_id?: number | null;
-          date_debut?: string | null;
-          date_fin?: string | null;
-          demande_id?: number | null;
-          id?: number | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
-          valide?: boolean | null;
-        };
+          collectivite_id?: number | null
+          date_debut?: string | null
+          date_fin?: string | null
+          demande_id?: number | null
+          id?: number | null
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null
+          valide?: boolean | null
+        }
         Update: {
-          collectivite_id?: number | null;
-          date_debut?: string | null;
-          date_fin?: string | null;
-          demande_id?: number | null;
-          id?: number | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
-          valide?: boolean | null;
-        };
-      };
+          collectivite_id?: number | null
+          date_debut?: string | null
+          date_fin?: string | null
+          demande_id?: number | null
+          id?: number | null
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null
+          valide?: boolean | null
+        }
+      }
       audit_en_cours: {
         Row: {
-          collectivite_id: number | null;
-          date_debut: string | null;
-          date_fin: string | null;
-          demande_id: number | null;
-          id: number | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          valide: boolean | null;
-        };
+          collectivite_id: number | null
+          date_debut: string | null
+          date_fin: string | null
+          demande_id: number | null
+          id: number | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          valide: boolean | null
+        }
         Insert: {
-          collectivite_id?: number | null;
-          date_debut?: string | null;
-          date_fin?: string | null;
-          demande_id?: number | null;
-          id?: number | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
-          valide?: boolean | null;
-        };
+          collectivite_id?: number | null
+          date_debut?: string | null
+          date_fin?: string | null
+          demande_id?: number | null
+          id?: number | null
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null
+          valide?: boolean | null
+        }
         Update: {
-          collectivite_id?: number | null;
-          date_debut?: string | null;
-          date_fin?: string | null;
-          demande_id?: number | null;
-          id?: number | null;
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
-          valide?: boolean | null;
-        };
-      };
+          collectivite_id?: number | null
+          date_debut?: string | null
+          date_fin?: string | null
+          demande_id?: number | null
+          id?: number | null
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null
+          valide?: boolean | null
+        }
+      }
       auditeurs: {
         Row: {
-          audit_id: number | null;
-          collectivite_id: number | null;
-          noms: Json | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-        };
-      };
+          audit_id: number | null
+          collectivite_id: number | null
+          noms: Json | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+        }
+      }
       audits: {
         Row: {
-          audit: unknown | null;
-          collectivite_id: number | null;
-          demande: unknown | null;
-          is_cot: boolean | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-        };
-      };
+          audit: unknown | null
+          collectivite_id: number | null
+          demande: unknown | null
+          is_cot: boolean | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+        }
+      }
       axe_descendants: {
         Row: {
-          axe_id: number | null;
-          depth: number | null;
-          descendants: number[] | null;
-          parents: number[] | null;
-        };
-      };
+          axe_id: number | null
+          depth: number | null
+          descendants: number[] | null
+          parents: number[] | null
+        }
+      }
       bibliotheque_annexe: {
         Row: {
-          collectivite_id: number | null;
-          commentaire: string | null;
-          created_at: string | null;
-          created_by: string | null;
-          created_by_nom: string | null;
-          fiche_id: number | null;
-          fichier: Json | null;
-          id: number | null;
-          lien: Json | null;
-          plan_ids: number[] | null;
-        };
-      };
+          collectivite_id: number | null
+          commentaire: string | null
+          created_at: string | null
+          created_by: string | null
+          created_by_nom: string | null
+          fiche_id: number | null
+          fichier: Json | null
+          id: number | null
+          lien: Json | null
+          plan_ids: number[] | null
+        }
+      }
       bibliotheque_fichier: {
         Row: {
-          bucket_id: string | null;
-          collectivite_id: number | null;
-          file_id: string | null;
-          filename: string | null;
-          filesize: number | null;
-          hash: string | null;
-          id: number | null;
-        };
-      };
+          bucket_id: string | null
+          collectivite_id: number | null
+          file_id: string | null
+          filename: string | null
+          filesize: number | null
+          hash: string | null
+          id: number | null
+        }
+      }
       business_action_children: {
         Row: {
-          children: unknown[] | null;
-          id: string | null;
-          parent: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-        };
-      };
+          children: unknown[] | null
+          id: string | null
+          parent: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+        }
+      }
       business_action_statut: {
         Row: {
-          action_id: string | null;
-          avancement: Database["public"]["Enums"]["avancement"] | null;
-          avancement_detaille: number[] | null;
-          collectivite_id: number | null;
-          concerne: boolean | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-        };
-      };
+          action_id: string | null
+          avancement: Database["public"]["Enums"]["avancement"] | null
+          avancement_detaille: number[] | null
+          collectivite_id: number | null
+          concerne: boolean | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+        }
+      }
       business_reponse: {
         Row: {
-          collectivite_id: number | null;
-          reponses: Json[] | null;
-        };
-      };
+          collectivite_id: number | null
+          reponses: Json[] | null
+        }
+      }
       client_action_statut: {
         Row: {
-          action_id: string | null;
-          avancement: Database["public"]["Enums"]["avancement"] | null;
-          collectivite_id: number | null;
-          concerne: boolean | null;
-          modified_by: string | null;
-        };
+          action_id: string | null
+          avancement: Database["public"]["Enums"]["avancement"] | null
+          collectivite_id: number | null
+          concerne: boolean | null
+          modified_by: string | null
+        }
         Insert: {
-          action_id?: string | null;
-          avancement?: Database["public"]["Enums"]["avancement"] | null;
-          collectivite_id?: number | null;
-          concerne?: boolean | null;
-          modified_by?: string | null;
-        };
+          action_id?: string | null
+          avancement?: Database["public"]["Enums"]["avancement"] | null
+          collectivite_id?: number | null
+          concerne?: boolean | null
+          modified_by?: string | null
+        }
         Update: {
-          action_id?: string | null;
-          avancement?: Database["public"]["Enums"]["avancement"] | null;
-          collectivite_id?: number | null;
-          concerne?: boolean | null;
-          modified_by?: string | null;
-        };
-      };
+          action_id?: string | null
+          avancement?: Database["public"]["Enums"]["avancement"] | null
+          collectivite_id?: number | null
+          concerne?: boolean | null
+          modified_by?: string | null
+        }
+      }
       collectivite_carte_identite: {
         Row: {
-          code_siren_insee: string | null;
-          collectivite_id: number | null;
-          departement_name: string | null;
-          is_cot: boolean | null;
-          nom: string | null;
-          population_source: string | null;
-          population_totale: number | null;
-          region_name: string | null;
+          code_siren_insee: string | null
+          collectivite_id: number | null
+          departement_name: string | null
+          is_cot: boolean | null
+          nom: string | null
+          population_source: string | null
+          population_totale: number | null
+          region_name: string | null
           type_collectivite:
             | Database["public"]["Enums"]["type_collectivite"]
-            | null;
-        };
-      };
+            | null
+        }
+      }
       collectivite_identite: {
         Row: {
-          id: number | null;
-          localisation: string[] | null;
-          population: string[] | null;
-          type: Database["public"]["Enums"]["type_collectivite"][] | null;
-        };
-      };
+          id: number | null
+          localisation: string[] | null
+          population: string[] | null
+          type: Database["public"]["Enums"]["type_collectivite"][] | null
+        }
+      }
       collectivite_niveau_acces: {
         Row: {
-          access_restreint: boolean | null;
-          collectivite_id: number | null;
-          est_auditeur: boolean | null;
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null;
-          nom: string | null;
-        };
-      };
+          access_restreint: boolean | null
+          collectivite_id: number | null
+          est_auditeur: boolean | null
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null
+          nom: string | null
+        }
+      }
       comparaison_scores_audit: {
         Row: {
-          action_id: string | null;
-          collectivite_id: number | null;
-          courant: Database["public"]["CompositeTypes"]["tabular_score"] | null;
+          action_id: string | null
+          collectivite_id: number | null
+          courant: Database["public"]["CompositeTypes"]["tabular_score"] | null
           pre_audit:
             | Database["public"]["CompositeTypes"]["tabular_score"]
-            | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-        };
-      };
+            | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+        }
+      }
       crm_collectivites: {
         Row: {
-          code_siren_insee: string | null;
-          collectivite_id: number | null;
-          cot: boolean | null;
-          departement_code: string | null;
-          departement_name: string | null;
-          key: string | null;
-          nature_collectivite: string | null;
-          nom: string | null;
-          population_totale: number | null;
-          region_code: string | null;
-          region_name: string | null;
+          code_siren_insee: string | null
+          collectivite_id: number | null
+          cot: boolean | null
+          departement_code: string | null
+          departement_name: string | null
+          key: string | null
+          nature_collectivite: string | null
+          nom: string | null
+          population_totale: number | null
+          region_code: string | null
+          region_name: string | null
           type_collectivite:
             | Database["public"]["Enums"]["type_collectivite"]
-            | null;
-        };
-      };
+            | null
+        }
+      }
       crm_droits: {
         Row: {
-          champ_intervention: string | null;
-          collectivite_id: number | null;
-          collectivite_key: string | null;
-          details_fonction: string | null;
-          fonction: Database["public"]["Enums"]["membre_fonction"] | null;
-          key: string | null;
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null;
-          user_id: string | null;
-          user_key: string | null;
-        };
-      };
+          champ_intervention: string | null
+          collectivite_id: number | null
+          collectivite_key: string | null
+          details_fonction: string | null
+          fonction: Database["public"]["Enums"]["membre_fonction"] | null
+          key: string | null
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null
+          user_id: string | null
+          user_key: string | null
+        }
+      }
       crm_labellisations: {
         Row: {
-          annee: number | null;
-          collectivite_key: string | null;
-          etoiles: number | null;
-          id: number | null;
-          obtenue_le: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          score_programme: number | null;
-          score_realise: number | null;
-        };
-      };
+          annee: number | null
+          collectivite_key: string | null
+          etoiles: number | null
+          id: number | null
+          obtenue_le: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          score_programme: number | null
+          score_realise: number | null
+        }
+      }
       crm_personnes: {
         Row: {
-          email: string | null;
-          key: string | null;
-          nom: string | null;
-          prenom: string | null;
-          telephone: string | null;
-          user_id: string | null;
-        };
+          email: string | null
+          key: string | null
+          nom: string | null
+          prenom: string | null
+          telephone: string | null
+          user_id: string | null
+        }
         Insert: {
-          email?: never;
-          key?: never;
-          nom?: never;
-          prenom?: never;
-          telephone?: never;
-          user_id?: string | null;
-        };
+          email?: never
+          key?: never
+          nom?: never
+          prenom?: never
+          telephone?: never
+          user_id?: string | null
+        }
         Update: {
-          email?: never;
-          key?: never;
-          nom?: never;
-          prenom?: never;
-          telephone?: never;
-          user_id?: string | null;
-        };
-      };
+          email?: never
+          key?: never
+          nom?: never
+          prenom?: never
+          telephone?: never
+          user_id?: string | null
+        }
+      }
       crm_usages: {
         Row: {
-          collectivite_id: number | null;
-          completude_cae: number | null;
-          completude_eci: number | null;
-          fiches: number | null;
-          indicateurs_perso: number | null;
-          key: string | null;
-          plans: number | null;
-          premier_rattachement: string | null;
-          resultats_indicateurs: number | null;
-          resultats_indicateurs_perso: number | null;
-        };
-      };
+          collectivite_id: number | null
+          completude_cae: number | null
+          completude_eci: number | null
+          fiches: number | null
+          indicateurs_perso: number | null
+          key: string | null
+          plans: number | null
+          premier_rattachement: string | null
+          resultats_indicateurs: number | null
+          resultats_indicateurs_perso: number | null
+        }
+      }
       departement: {
         Row: {
-          code: string | null;
-          libelle: string | null;
-          region_code: string | null;
-        };
+          code: string | null
+          libelle: string | null
+          region_code: string | null
+        }
         Insert: {
-          code?: string | null;
-          libelle?: string | null;
-          region_code?: string | null;
-        };
+          code?: string | null
+          libelle?: string | null
+          region_code?: string | null
+        }
         Update: {
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> d8b0e10a9 (update types)
+>>>>>>> a342e9c9a (update types)
           code?: string | null
           libelle?: string | null
           region_code?: string | null
         }
       }
+<<<<<<< HEAD
       export_score_audit: {
         Row: {
           collectivite: string | null
@@ -2869,3611 +3461,3633 @@ export interface Database {
           signataire: string | null
         }
       }
+<<<<<<< HEAD
+=======
+=======
+          code?: string | null;
+          libelle?: string | null;
+          region_code?: string | null;
+        };
+      };
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
+=======
+>>>>>>> d8b0e10a9 (update types)
+>>>>>>> a342e9c9a (update types)
       fiche_action_personne_pilote: {
         Row: {
-          collectivite_id: number | null;
-          nom: string | null;
-          tag_id: number | null;
-          user_id: string | null;
-        };
-      };
+          collectivite_id: number | null
+          nom: string | null
+          tag_id: number | null
+          user_id: string | null
+        }
+      }
       fiche_action_personne_referente: {
         Row: {
-          collectivite_id: number | null;
-          nom: string | null;
-          tag_id: number | null;
-          user_id: string | null;
-        };
-      };
+          collectivite_id: number | null
+          nom: string | null
+          tag_id: number | null
+          user_id: string | null
+        }
+      }
       fiche_resume: {
         Row: {
-          collectivite_id: number | null;
-          id: number | null;
-          modified_at: string | null;
-          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null;
-          plans: unknown[] | null;
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
-          titre: string | null;
-        };
-      };
+          collectivite_id: number | null
+          id: number | null
+          modified_at: string | null
+          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
+          plans: unknown[] | null
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
+          titre: string | null
+        }
+      }
       fiches_action: {
         Row: {
-          actions: unknown[] | null;
-          amelioration_continue: boolean | null;
-          axes: unknown[] | null;
-          budget_previsionnel: number | null;
-          calendrier: string | null;
-          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null;
-          collectivite_id: number | null;
-          created_at: string | null;
-          date_debut: string | null;
-          date_fin_provisoire: string | null;
-          description: string | null;
-          fiches_liees: unknown[] | null;
-          financements: string | null;
+          actions: unknown[] | null
+          amelioration_continue: boolean | null
+          axes: unknown[] | null
+          budget_previsionnel: number | null
+          calendrier: string | null
+          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null
+          collectivite_id: number | null
+          created_at: string | null
+          date_debut: string | null
+          date_fin_provisoire: string | null
+          description: string | null
+          fiches_liees: unknown[] | null
+          financements: string | null
           financeurs:
             | Database["public"]["CompositeTypes"]["financeur_montant"][]
-            | null;
-          id: number | null;
+            | null
+          id: number | null
           indicateurs:
             | Database["public"]["CompositeTypes"]["indicateur_generique"][]
-            | null;
-          maj_termine: boolean | null;
-          modified_at: string | null;
-          modified_by: string | null;
+            | null
+          maj_termine: boolean | null
+          modified_at: string | null
+          modified_by: string | null
           niveau_priorite:
             | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null;
-          notes_complementaires: string | null;
-          objectifs: string | null;
-          partenaires: unknown[] | null;
+            | null
+          notes_complementaires: string | null
+          objectifs: string | null
+          partenaires: unknown[] | null
           piliers_eci:
             | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null;
-          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null;
-          referents: Database["public"]["CompositeTypes"]["personne"][] | null;
-          ressources: string | null;
+            | null
+          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
+          referents: Database["public"]["CompositeTypes"]["personne"][] | null
+          ressources: string | null
           resultats_attendus:
             | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null;
-          services: unknown[] | null;
-          sous_thematiques: unknown[] | null;
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
-          structures: unknown[] | null;
-          thematiques: unknown[] | null;
-          titre: string | null;
-        };
-      };
+            | null
+          services: unknown[] | null
+          sous_thematiques: unknown[] | null
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
+          structures: unknown[] | null
+          thematiques: unknown[] | null
+          titre: string | null
+        }
+      }
       fiches_liees_par_fiche: {
         Row: {
-          fiche_id: number | null;
-          fiche_liee_id: number | null;
-        };
-      };
+          fiche_id: number | null
+          fiche_liee_id: number | null
+        }
+      }
       historique: {
         Row: {
-          action_id: string | null;
-          action_identifiant: string | null;
-          action_ids: unknown[] | null;
-          action_nom: string | null;
-          avancement: Database["public"]["Enums"]["avancement"] | null;
-          avancement_detaille: number[] | null;
-          collectivite_id: number | null;
-          concerne: boolean | null;
-          justification: string | null;
-          modified_at: string | null;
-          modified_by_id: string | null;
-          modified_by_nom: string | null;
-          precision: string | null;
-          previous_avancement: Database["public"]["Enums"]["avancement"] | null;
-          previous_avancement_detaille: number[] | null;
-          previous_concerne: boolean | null;
-          previous_justification: string | null;
-          previous_modified_at: string | null;
-          previous_modified_by_id: string | null;
-          previous_precision: string | null;
-          previous_reponse: Json | null;
-          question_formulation: string | null;
-          question_id: string | null;
-          question_type: Database["public"]["Enums"]["question_type"] | null;
-          reponse: Json | null;
-          tache_identifiant: string | null;
-          tache_nom: string | null;
-          thematique_id: string | null;
-          thematique_nom: string | null;
-          type: string | null;
-        };
-      };
+          action_id: string | null
+          action_identifiant: string | null
+          action_ids: unknown[] | null
+          action_nom: string | null
+          avancement: Database["public"]["Enums"]["avancement"] | null
+          avancement_detaille: number[] | null
+          collectivite_id: number | null
+          concerne: boolean | null
+          justification: string | null
+          modified_at: string | null
+          modified_by_id: string | null
+          modified_by_nom: string | null
+          precision: string | null
+          previous_avancement: Database["public"]["Enums"]["avancement"] | null
+          previous_avancement_detaille: number[] | null
+          previous_concerne: boolean | null
+          previous_justification: string | null
+          previous_modified_at: string | null
+          previous_modified_by_id: string | null
+          previous_precision: string | null
+          previous_reponse: Json | null
+          question_formulation: string | null
+          question_id: string | null
+          question_type: Database["public"]["Enums"]["question_type"] | null
+          reponse: Json | null
+          tache_identifiant: string | null
+          tache_nom: string | null
+          thematique_id: string | null
+          thematique_nom: string | null
+          type: string | null
+        }
+      }
       historique_utilisateur: {
         Row: {
-          collectivite_id: number | null;
-          modified_by_id: string | null;
-          modified_by_nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          modified_by_id: string | null
+          modified_by_nom: string | null
+        }
+      }
       indicateur_summary: {
         Row: {
-          collectivite_id: number | null;
+          collectivite_id: number | null
           indicateur_group:
             | Database["public"]["Enums"]["indicateur_group"]
-            | null;
-          indicateur_id: string | null;
-          resultats: number | null;
-        };
-      };
+            | null
+          indicateur_id: string | null
+          resultats: number | null
+        }
+      }
       indicateurs_collectivite: {
         Row: {
-          collectivite_id: number | null;
-          description: string | null;
-          indicateur_id: string | null;
-          indicateur_personnalise_id: number | null;
-          nom: string | null;
-          unite: string | null;
-        };
-      };
+          collectivite_id: number | null
+          description: string | null
+          indicateur_id: string | null
+          indicateur_personnalise_id: number | null
+          nom: string | null
+          unite: string | null
+        }
+      }
       mes_collectivites: {
         Row: {
-          collectivite_id: number | null;
-          est_auditeur: boolean | null;
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          est_auditeur: boolean | null
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null
+          nom: string | null
+        }
+      }
       named_collectivite: {
         Row: {
-          collectivite_id: number | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          nom: string | null
+        }
+      }
       ongoing_maintenance: {
         Row: {
-          begins_at: string | null;
-          ends_at: string | null;
-          now: string | null;
-        };
-      };
+          begins_at: string | null
+          ends_at: string | null
+          now: string | null
+        }
+      }
       pg_all_foreign_keys: {
         Row: {
-          fk_columns: unknown[] | null;
-          fk_constraint_name: unknown | null;
-          fk_schema_name: unknown | null;
-          fk_table_name: unknown | null;
-          fk_table_oid: unknown | null;
-          is_deferrable: boolean | null;
-          is_deferred: boolean | null;
-          match_type: string | null;
-          on_delete: string | null;
-          on_update: string | null;
-          pk_columns: unknown[] | null;
-          pk_constraint_name: unknown | null;
-          pk_index_name: unknown | null;
-          pk_schema_name: unknown | null;
-          pk_table_name: unknown | null;
-          pk_table_oid: unknown | null;
-        };
-      };
+          fk_columns: unknown[] | null
+          fk_constraint_name: unknown | null
+          fk_schema_name: unknown | null
+          fk_table_name: unknown | null
+          fk_table_oid: unknown | null
+          is_deferrable: boolean | null
+          is_deferred: boolean | null
+          match_type: string | null
+          on_delete: string | null
+          on_update: string | null
+          pk_columns: unknown[] | null
+          pk_constraint_name: unknown | null
+          pk_index_name: unknown | null
+          pk_schema_name: unknown | null
+          pk_table_name: unknown | null
+          pk_table_oid: unknown | null
+        }
+      }
       plan_action: {
         Row: {
-          collectivite_id: number | null;
-          id: number | null;
-          plan: Json | null;
-        };
+          collectivite_id: number | null
+          id: number | null
+          plan: Json | null
+        }
         Insert: {
-          collectivite_id?: number | null;
-          id?: number | null;
-          plan?: never;
-        };
+          collectivite_id?: number | null
+          id?: number | null
+          plan?: never
+        }
         Update: {
-          collectivite_id?: number | null;
-          id?: number | null;
-          plan?: never;
-        };
-      };
+          collectivite_id?: number | null
+          id?: number | null
+          plan?: never
+        }
+      }
       plan_action_chemin: {
         Row: {
-          axe_id: number | null;
-          chemin: unknown[] | null;
-          collectivite_id: number | null;
-          plan_id: number | null;
-        };
-      };
+          axe_id: number | null
+          chemin: unknown[] | null
+          collectivite_id: number | null
+          plan_id: number | null
+        }
+      }
       plan_action_profondeur: {
         Row: {
-          collectivite_id: number | null;
-          id: number | null;
-          plan: Json | null;
-        };
+          collectivite_id: number | null
+          id: number | null
+          plan: Json | null
+        }
         Insert: {
-          collectivite_id?: number | null;
-          id?: number | null;
-          plan?: never;
-        };
+          collectivite_id?: number | null
+          id?: number | null
+          plan?: never
+        }
         Update: {
-          collectivite_id?: number | null;
-          id?: number | null;
-          plan?: never;
-        };
-      };
+          collectivite_id?: number | null
+          id?: number | null
+          plan?: never
+        }
+      }
       preuve: {
         Row: {
-          action: Json | null;
-          audit: Json | null;
-          collectivite_id: number | null;
-          commentaire: string | null;
-          created_at: string | null;
-          created_by: string | null;
-          created_by_nom: string | null;
-          demande: Json | null;
-          fichier: Json | null;
-          id: number | null;
-          lien: Json | null;
-          preuve_reglementaire: Json | null;
-          preuve_type: Database["public"]["Enums"]["preuve_type"] | null;
-          rapport: Json | null;
-        };
-      };
+          action: Json | null
+          audit: Json | null
+          collectivite_id: number | null
+          commentaire: string | null
+          created_at: string | null
+          created_by: string | null
+          created_by_nom: string | null
+          demande: Json | null
+          fichier: Json | null
+          id: number | null
+          lien: Json | null
+          preuve_reglementaire: Json | null
+          preuve_type: Database["public"]["Enums"]["preuve_type"] | null
+          rapport: Json | null
+        }
+      }
       question_display: {
         Row: {
-          action_ids: unknown[] | null;
-          choix: Json[] | null;
-          collectivite_id: number | null;
-          description: string | null;
-          formulation: string | null;
-          id: string | null;
-          localisation: string[] | null;
-          ordonnancement: number | null;
-          population: string[] | null;
-          thematique_id: string | null;
-          thematique_nom: string | null;
-          type: Database["public"]["Enums"]["question_type"] | null;
+          action_ids: unknown[] | null
+          choix: Json[] | null
+          collectivite_id: number | null
+          description: string | null
+          formulation: string | null
+          id: string | null
+          localisation: string[] | null
+          ordonnancement: number | null
+          population: string[] | null
+          thematique_id: string | null
+          thematique_nom: string | null
+          type: Database["public"]["Enums"]["question_type"] | null
           types_collectivites_concernees:
             | Database["public"]["Enums"]["type_collectivite"][]
-            | null;
-        };
-      };
+            | null
+        }
+      }
       question_engine: {
         Row: {
-          choix_ids: unknown[] | null;
-          id: string | null;
-          type: Database["public"]["Enums"]["question_type"] | null;
-        };
-      };
+          choix_ids: unknown[] | null
+          id: string | null
+          type: Database["public"]["Enums"]["question_type"] | null
+        }
+      }
       question_thematique_completude: {
         Row: {
-          collectivite_id: number | null;
+          collectivite_id: number | null
           completude:
             | Database["public"]["Enums"]["thematique_completude"]
-            | null;
-          id: string | null;
-          nom: string | null;
-          referentiels: Database["public"]["Enums"]["referentiel"][] | null;
-        };
-      };
+            | null
+          id: string | null
+          nom: string | null
+          referentiels: Database["public"]["Enums"]["referentiel"][] | null
+        }
+      }
       question_thematique_display: {
         Row: {
-          id: string | null;
-          nom: string | null;
-          referentiels: Database["public"]["Enums"]["referentiel"][] | null;
-        };
-      };
+          id: string | null
+          nom: string | null
+          referentiels: Database["public"]["Enums"]["referentiel"][] | null
+        }
+      }
       region: {
         Row: {
-          code: string | null;
-          libelle: string | null;
-        };
+          code: string | null
+          libelle: string | null
+        }
         Insert: {
-          code?: string | null;
-          libelle?: string | null;
-        };
+          code?: string | null
+          libelle?: string | null
+        }
         Update: {
-          code?: string | null;
-          libelle?: string | null;
-        };
-      };
+          code?: string | null
+          libelle?: string | null
+        }
+      }
       reponse_display: {
         Row: {
-          collectivite_id: number | null;
-          justification: string | null;
-          question_id: string | null;
-          reponse: Json | null;
-        };
-      };
+          collectivite_id: number | null
+          justification: string | null
+          question_id: string | null
+          reponse: Json | null
+        }
+      }
       retool_active_collectivite: {
         Row: {
-          collectivite_id: number | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          nom: string | null
+        }
+      }
       retool_audit: {
         Row: {
-          collectivite_id: number | null;
-          date_attribution: string | null;
-          date_debut: string | null;
-          date_fin: string | null;
-          envoyee_le: string | null;
-          nom: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          type_audit: string | null;
-        };
-      };
+          collectivite_id: number | null
+          date_attribution: string | null
+          date_debut: string | null
+          date_fin: string | null
+          envoyee_le: string | null
+          nom: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          type_audit: string | null
+        }
+      }
       retool_completude: {
         Row: {
-          code_siren_insee: string | null;
-          collectivite_id: number | null;
-          completude_cae: number | null;
-          completude_eci: number | null;
-          departement_name: string | null;
-          nom: string | null;
-          population_totale: number | null;
-          region_name: string | null;
+          code_siren_insee: string | null
+          collectivite_id: number | null
+          completude_cae: number | null
+          completude_eci: number | null
+          departement_name: string | null
+          nom: string | null
+          population_totale: number | null
+          region_name: string | null
           type_collectivite:
             | Database["public"]["Enums"]["type_collectivite"]
-            | null;
-        };
-      };
+            | null
+        }
+      }
       retool_completude_compute: {
         Row: {
-          collectivite_id: number | null;
-          completude_cae: number | null;
-          completude_eci: number | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          completude_cae: number | null
+          completude_eci: number | null
+          nom: string | null
+        }
+      }
       retool_labellisation: {
         Row: {
-          annee: number | null;
-          collectivite_id: number | null;
-          collectivite_nom: string | null;
-          etoiles: number | null;
-          id: number | null;
-          obtenue_le: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          score_programme: number | null;
-          score_realise: number | null;
-        };
-      };
+          annee: number | null
+          collectivite_id: number | null
+          collectivite_nom: string | null
+          etoiles: number | null
+          id: number | null
+          obtenue_le: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          score_programme: number | null
+          score_realise: number | null
+        }
+      }
       retool_labellisation_demande: {
         Row: {
-          collectivite_id: number | null;
-          date: string | null;
-          demandeur_email: string | null;
+          collectivite_id: number | null
+          date: string | null
+          demandeur_email: string | null
           demandeur_fonction:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
-          demandeur_nom: string | null;
-          demandeur_prenom: string | null;
-          en_cours: boolean | null;
-          envoyee_le: string | null;
-          etoiles: Database["labellisation"]["Enums"]["etoile"] | null;
-          id: number | null;
-          modified_at: string | null;
-          nom: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"] | null;
-        };
-      };
+            | null
+          demandeur_nom: string | null
+          demandeur_prenom: string | null
+          en_cours: boolean | null
+          envoyee_le: string | null
+          etoiles: Database["labellisation"]["Enums"]["etoile"] | null
+          id: number | null
+          modified_at: string | null
+          nom: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"] | null
+        }
+      }
       retool_plan_action_hebdo: {
         Row: {
-          collectivite_id: number | null;
-          contributeurs: string[] | null;
-          date_range: string | null;
-          day: string | null;
-          nb_fiches: number | null;
-          nb_plans: number | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          contributeurs: string[] | null
+          date_range: string | null
+          day: string | null
+          nb_fiches: number | null
+          nb_plans: number | null
+          nom: string | null
+        }
+      }
       retool_plan_action_premier_usage: {
         Row: {
-          collectivite_id: number | null;
-          created_at: string | null;
-          email: string | null;
-          fiche: boolean | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          created_at: string | null
+          email: string | null
+          fiche: boolean | null
+          nom: string | null
+        }
+      }
       retool_plan_action_usage: {
         Row: {
-          collectivite_id: number | null;
-          derniere_modif: string | null;
-          nb_fiches: number | null;
-          nb_plans: number | null;
-          nb_utilisateurs: string | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          derniere_modif: string | null
+          nb_fiches: number | null
+          nb_plans: number | null
+          nb_utilisateurs: string | null
+          nom: string | null
+        }
+      }
       retool_preuves: {
         Row: {
-          action: string | null;
-          collectivite_id: number | null;
-          created_at: string | null;
-          fichier: string | null;
-          lien: string | null;
-          nom: string | null;
-          preuve_type: Database["public"]["Enums"]["preuve_type"] | null;
-          referentiel: string | null;
-        };
-      };
+          action: string | null
+          collectivite_id: number | null
+          created_at: string | null
+          fichier: string | null
+          lien: string | null
+          nom: string | null
+          preuve_type: Database["public"]["Enums"]["preuve_type"] | null
+          referentiel: string | null
+        }
+      }
       retool_score: {
         Row: {
-          Avancement: string | null;
-          Collectivité: string | null;
-          collectivite_id: number | null;
-          Commentaire: string | null;
-          "Commentaires fusionnés": string | null;
-          Identifiant: string | null;
-          "Modifié le": string | null;
-          "Points potentiels": number | null;
-          "Points programmés": number | null;
-          "Points realisés": number | null;
-          "Pourcentage non renseigné": number | null;
-          "Pourcentage programmé": number | null;
-          "Pourcentage réalisé": number | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          Titre: string | null;
-        };
-      };
+          Avancement: string | null
+          Collectivité: string | null
+          collectivite_id: number | null
+          Commentaire: string | null
+          "Commentaires fusionnés": string | null
+          Identifiant: string | null
+          "Modifié le": string | null
+          "Points potentiels": number | null
+          "Points programmés": number | null
+          "Points realisés": number | null
+          "Pourcentage non renseigné": number | null
+          "Pourcentage programmé": number | null
+          "Pourcentage réalisé": number | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          Titre: string | null
+        }
+      }
       retool_stats_usages: {
         Row: {
           admin_champs_intervention_1:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_10:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_2:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_3:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_4:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_5:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_6:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_7:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_8:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
+            | null
           admin_champs_intervention_9:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
-          admin_derniere_connexion_1: string | null;
-          admin_derniere_connexion_10: string | null;
-          admin_derniere_connexion_2: string | null;
-          admin_derniere_connexion_3: string | null;
-          admin_derniere_connexion_4: string | null;
-          admin_derniere_connexion_5: string | null;
-          admin_derniere_connexion_6: string | null;
-          admin_derniere_connexion_7: string | null;
-          admin_derniere_connexion_8: string | null;
-          admin_derniere_connexion_9: string | null;
-          admin_detail_fonction_1: string | null;
-          admin_detail_fonction_10: string | null;
-          admin_detail_fonction_2: string | null;
-          admin_detail_fonction_3: string | null;
-          admin_detail_fonction_4: string | null;
-          admin_detail_fonction_5: string | null;
-          admin_detail_fonction_6: string | null;
-          admin_detail_fonction_7: string | null;
-          admin_detail_fonction_8: string | null;
-          admin_detail_fonction_9: string | null;
-          admin_email_1: string | null;
-          admin_email_10: string | null;
-          admin_email_2: string | null;
-          admin_email_3: string | null;
-          admin_email_4: string | null;
-          admin_email_5: string | null;
-          admin_email_6: string | null;
-          admin_email_7: string | null;
-          admin_email_8: string | null;
-          admin_email_9: string | null;
+            | null
+          admin_derniere_connexion_1: string | null
+          admin_derniere_connexion_10: string | null
+          admin_derniere_connexion_2: string | null
+          admin_derniere_connexion_3: string | null
+          admin_derniere_connexion_4: string | null
+          admin_derniere_connexion_5: string | null
+          admin_derniere_connexion_6: string | null
+          admin_derniere_connexion_7: string | null
+          admin_derniere_connexion_8: string | null
+          admin_derniere_connexion_9: string | null
+          admin_detail_fonction_1: string | null
+          admin_detail_fonction_10: string | null
+          admin_detail_fonction_2: string | null
+          admin_detail_fonction_3: string | null
+          admin_detail_fonction_4: string | null
+          admin_detail_fonction_5: string | null
+          admin_detail_fonction_6: string | null
+          admin_detail_fonction_7: string | null
+          admin_detail_fonction_8: string | null
+          admin_detail_fonction_9: string | null
+          admin_email_1: string | null
+          admin_email_10: string | null
+          admin_email_2: string | null
+          admin_email_3: string | null
+          admin_email_4: string | null
+          admin_email_5: string | null
+          admin_email_6: string | null
+          admin_email_7: string | null
+          admin_email_8: string | null
+          admin_email_9: string | null
           admin_fonction_1:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_10:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_2:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_3:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_4:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_5:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_6:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_7:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_8:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
+            | null
           admin_fonction_9:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null;
-          admin_nom_1: string | null;
-          admin_nom_10: string | null;
-          admin_nom_2: string | null;
-          admin_nom_3: string | null;
-          admin_nom_4: string | null;
-          admin_nom_5: string | null;
-          admin_nom_6: string | null;
-          admin_nom_7: string | null;
-          admin_nom_8: string | null;
-          admin_nom_9: string | null;
-          admin_prenom_1: string | null;
-          admin_prenom_10: string | null;
-          admin_prenom_2: string | null;
-          admin_prenom_3: string | null;
-          admin_prenom_4: string | null;
-          admin_prenom_5: string | null;
-          admin_prenom_6: string | null;
-          admin_prenom_7: string | null;
-          admin_prenom_8: string | null;
-          admin_prenom_9: string | null;
-          admin_telephone_1: string | null;
-          admin_telephone_10: string | null;
-          admin_telephone_2: string | null;
-          admin_telephone_3: string | null;
-          admin_telephone_4: string | null;
-          admin_telephone_5: string | null;
-          admin_telephone_6: string | null;
-          admin_telephone_7: string | null;
-          admin_telephone_8: string | null;
-          admin_telephone_9: string | null;
-          code_siren_insee: string | null;
-          collectivite_id: number | null;
-          completude_cae: number | null;
-          completude_eci: number | null;
-          cot: boolean | null;
-          date_activation: string | null;
-          departement_code: string | null;
-          departement_name: string | null;
-          nature_collectivite: Database["public"]["Enums"]["nature"] | null;
-          nb_admin: number | null;
-          nb_ecriture: number | null;
-          nb_fiches: number | null;
-          nb_indicateurs: number | null;
-          nb_indicateurs_cae: number | null;
-          nb_indicateurs_eci: number | null;
-          nb_indicateurs_personnalises: number | null;
-          nb_lecture: number | null;
-          nb_plans: number | null;
-          nb_users_actifs: number | null;
-          nb_valeurs_indicateurs: number | null;
-          niveau_label_cae: number | null;
-          niveau_label_eci: number | null;
-          nom: string | null;
-          population_totale: number | null;
-          programme_courant_cae: number | null;
-          programme_courant_eci: number | null;
-          programme_label_cae: number | null;
-          programme_label_eci: number | null;
-          realise_courant_cae: number | null;
-          realise_courant_eci: number | null;
-          realise_label_cae: number | null;
-          realise_label_eci: number | null;
-          region_code: string | null;
-          region_name: string | null;
+            | null
+          admin_nom_1: string | null
+          admin_nom_10: string | null
+          admin_nom_2: string | null
+          admin_nom_3: string | null
+          admin_nom_4: string | null
+          admin_nom_5: string | null
+          admin_nom_6: string | null
+          admin_nom_7: string | null
+          admin_nom_8: string | null
+          admin_nom_9: string | null
+          admin_prenom_1: string | null
+          admin_prenom_10: string | null
+          admin_prenom_2: string | null
+          admin_prenom_3: string | null
+          admin_prenom_4: string | null
+          admin_prenom_5: string | null
+          admin_prenom_6: string | null
+          admin_prenom_7: string | null
+          admin_prenom_8: string | null
+          admin_prenom_9: string | null
+          admin_telephone_1: string | null
+          admin_telephone_10: string | null
+          admin_telephone_2: string | null
+          admin_telephone_3: string | null
+          admin_telephone_4: string | null
+          admin_telephone_5: string | null
+          admin_telephone_6: string | null
+          admin_telephone_7: string | null
+          admin_telephone_8: string | null
+          admin_telephone_9: string | null
+          code_siren_insee: string | null
+          collectivite_id: number | null
+          completude_cae: number | null
+          completude_eci: number | null
+          cot: boolean | null
+          date_activation: string | null
+          departement_code: string | null
+          departement_name: string | null
+          nature_collectivite: Database["public"]["Enums"]["nature"] | null
+          nb_admin: number | null
+          nb_ecriture: number | null
+          nb_fiches: number | null
+          nb_indicateurs: number | null
+          nb_indicateurs_cae: number | null
+          nb_indicateurs_eci: number | null
+          nb_indicateurs_personnalises: number | null
+          nb_lecture: number | null
+          nb_plans: number | null
+          nb_users_actifs: number | null
+          nb_valeurs_indicateurs: number | null
+          niveau_label_cae: number | null
+          niveau_label_eci: number | null
+          nom: string | null
+          population_totale: number | null
+          programme_courant_cae: number | null
+          programme_courant_eci: number | null
+          programme_label_cae: number | null
+          programme_label_eci: number | null
+          realise_courant_cae: number | null
+          realise_courant_eci: number | null
+          realise_label_cae: number | null
+          realise_label_eci: number | null
+          region_code: string | null
+          region_name: string | null
           type_collectivite:
             | Database["public"]["Enums"]["filterable_type_collectivite"]
-            | null;
-        };
-      };
+            | null
+        }
+      }
       retool_user_collectivites_list: {
         Row: {
-          collectivites: string[] | null;
-          creation: string | null;
-          derniere_connexion: string | null;
-          email: string | null;
-          nb_collectivite: number | null;
-          nom: string | null;
-          prenom: string | null;
-        };
-      };
+          collectivites: string[] | null
+          creation: string | null
+          derniere_connexion: string | null
+          email: string | null
+          nb_collectivite: number | null
+          nom: string | null
+          prenom: string | null
+        }
+      }
       retool_user_list: {
         Row: {
-          active: boolean | null;
+          active: boolean | null
           champ_intervention:
             | Database["public"]["Enums"]["referentiel"][]
-            | null;
-          collectivite: string | null;
-          collectivite_id: number | null;
-          details_fonction: string | null;
-          droit_id: number | null;
-          email: string | null;
-          fonction: Database["public"]["Enums"]["membre_fonction"] | null;
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null;
-          nom: string | null;
-          prenom: string | null;
-          telephone: string | null;
-          user_id: string | null;
-        };
-      };
+            | null
+          collectivite: string | null
+          collectivite_id: number | null
+          details_fonction: string | null
+          droit_id: number | null
+          email: string | null
+          fonction: Database["public"]["Enums"]["membre_fonction"] | null
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null
+          nom: string | null
+          prenom: string | null
+          telephone: string | null
+          user_id: string | null
+        }
+      }
       stats_active_real_collectivites: {
         Row: {
-          collectivite_id: number | null;
-          nom: string | null;
-        };
-      };
+          collectivite_id: number | null
+          nom: string | null
+        }
+      }
       stats_carte_collectivite_active: {
         Row: {
-          code_siren_insee: string | null;
-          collectivite_id: number | null;
-          departement_code: string | null;
-          departement_name: string | null;
-          geojson: Json | null;
-          nature_collectivite: string | null;
-          nom: string | null;
-          population_totale: number | null;
-          region_code: string | null;
-          region_name: string | null;
+          code_siren_insee: string | null
+          collectivite_id: number | null
+          departement_code: string | null
+          departement_name: string | null
+          geojson: Json | null
+          nature_collectivite: string | null
+          nom: string | null
+          population_totale: number | null
+          region_code: string | null
+          region_name: string | null
           type_collectivite:
             | Database["public"]["Enums"]["type_collectivite"]
-            | null;
-        };
-      };
+            | null
+        }
+      }
       stats_carte_epci_par_departement: {
         Row: {
-          actives: number | null;
-          geojson: Json | null;
-          insee: string | null;
-          libelle: string | null;
-          total: number | null;
-        };
-      };
+          actives: number | null
+          geojson: Json | null
+          insee: string | null
+          libelle: string | null
+          total: number | null
+        }
+      }
       stats_collectivite_actives_et_total_par_type: {
         Row: {
-          actives: number | null;
-          total: number | null;
-          type_collectivite: string | null;
-        };
-      };
+          actives: number | null
+          total: number | null
+          type_collectivite: string | null
+        }
+      }
       stats_evolution_collectivite_avec_minimum_fiches: {
         Row: {
-          collectivites: number | null;
-          mois: string | null;
-        };
-      };
+          collectivites: number | null
+          mois: string | null
+        }
+      }
       stats_evolution_indicateur_referentiel: {
         Row: {
-          indicateurs: number | null;
-          mois: string | null;
-        };
-      };
+          indicateurs: number | null
+          mois: string | null
+        }
+      }
       stats_evolution_nombre_fiches: {
         Row: {
-          fiches: number | null;
-          mois: string | null;
-        };
-      };
+          fiches: number | null
+          mois: string | null
+        }
+      }
       stats_evolution_nombre_utilisateur_par_collectivite: {
         Row: {
-          maximum: number | null;
-          median: number | null;
-          mois: string | null;
-          moyen: number | null;
-        };
-      };
+          maximum: number | null
+          median: number | null
+          mois: string | null
+          moyen: number | null
+        }
+      }
       stats_evolution_resultat_indicateur_personnalise: {
         Row: {
-          mois: string | null;
-          resultats: number | null;
-        };
-      };
+          mois: string | null
+          resultats: number | null
+        }
+      }
       stats_evolution_resultat_indicateur_referentiel: {
         Row: {
-          mois: string | null;
-          resultats: number | null;
-        };
-      };
+          mois: string | null
+          resultats: number | null
+        }
+      }
       stats_evolution_total_activation_par_type: {
         Row: {
-          mois: string | null;
-          total: number | null;
-          total_commune: number | null;
-          total_epci: number | null;
-          total_syndicat: number | null;
-        };
-      };
+          mois: string | null
+          total: number | null
+          total_commune: number | null
+          total_epci: number | null
+          total_syndicat: number | null
+        }
+      }
       stats_evolution_utilisateur: {
         Row: {
-          mois: string | null;
-          total_utilisateurs: number | null;
-          utilisateurs: number | null;
-        };
-      };
+          mois: string | null
+          total_utilisateurs: number | null
+          utilisateurs: number | null
+        }
+      }
       stats_labellisation_par_niveau: {
         Row: {
-          etoiles: number | null;
-          labellisations: number | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-        };
-      };
+          etoiles: number | null
+          labellisations: number | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+        }
+      }
       stats_locales_collectivite_actives_et_total_par_type: {
         Row: {
-          actives: number | null;
-          code_departement: string | null;
-          code_region: string | null;
-          total: number | null;
-          typologie: string | null;
-        };
-      };
+          actives: number | null
+          code_departement: string | null
+          code_region: string | null
+          total: number | null
+          typologie: string | null
+        }
+      }
       stats_locales_engagement_collectivite: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          collectivite_id: number | null;
-          cot: boolean | null;
-          etoiles_cae: number | null;
-          etoiles_eci: number | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          collectivite_id: number | null
+          cot: boolean | null
+          etoiles_cae: number | null
+          etoiles_eci: number | null
+        }
+      }
       stats_locales_evolution_collectivite_avec_indicateur: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          collectivites: number | null;
-          mois: string | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          collectivites: number | null
+          mois: string | null
+        }
+      }
       stats_locales_evolution_collectivite_avec_minimum_fiches: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          collectivites: number | null;
-          mois: string | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          collectivites: number | null
+          mois: string | null
+        }
+      }
       stats_locales_evolution_indicateur_referentiel: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          indicateurs: number | null;
-          mois: string | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          indicateurs: number | null
+          mois: string | null
+        }
+      }
       stats_locales_evolution_nombre_fiches: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          fiches: number | null;
-          mois: string | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          fiches: number | null
+          mois: string | null
+        }
+      }
       stats_locales_evolution_nombre_utilisateur_par_collectivite: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          maximum: number | null;
-          median: number | null;
-          mois: string | null;
-          moyen: number | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          maximum: number | null
+          median: number | null
+          mois: string | null
+          moyen: number | null
+        }
+      }
       stats_locales_evolution_resultat_indicateur_personnalise: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          indicateurs: number | null;
-          mois: string | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          indicateurs: number | null
+          mois: string | null
+        }
+      }
       stats_locales_evolution_resultat_indicateur_referentiel: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          indicateurs: number | null;
-          mois: string | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          indicateurs: number | null
+          mois: string | null
+        }
+      }
       stats_locales_evolution_total_activation: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          mois: string | null;
-          total: number | null;
-          total_commune: number | null;
-          total_epci: number | null;
-          total_syndicat: number | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          mois: string | null
+          total: number | null
+          total_commune: number | null
+          total_epci: number | null
+          total_syndicat: number | null
+        }
+      }
       stats_locales_evolution_utilisateur: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          mois: string | null;
-          total_utilisateurs: number | null;
-          utilisateurs: number | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          mois: string | null
+          total_utilisateurs: number | null
+          utilisateurs: number | null
+        }
+      }
       stats_locales_labellisation_par_niveau: {
         Row: {
-          code_departement: string | null;
-          code_region: string | null;
-          etoiles: number | null;
-          labellisations: number | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-        };
-      };
+          code_departement: string | null
+          code_region: string | null
+          etoiles: number | null
+          labellisations: number | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+        }
+      }
       stats_locales_tranche_completude: {
         Row: {
-          cae: number | null;
-          code_departement: string | null;
-          code_region: string | null;
-          eci: number | null;
-          lower_bound: number | null;
-          upper_bound: number | null;
-        };
-      };
+          cae: number | null
+          code_departement: string | null
+          code_region: string | null
+          eci: number | null
+          lower_bound: number | null
+          upper_bound: number | null
+        }
+      }
       suivi_audit: {
         Row: {
-          action_id: string | null;
-          avis: string | null;
-          collectivite_id: number | null;
-          have_children: boolean | null;
-          ordre_du_jour: boolean | null;
-          ordres_du_jour: boolean[] | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          statut: Database["public"]["Enums"]["audit_statut"] | null;
-          statuts: Database["public"]["Enums"]["audit_statut"][] | null;
-          type: Database["public"]["Enums"]["action_type"] | null;
-        };
-      };
+          action_id: string | null
+          avis: string | null
+          collectivite_id: number | null
+          have_children: boolean | null
+          ordre_du_jour: boolean | null
+          ordres_du_jour: boolean[] | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          statut: Database["public"]["Enums"]["audit_statut"] | null
+          statuts: Database["public"]["Enums"]["audit_statut"][] | null
+          type: Database["public"]["Enums"]["action_type"] | null
+        }
+      }
       tap_funky: {
         Row: {
-          args: string | null;
-          is_definer: boolean | null;
-          is_strict: boolean | null;
-          is_visible: boolean | null;
-          kind: unknown | null;
-          langoid: unknown | null;
-          name: unknown | null;
-          oid: unknown | null;
-          owner: unknown | null;
-          returns: string | null;
-          returns_set: boolean | null;
-          schema: unknown | null;
-          volatility: string | null;
-        };
-      };
-    };
+          args: string | null
+          is_definer: boolean | null
+          is_strict: boolean | null
+          is_visible: boolean | null
+          kind: unknown | null
+          langoid: unknown | null
+          name: unknown | null
+          oid: unknown | null
+          owner: unknown | null
+          returns: string | null
+          returns_set: boolean | null
+          schema: unknown | null
+          volatility: string | null
+        }
+      }
+    }
     Functions: {
       _cleanup: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
       _contract_on: {
         Args: {
-          "": string;
-        };
-        Returns: unknown;
-      };
+          "": string
+        }
+        Returns: unknown
+      }
       _currtest: {
-        Args: Record<PropertyKey, never>;
-        Returns: number;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
       _db_privs: {
-        Args: Record<PropertyKey, never>;
-        Returns: unknown[];
-      };
+        Args: Record<PropertyKey, never>
+        Returns: unknown[]
+      }
       _definer: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _dexists: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _expand_context: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       _expand_on: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       _expand_vol: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       _ext_exists: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _extensions:
         | {
             Args: {
-              "": unknown;
-            };
-            Returns: unknown[];
+              "": unknown
+            }
+            Returns: unknown[]
           }
         | {
-            Args: Record<PropertyKey, never>;
-            Returns: unknown[];
-          };
+            Args: Record<PropertyKey, never>
+            Returns: unknown[]
+          }
       _funkargs: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       _get: {
         Args: {
-          "": string;
-        };
-        Returns: number;
-      };
+          "": string
+        }
+        Returns: number
+      }
       _get_db_owner: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       _get_dtype: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       _get_language_owner: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       _get_latest: {
         Args: {
-          "": string;
-        };
-        Returns: number[];
-      };
+          "": string
+        }
+        Returns: number[]
+      }
       _get_note:
         | {
             Args: {
-              "": string;
-            };
-            Returns: string;
+              "": string
+            }
+            Returns: string
           }
         | {
             Args: {
-              "": number;
-            };
-            Returns: string;
-          };
+              "": number
+            }
+            Returns: string
+          }
       _get_opclass_owner: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       _get_rel_owner: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       _get_schema_owner: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       _get_tablespace_owner: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       _get_type_owner: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       _got_func: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _grolist: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown[];
-      };
+          "": unknown
+        }
+        Returns: unknown[]
+      }
       _has_group: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _has_role: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _has_user: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _inherited: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _is_schema: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _is_super: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _is_trusted: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _is_verbose: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
       _lang: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       _opc_exists: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _parts: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown[];
-      };
+          "": unknown
+        }
+        Returns: unknown[]
+      }
       _pg_sv_type_array: {
         Args: {
-          "": unknown[];
-        };
-        Returns: unknown[];
-      };
+          "": unknown[]
+        }
+        Returns: unknown[]
+      }
       _prokind: {
         Args: {
-          p_oid: unknown;
-        };
-        Returns: unknown;
-      };
+          p_oid: unknown
+        }
+        Returns: unknown
+      }
       _query: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       _refine_vol: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       _relexists: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _returns: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       _strict: {
         Args: {
-          "": unknown;
-        };
-        Returns: boolean;
-      };
+          "": unknown
+        }
+        Returns: boolean
+      }
       _table_privs: {
-        Args: Record<PropertyKey, never>;
-        Returns: unknown[];
-      };
+        Args: Record<PropertyKey, never>
+        Returns: unknown[]
+      }
       _temptypes: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       _todo: {
-        Args: Record<PropertyKey, never>;
-        Returns: string;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
       _vol: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       accepter_cgu: {
-        Args: Record<PropertyKey, never>;
+        Args: Record<PropertyKey, never>
         Returns: {
-          cgu_acceptees_le: string | null;
-          created_at: string;
-          deleted: boolean;
-          email: string;
-          limited: boolean;
-          modified_at: string;
-          nom: string;
-          prenom: string;
-          telephone: string | null;
-          user_id: string;
-        };
-      };
+          cgu_acceptees_le: string | null
+          created_at: string
+          deleted: boolean
+          email: string
+          limited: boolean
+          modified_at: string
+          nom: string
+          prenom: string
+          telephone: string | null
+          user_id: string
+        }
+      }
       action_contexte: {
         Args: {
-          id: unknown;
-        };
-        Returns: Record<string, unknown>;
-      };
+          id: unknown
+        }
+        Returns: Record<string, unknown>
+      }
       action_down_to_tache: {
         Args: {
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          identifiant: string;
-        };
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          identifiant: string
+        }
         Returns: {
-          children: unknown[] | null;
-          depth: number | null;
-          description: string | null;
-          have_contexte: boolean | null;
-          have_exemples: boolean | null;
-          have_perimetre_evaluation: boolean | null;
-          have_preuve: boolean | null;
-          have_questions: boolean | null;
-          have_reduction_potentiel: boolean | null;
-          have_ressources: boolean | null;
-          id: string | null;
-          identifiant: string | null;
-          nom: string | null;
-          phase: Database["public"]["Enums"]["action_categorie"] | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          type: Database["public"]["Enums"]["action_type"] | null;
-        }[];
-      };
+          children: unknown[] | null
+          depth: number | null
+          description: string | null
+          have_contexte: boolean | null
+          have_exemples: boolean | null
+          have_perimetre_evaluation: boolean | null
+          have_preuve: boolean | null
+          have_questions: boolean | null
+          have_reduction_potentiel: boolean | null
+          have_ressources: boolean | null
+          id: string | null
+          identifiant: string | null
+          nom: string | null
+          phase: Database["public"]["Enums"]["action_categorie"] | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          type: Database["public"]["Enums"]["action_type"] | null
+        }[]
+      }
       action_exemples: {
         Args: {
-          id: unknown;
-        };
-        Returns: Record<string, unknown>;
-      };
+          id: unknown
+        }
+        Returns: Record<string, unknown>
+      }
       action_perimetre_evaluation: {
         Args: {
-          id: unknown;
-        };
-        Returns: Record<string, unknown>;
-      };
+          id: unknown
+        }
+        Returns: Record<string, unknown>
+      }
       action_preuve: {
         Args: {
-          id: unknown;
-        };
-        Returns: Record<string, unknown>;
-      };
+          id: unknown
+        }
+        Returns: Record<string, unknown>
+      }
       action_reduction_potentiel: {
         Args: {
-          id: unknown;
-        };
-        Returns: Record<string, unknown>;
-      };
+          id: unknown
+        }
+        Returns: Record<string, unknown>
+      }
       action_ressources: {
         Args: {
-          id: unknown;
-        };
-        Returns: Record<string, unknown>;
-      };
+          id: unknown
+        }
+        Returns: Record<string, unknown>
+      }
       add_bibliotheque_fichier: {
         Args: {
-          collectivite_id: number;
-          hash: string;
-          filename: string;
-        };
+          collectivite_id: number
+          hash: string
+          filename: string
+        }
         Returns: {
-          bucket_id: string | null;
-          collectivite_id: number | null;
-          file_id: string | null;
-          filename: string | null;
-          filesize: number | null;
-          hash: string | null;
-          id: number | null;
-        };
-      };
+          bucket_id: string | null
+          collectivite_id: number | null
+          file_id: string | null
+          filename: string | null
+          filesize: number | null
+          hash: string | null
+          id: number | null
+        }
+      }
       add_compression_policy: {
         Args: {
-          hypertable: unknown;
-          compress_after: unknown;
-          if_not_exists?: boolean;
-          schedule_interval?: unknown;
-          initial_start?: string;
-          timezone?: string;
-        };
-        Returns: number;
-      };
+          hypertable: unknown
+          compress_after: unknown
+          if_not_exists?: boolean
+          schedule_interval?: unknown
+          initial_start?: string
+          timezone?: string
+        }
+        Returns: number
+      }
       add_continuous_aggregate_policy: {
         Args: {
-          continuous_aggregate: unknown;
-          start_offset: unknown;
-          end_offset: unknown;
-          schedule_interval: unknown;
-          if_not_exists?: boolean;
-          initial_start?: string;
-          timezone?: string;
-        };
-        Returns: number;
-      };
+          continuous_aggregate: unknown
+          start_offset: unknown
+          end_offset: unknown
+          schedule_interval: unknown
+          if_not_exists?: boolean
+          initial_start?: string
+          timezone?: string
+        }
+        Returns: number
+      }
       add_data_node: {
         Args: {
-          node_name: unknown;
-          host: string;
-          database?: unknown;
-          port?: number;
-          if_not_exists?: boolean;
-          bootstrap?: boolean;
-          password?: string;
-        };
+          node_name: unknown
+          host: string
+          database?: unknown
+          port?: number
+          if_not_exists?: boolean
+          bootstrap?: boolean
+          password?: string
+        }
         Returns: {
-          node_name: unknown;
-          host: string;
-          port: number;
-          database: unknown;
-          node_created: boolean;
-          database_created: boolean;
-          extension_created: boolean;
-        }[];
-      };
+          node_name: unknown
+          host: string
+          port: number
+          database: unknown
+          node_created: boolean
+          database_created: boolean
+          extension_created: boolean
+        }[]
+      }
       add_dimension: {
         Args: {
-          hypertable: unknown;
-          column_name: unknown;
-          number_partitions?: number;
-          chunk_time_interval?: unknown;
-          partitioning_func?: unknown;
-          if_not_exists?: boolean;
-        };
+          hypertable: unknown
+          column_name: unknown
+          number_partitions?: number
+          chunk_time_interval?: unknown
+          partitioning_func?: unknown
+          if_not_exists?: boolean
+        }
         Returns: {
-          dimension_id: number;
-          schema_name: unknown;
-          table_name: unknown;
-          column_name: unknown;
-          created: boolean;
-        }[];
-      };
+          dimension_id: number
+          schema_name: unknown
+          table_name: unknown
+          column_name: unknown
+          created: boolean
+        }[]
+      }
       add_job: {
         Args: {
-          proc: unknown;
-          schedule_interval: unknown;
-          config?: Json;
-          initial_start?: string;
-          scheduled?: boolean;
-          check_config?: unknown;
-          fixed_schedule?: boolean;
-          timezone?: string;
-        };
-        Returns: number;
-      };
+          proc: unknown
+          schedule_interval: unknown
+          config?: Json
+          initial_start?: string
+          scheduled?: boolean
+          check_config?: unknown
+          fixed_schedule?: boolean
+          timezone?: string
+        }
+        Returns: number
+      }
       add_reorder_policy: {
         Args: {
-          hypertable: unknown;
-          index_name: unknown;
-          if_not_exists?: boolean;
-          initial_start?: string;
-          timezone?: string;
-        };
-        Returns: number;
-      };
+          hypertable: unknown
+          index_name: unknown
+          if_not_exists?: boolean
+          initial_start?: string
+          timezone?: string
+        }
+        Returns: number
+      }
       add_retention_policy: {
         Args: {
-          relation: unknown;
-          drop_after: unknown;
-          if_not_exists?: boolean;
-          schedule_interval?: unknown;
-          initial_start?: string;
-          timezone?: string;
-        };
-        Returns: number;
-      };
+          relation: unknown
+          drop_after: unknown
+          if_not_exists?: boolean
+          schedule_interval?: unknown
+          initial_start?: string
+          timezone?: string
+        }
+        Returns: number
+      }
       add_user: {
         Args: {
-          collectivite_id: number;
-          email: string;
-          niveau: Database["public"]["Enums"]["niveau_acces"];
-        };
-        Returns: Json;
-      };
+          collectivite_id: number
+          email: string
+          niveau: Database["public"]["Enums"]["niveau_acces"]
+        }
+        Returns: Json
+      }
       ajouter_action: {
         Args: {
-          fiche_id: number;
-          action_id: unknown;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          action_id: unknown
+        }
+        Returns: undefined
+      }
       ajouter_fiche_action_dans_un_axe: {
         Args: {
-          fiche_id: number;
-          axe_id: number;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          axe_id: number
+        }
+        Returns: undefined
+      }
       ajouter_financeur: {
         Args: {
-          fiche_id: number;
-          financeur: Database["public"]["CompositeTypes"]["financeur_montant"];
-        };
-        Returns: Database["public"]["CompositeTypes"]["financeur_montant"];
-      };
+          fiche_id: number
+          financeur: Database["public"]["CompositeTypes"]["financeur_montant"]
+        }
+        Returns: Database["public"]["CompositeTypes"]["financeur_montant"]
+      }
       ajouter_indicateur: {
         Args: {
-          fiche_id: number;
-          indicateur: Database["public"]["CompositeTypes"]["indicateur_generique"];
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          indicateur: Database["public"]["CompositeTypes"]["indicateur_generique"]
+        }
+        Returns: undefined
+      }
       ajouter_partenaire: {
         Args: {
-          fiche_id: number;
-          partenaire: unknown;
-        };
+          fiche_id: number
+          partenaire: unknown
+        }
         Returns: {
-          collectivite_id: number;
-          id: number;
-          nom: string;
-        };
-      };
+          collectivite_id: number
+          id: number
+          nom: string
+        }
+      }
       ajouter_pilote: {
         Args: {
-          fiche_id: number;
-          pilote: Database["public"]["CompositeTypes"]["personne"];
-        };
-        Returns: Database["public"]["CompositeTypes"]["personne"];
-      };
+          fiche_id: number
+          pilote: Database["public"]["CompositeTypes"]["personne"]
+        }
+        Returns: Database["public"]["CompositeTypes"]["personne"]
+      }
       ajouter_referent: {
         Args: {
-          fiche_id: number;
-          referent: Database["public"]["CompositeTypes"]["personne"];
-        };
-        Returns: Database["public"]["CompositeTypes"]["personne"];
-      };
+          fiche_id: number
+          referent: Database["public"]["CompositeTypes"]["personne"]
+        }
+        Returns: Database["public"]["CompositeTypes"]["personne"]
+      }
       ajouter_service: {
         Args: {
-          fiche_id: number;
-          service: unknown;
-        };
+          fiche_id: number
+          service: unknown
+        }
         Returns: {
-          collectivite_id: number;
-          id: number;
-          nom: string;
-        };
-      };
+          collectivite_id: number
+          id: number
+          nom: string
+        }
+      }
       ajouter_sous_thematique: {
         Args: {
-          fiche_id: number;
-          thematique_id: number;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          thematique_id: number
+        }
+        Returns: undefined
+      }
       ajouter_structure: {
         Args: {
-          fiche_id: number;
-          structure: unknown;
-        };
+          fiche_id: number
+          structure: unknown
+        }
         Returns: {
-          collectivite_id: number;
-          id: number;
-          nom: string;
-        };
-      };
+          collectivite_id: number
+          id: number
+          nom: string
+        }
+      }
       ajouter_thematique: {
         Args: {
-          fiche_id: number;
-          thematique: string;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          thematique: string
+        }
+        Returns: undefined
+      }
       alter_data_node: {
         Args: {
-          node_name: unknown;
-          host?: string;
-          database?: unknown;
-          port?: number;
-          available?: boolean;
-        };
+          node_name: unknown
+          host?: string
+          database?: unknown
+          port?: number
+          available?: boolean
+        }
         Returns: {
-          node_name: unknown;
-          host: string;
-          port: number;
-          database: unknown;
-          available: boolean;
-        }[];
-      };
+          node_name: unknown
+          host: string
+          port: number
+          database: unknown
+          available: boolean
+        }[]
+      }
       alter_job: {
         Args: {
-          job_id: number;
-          schedule_interval?: unknown;
-          max_runtime?: unknown;
-          max_retries?: number;
-          retry_period?: unknown;
-          scheduled?: boolean;
-          config?: Json;
-          next_start?: string;
-          if_exists?: boolean;
-          check_config?: unknown;
-        };
+          job_id: number
+          schedule_interval?: unknown
+          max_runtime?: unknown
+          max_retries?: number
+          retry_period?: unknown
+          scheduled?: boolean
+          config?: Json
+          next_start?: string
+          if_exists?: boolean
+          check_config?: unknown
+        }
         Returns: {
-          job_id: number;
-          schedule_interval: unknown;
-          max_runtime: unknown;
-          max_retries: number;
-          retry_period: unknown;
-          scheduled: boolean;
-          config: Json;
-          next_start: string;
-          check_config: string;
-        }[];
-      };
+          job_id: number
+          schedule_interval: unknown
+          max_runtime: unknown
+          max_retries: number
+          retry_period: unknown
+          scheduled: boolean
+          config: Json
+          next_start: string
+          check_config: string
+        }[]
+      }
       approximate_row_count: {
         Args: {
-          relation: unknown;
-        };
-        Returns: number;
-      };
+          relation: unknown
+        }
+        Returns: number
+      }
       attach_data_node: {
         Args: {
-          node_name: unknown;
-          hypertable: unknown;
-          if_not_attached?: boolean;
-          repartition?: boolean;
-        };
+          node_name: unknown
+          hypertable: unknown
+          if_not_attached?: boolean
+          repartition?: boolean
+        }
         Returns: {
-          hypertable_id: number;
-          node_hypertable_id: number;
-          node_name: unknown;
-        }[];
-      };
+          hypertable_id: number
+          node_hypertable_id: number
+          node_name: unknown
+        }[]
+      }
       attach_tablespace: {
         Args: {
-          tablespace: unknown;
-          hypertable: unknown;
-          if_not_attached?: boolean;
-        };
-        Returns: undefined;
-      };
+          tablespace: unknown
+          hypertable: unknown
+          if_not_attached?: boolean
+        }
+        Returns: undefined
+      }
       business_insert_actions: {
         Args: {
-          relations: unknown[];
-          definitions: unknown[];
-          computed_points: unknown[];
-        };
-        Returns: undefined;
-      };
+          relations: unknown[]
+          definitions: unknown[]
+          computed_points: unknown[]
+        }
+        Returns: undefined
+      }
       business_update_actions: {
         Args: {
-          definitions: unknown[];
-          computed_points: unknown[];
-        };
-        Returns: undefined;
-      };
+          definitions: unknown[]
+          computed_points: unknown[]
+        }
+        Returns: undefined
+      }
       business_upsert_indicateurs: {
         Args: {
-          indicateur_definitions: unknown[];
-          indicateur_actions: unknown[];
-        };
-        Returns: undefined;
-      };
+          indicateur_definitions: unknown[]
+          indicateur_actions: unknown[]
+        }
+        Returns: undefined
+      }
       can: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       can_read_acces_restreint: {
         Args: {
-          collectivite_id: number;
-        };
-        Returns: boolean;
-      };
+          collectivite_id: number
+        }
+        Returns: boolean
+      }
       casts_are: {
         Args: {
-          "": string[];
-        };
-        Returns: string;
-      };
+          "": string[]
+        }
+        Returns: string
+      }
       chunk_compression_stats: {
         Args: {
-          hypertable: unknown;
-        };
+          hypertable: unknown
+        }
         Returns: {
-          chunk_schema: unknown;
-          chunk_name: unknown;
-          compression_status: string;
-          before_compression_table_bytes: number;
-          before_compression_index_bytes: number;
-          before_compression_toast_bytes: number;
-          before_compression_total_bytes: number;
-          after_compression_table_bytes: number;
-          after_compression_index_bytes: number;
-          after_compression_toast_bytes: number;
-          after_compression_total_bytes: number;
-          node_name: unknown;
-        }[];
-      };
+          chunk_schema: unknown
+          chunk_name: unknown
+          compression_status: string
+          before_compression_table_bytes: number
+          before_compression_index_bytes: number
+          before_compression_toast_bytes: number
+          before_compression_total_bytes: number
+          after_compression_table_bytes: number
+          after_compression_index_bytes: number
+          after_compression_toast_bytes: number
+          after_compression_total_bytes: number
+          node_name: unknown
+        }[]
+      }
       chunks_detailed_size: {
         Args: {
-          hypertable: unknown;
-        };
+          hypertable: unknown
+        }
         Returns: {
-          chunk_schema: unknown;
-          chunk_name: unknown;
-          table_bytes: number;
-          index_bytes: number;
-          toast_bytes: number;
-          total_bytes: number;
-          node_name: unknown;
-        }[];
-      };
+          chunk_schema: unknown
+          chunk_name: unknown
+          table_bytes: number
+          index_bytes: number
+          toast_bytes: number
+          total_bytes: number
+          node_name: unknown
+        }[]
+      }
       claim_collectivite: {
         Args: {
-          id: number;
-        };
-        Returns: Json;
-      };
+          id: number
+        }
+        Returns: Json
+      }
       col_is_null:
         | {
             Args: {
-              schema_name: unknown;
-              table_name: unknown;
-              column_name: unknown;
-              description?: string;
-            };
-            Returns: string;
+              schema_name: unknown
+              table_name: unknown
+              column_name: unknown
+              description?: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              table_name: unknown;
-              column_name: unknown;
-              description?: string;
-            };
-            Returns: string;
-          };
+              table_name: unknown
+              column_name: unknown
+              description?: string
+            }
+            Returns: string
+          }
       col_not_null:
         | {
             Args: {
-              schema_name: unknown;
-              table_name: unknown;
-              column_name: unknown;
-              description?: string;
-            };
-            Returns: string;
+              schema_name: unknown
+              table_name: unknown
+              column_name: unknown
+              description?: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              table_name: unknown;
-              column_name: unknown;
-              description?: string;
-            };
-            Returns: string;
-          };
+              table_name: unknown
+              column_name: unknown
+              description?: string
+            }
+            Returns: string
+          }
       collect_tap:
         | {
-            Args: Record<PropertyKey, never>;
-            Returns: string;
+            Args: Record<PropertyKey, never>
+            Returns: string
           }
         | {
             Args: {
-              "": string[];
-            };
-            Returns: string;
-          };
+              "": string[]
+            }
+            Returns: string
+          }
       collectivite_membres: {
         Args: {
-          id: number;
-        };
+          id: number
+        }
         Returns: {
-          user_id: string;
-          prenom: string;
-          nom: string;
-          email: string;
-          telephone: string;
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"];
-          fonction: Database["public"]["Enums"]["membre_fonction"];
-          details_fonction: string;
-          champ_intervention: Database["public"]["Enums"]["referentiel"][];
-        }[];
-      };
+          user_id: string
+          prenom: string
+          nom: string
+          email: string
+          telephone: string
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"]
+          fonction: Database["public"]["Enums"]["membre_fonction"]
+          details_fonction: string
+          champ_intervention: Database["public"]["Enums"]["referentiel"][]
+        }[]
+      }
       compress_chunk: {
         Args: {
-          uncompressed_chunk: unknown;
-          if_not_compressed?: boolean;
-        };
-        Returns: unknown;
-      };
+          uncompressed_chunk: unknown
+          if_not_compressed?: boolean
+        }
+        Returns: unknown
+      }
       consume_invitation: {
         Args: {
-          id: string;
-        };
-        Returns: undefined;
-      };
+          id: string
+        }
+        Returns: undefined
+      }
       create_distributed_hypertable: {
         Args: {
-          relation: unknown;
-          time_column_name: unknown;
-          partitioning_column?: unknown;
-          number_partitions?: number;
-          associated_schema_name?: unknown;
-          associated_table_prefix?: unknown;
-          chunk_time_interval?: unknown;
-          create_default_indexes?: boolean;
-          if_not_exists?: boolean;
-          partitioning_func?: unknown;
-          migrate_data?: boolean;
-          chunk_target_size?: string;
-          chunk_sizing_func?: unknown;
-          time_partitioning_func?: unknown;
-          replication_factor?: number;
-          data_nodes?: unknown[];
-        };
+          relation: unknown
+          time_column_name: unknown
+          partitioning_column?: unknown
+          number_partitions?: number
+          associated_schema_name?: unknown
+          associated_table_prefix?: unknown
+          chunk_time_interval?: unknown
+          create_default_indexes?: boolean
+          if_not_exists?: boolean
+          partitioning_func?: unknown
+          migrate_data?: boolean
+          chunk_target_size?: string
+          chunk_sizing_func?: unknown
+          time_partitioning_func?: unknown
+          replication_factor?: number
+          data_nodes?: unknown[]
+        }
         Returns: {
-          hypertable_id: number;
-          schema_name: unknown;
-          table_name: unknown;
-          created: boolean;
-        }[];
-      };
+          hypertable_id: number
+          schema_name: unknown
+          table_name: unknown
+          created: boolean
+        }[]
+      }
       create_distributed_restore_point: {
         Args: {
-          name: string;
-        };
+          name: string
+        }
         Returns: {
-          node_name: unknown;
-          node_type: string;
-          restore_point: unknown;
-        }[];
-      };
+          node_name: unknown
+          node_type: string
+          restore_point: unknown
+        }[]
+      }
       create_hypertable: {
         Args: {
-          relation: unknown;
-          time_column_name: unknown;
-          partitioning_column?: unknown;
-          number_partitions?: number;
-          associated_schema_name?: unknown;
-          associated_table_prefix?: unknown;
-          chunk_time_interval?: unknown;
-          create_default_indexes?: boolean;
-          if_not_exists?: boolean;
-          partitioning_func?: unknown;
-          migrate_data?: boolean;
-          chunk_target_size?: string;
-          chunk_sizing_func?: unknown;
-          time_partitioning_func?: unknown;
-          replication_factor?: number;
-          data_nodes?: unknown[];
-          distributed?: boolean;
-        };
+          relation: unknown
+          time_column_name: unknown
+          partitioning_column?: unknown
+          number_partitions?: number
+          associated_schema_name?: unknown
+          associated_table_prefix?: unknown
+          chunk_time_interval?: unknown
+          create_default_indexes?: boolean
+          if_not_exists?: boolean
+          partitioning_func?: unknown
+          migrate_data?: boolean
+          chunk_target_size?: string
+          chunk_sizing_func?: unknown
+          time_partitioning_func?: unknown
+          replication_factor?: number
+          data_nodes?: unknown[]
+          distributed?: boolean
+        }
         Returns: {
-          hypertable_id: number;
-          schema_name: unknown;
-          table_name: unknown;
-          created: boolean;
-        }[];
-      };
+          hypertable_id: number
+          schema_name: unknown
+          table_name: unknown
+          created: boolean
+        }[]
+      }
       decompress_chunk: {
         Args: {
-          uncompressed_chunk: unknown;
-          if_compressed?: boolean;
-        };
-        Returns: unknown;
-      };
+          uncompressed_chunk: unknown
+          if_compressed?: boolean
+        }
+        Returns: unknown
+      }
       delete_axe_all: {
         Args: {
-          axe_id: number;
-        };
-        Returns: undefined;
-      };
+          axe_id: number
+        }
+        Returns: undefined
+      }
       delete_data_node: {
         Args: {
-          node_name: unknown;
-          if_exists?: boolean;
-          force?: boolean;
-          repartition?: boolean;
-          drop_database?: boolean;
-        };
-        Returns: boolean;
-      };
+          node_name: unknown
+          if_exists?: boolean
+          force?: boolean
+          repartition?: boolean
+          drop_database?: boolean
+        }
+        Returns: boolean
+      }
       delete_job: {
         Args: {
-          job_id: number;
-        };
-        Returns: undefined;
-      };
+          job_id: number
+        }
+        Returns: undefined
+      }
       detach_data_node: {
         Args: {
-          node_name: unknown;
-          hypertable?: unknown;
-          if_attached?: boolean;
-          force?: boolean;
-          repartition?: boolean;
-          drop_remote_data?: boolean;
-        };
-        Returns: number;
-      };
+          node_name: unknown
+          hypertable?: unknown
+          if_attached?: boolean
+          force?: boolean
+          repartition?: boolean
+          drop_remote_data?: boolean
+        }
+        Returns: number
+      }
       detach_tablespace: {
         Args: {
-          tablespace: unknown;
-          hypertable?: unknown;
-          if_attached?: boolean;
-        };
-        Returns: number;
-      };
+          tablespace: unknown
+          hypertable?: unknown
+          if_attached?: boolean
+        }
+        Returns: number
+      }
       detach_tablespaces: {
         Args: {
-          hypertable: unknown;
-        };
-        Returns: number;
-      };
+          hypertable: unknown
+        }
+        Returns: number
+      }
       diag:
         | {
             Args: {
-              msg: string;
-            };
-            Returns: string;
+              msg: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              msg: unknown;
-            };
-            Returns: string;
+              msg: unknown
+            }
+            Returns: string
           }
         | {
-            Args: Record<PropertyKey, never>;
-            Returns: string;
+            Args: Record<PropertyKey, never>
+            Returns: string
           }
         | {
-            Args: Record<PropertyKey, never>;
-            Returns: string;
-          };
+            Args: Record<PropertyKey, never>
+            Returns: string
+          }
       diag_test_name: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       do_tap:
         | {
             Args: {
-              "": unknown;
-            };
-            Returns: string[];
+              "": unknown
+            }
+            Returns: string[]
           }
         | {
             Args: {
-              "": string;
-            };
-            Returns: string[];
+              "": string
+            }
+            Returns: string[]
           }
         | {
-            Args: Record<PropertyKey, never>;
-            Returns: string[];
-          };
+            Args: Record<PropertyKey, never>
+            Returns: string[]
+          }
       domains_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       drop_chunks: {
         Args: {
-          relation: unknown;
-          older_than?: unknown;
-          newer_than?: unknown;
-          verbose?: boolean;
-        };
-        Returns: string[];
-      };
+          relation: unknown
+          older_than?: unknown
+          newer_than?: unknown
+          verbose?: boolean
+        }
+        Returns: string[]
+      }
       enlever_action: {
         Args: {
-          fiche_id: number;
-          action_id: unknown;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          action_id: unknown
+        }
+        Returns: undefined
+      }
       enlever_fiche_action_d_un_axe: {
         Args: {
-          fiche_id: number;
-          axe_id: number;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          axe_id: number
+        }
+        Returns: undefined
+      }
       enlever_indicateur: {
         Args: {
-          fiche_id: number;
-          indicateur: Database["public"]["CompositeTypes"]["indicateur_generique"];
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          indicateur: Database["public"]["CompositeTypes"]["indicateur_generique"]
+        }
+        Returns: undefined
+      }
       enlever_partenaire: {
         Args: {
-          fiche_id: number;
-          partenaire: unknown;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          partenaire: unknown
+        }
+        Returns: undefined
+      }
       enlever_pilote: {
         Args: {
-          fiche_id: number;
-          pilote: Database["public"]["CompositeTypes"]["personne"];
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          pilote: Database["public"]["CompositeTypes"]["personne"]
+        }
+        Returns: undefined
+      }
       enlever_referent: {
         Args: {
-          fiche_id: number;
-          referent: Database["public"]["CompositeTypes"]["personne"];
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          referent: Database["public"]["CompositeTypes"]["personne"]
+        }
+        Returns: undefined
+      }
       enlever_service: {
         Args: {
-          fiche_id: number;
-          service: unknown;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          service: unknown
+        }
+        Returns: undefined
+      }
       enlever_sous_thematique: {
         Args: {
-          fiche_id: number;
-          thematique_id: number;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          thematique_id: number
+        }
+        Returns: undefined
+      }
       enlever_structure: {
         Args: {
-          fiche_id: number;
-          structure: unknown;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          structure: unknown
+        }
+        Returns: undefined
+      }
       enlever_thematique: {
         Args: {
-          fiche_id: number;
-          thematique: string;
-        };
-        Returns: undefined;
-      };
+          fiche_id: number
+          thematique: string
+        }
+        Returns: undefined
+      }
       enums_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       est_auditeur: {
         Args: {
-          collectivite: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Returns: boolean;
-      };
+          collectivite: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Returns: boolean
+      }
       extensions_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       fail:
         | {
             Args: {
-              "": string;
-            };
-            Returns: string;
+              "": string
+            }
+            Returns: string
           }
         | {
-            Args: Record<PropertyKey, never>;
-            Returns: string;
-          };
+            Args: Record<PropertyKey, never>
+            Returns: string
+          }
       fiche_resume: {
         Args: {
-          "": unknown;
-        };
+          "": unknown
+        }
         Returns: {
-          collectivite_id: number | null;
-          id: number | null;
-          modified_at: string | null;
-          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null;
-          plans: unknown[] | null;
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
-          titre: string | null;
-        }[];
-      };
+          collectivite_id: number | null
+          id: number | null
+          modified_at: string | null
+          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
+          plans: unknown[] | null
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
+          titre: string | null
+        }[]
+      }
       filter_fiches_action: {
         Args: {
-          collectivite_id: number;
-          sans_plan?: boolean;
-          axes_id?: number[];
-          sans_pilote?: boolean;
-          pilotes?: Database["public"]["CompositeTypes"]["personne"][];
-          sans_referent?: boolean;
-          referents?: Database["public"]["CompositeTypes"]["personne"][];
-          niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][];
-          statuts?: Database["public"]["Enums"]["fiche_action_statuts"][];
-          thematiques?: unknown[];
-          sous_thematiques?: unknown[];
-          budget_min?: number;
-          budget_max?: number;
-          date_debut?: string;
-          date_fin?: string;
-          echeance?: Database["public"]["Enums"]["fiche_action_echeances"];
-          limit?: number;
-        };
+          collectivite_id: number
+          sans_plan?: boolean
+          axes_id?: number[]
+          sans_pilote?: boolean
+          pilotes?: Database["public"]["CompositeTypes"]["personne"][]
+          sans_referent?: boolean
+          referents?: Database["public"]["CompositeTypes"]["personne"][]
+          sans_niveau?: boolean
+          niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][]
+          sans_statut?: boolean
+          statuts?: Database["public"]["Enums"]["fiche_action_statuts"][]
+          sans_thematique?: boolean
+          thematiques?: unknown[]
+          sans_sous_thematique?: boolean
+          sous_thematiques?: unknown[]
+          sans_budget?: boolean
+          budget_min?: number
+          budget_max?: number
+          sans_date?: boolean
+          date_debut?: string
+          date_fin?: string
+          echeance?: Database["public"]["Enums"]["fiche_action_echeances"]
+          limit?: number
+        }
         Returns: {
-          collectivite_id: number | null;
-          id: number | null;
-          modified_at: string | null;
-          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null;
-          plans: unknown[] | null;
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
-          titre: string | null;
-        }[];
-      };
+          collectivite_id: number | null
+          id: number | null
+          modified_at: string | null
+          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
+          plans: unknown[] | null
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
+          titre: string | null
+        }[]
+      }
       findfuncs: {
         Args: {
-          "": string;
-        };
-        Returns: string[];
-      };
+          "": string
+        }
+        Returns: string[]
+      }
       finish: {
         Args: {
-          exception_on_failure?: boolean;
-        };
-        Returns: string[];
-      };
+          exception_on_failure?: boolean
+        }
+        Returns: string[]
+      }
       flat_axes: {
         Args: {
-          axe_id: number;
-          max_depth?: number;
-        };
-        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][];
-      };
+          axe_id: number
+          max_depth?: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+      }
       foreign_tables_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       functions_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       gbt_bit_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_bool_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_bool_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_bpchar_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_bytea_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_cash_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_cash_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_date_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_date_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_decompress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_enum_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_enum_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_float4_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_float4_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_float8_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_float8_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_inet_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_int2_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_int2_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_int4_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_int4_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_int8_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_int8_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_intv_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_intv_decompress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_intv_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_macad_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_macad_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_macad8_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_macad8_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_numeric_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_oid_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_oid_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_text_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_time_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_time_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_timetz_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_ts_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_ts_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_tstz_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_uuid_compress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_uuid_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_var_decompress: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbt_var_fetch: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey_var_in: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey_var_out: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey16_in: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey16_out: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey2_in: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey2_out: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey32_in: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey32_out: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey4_in: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey4_out: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey8_in: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       gbtreekey8_out: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       get_telemetry_report: {
-        Args: Record<PropertyKey, never>;
-        Returns: Json;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: Json
+      }
       groups_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       has_check: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_composite: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_domain: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_enum: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_extension: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_fk: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_foreign_table: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_function: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_group: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_inherited_tables: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_language: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_materialized_view: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_opclass: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_pk: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_relation: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_role: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_schema: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_sequence: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_table: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_tablespace: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_type: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_unique: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       has_user: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       has_view: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_composite: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_domain: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_enum: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_extension: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_fk: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_foreign_table: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_function: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_group: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_inherited_tables: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_language: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_materialized_view: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_opclass: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_pk: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_relation: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_role: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_schema: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_sequence: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_table: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_tablespace: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_type: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_user: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       hasnt_view: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       have_admin_acces: {
         Args: {
-          id: number;
-        };
-        Returns: boolean;
-      };
+          id: number
+        }
+        Returns: boolean
+      }
       have_discussion_edition_acces: {
         Args: {
-          id: number;
-        };
-        Returns: boolean;
-      };
+          id: number
+        }
+        Returns: boolean
+      }
       have_discussion_lecture_acces: {
         Args: {
-          id: number;
-        };
-        Returns: boolean;
-      };
+          id: number
+        }
+        Returns: boolean
+      }
       have_edition_acces: {
         Args: {
-          id: number;
-        };
-        Returns: boolean;
-      };
+          id: number
+        }
+        Returns: boolean
+      }
       have_lecture_acces: {
         Args: {
-          id: number;
-        };
-        Returns: boolean;
-      };
+          id: number
+        }
+        Returns: boolean
+      }
       have_one_of_niveaux_acces: {
         Args: {
-          niveaux: Database["public"]["Enums"]["niveau_acces"][];
-          id: number;
-        };
-        Returns: boolean;
-      };
+          niveaux: Database["public"]["Enums"]["niveau_acces"][]
+          id: number
+        }
+        Returns: boolean
+      }
       hypertable_compression_stats: {
         Args: {
-          hypertable: unknown;
-        };
+          hypertable: unknown
+        }
         Returns: {
-          total_chunks: number;
-          number_compressed_chunks: number;
-          before_compression_table_bytes: number;
-          before_compression_index_bytes: number;
-          before_compression_toast_bytes: number;
-          before_compression_total_bytes: number;
-          after_compression_table_bytes: number;
-          after_compression_index_bytes: number;
-          after_compression_toast_bytes: number;
-          after_compression_total_bytes: number;
-          node_name: unknown;
-        }[];
-      };
+          total_chunks: number
+          number_compressed_chunks: number
+          before_compression_table_bytes: number
+          before_compression_index_bytes: number
+          before_compression_toast_bytes: number
+          before_compression_total_bytes: number
+          after_compression_table_bytes: number
+          after_compression_index_bytes: number
+          after_compression_toast_bytes: number
+          after_compression_total_bytes: number
+          node_name: unknown
+        }[]
+      }
       hypertable_detailed_size: {
         Args: {
-          hypertable: unknown;
-        };
+          hypertable: unknown
+        }
         Returns: {
-          table_bytes: number;
-          index_bytes: number;
-          toast_bytes: number;
-          total_bytes: number;
-          node_name: unknown;
-        }[];
-      };
+          table_bytes: number
+          index_bytes: number
+          toast_bytes: number
+          total_bytes: number
+          node_name: unknown
+        }[]
+      }
       hypertable_index_size: {
         Args: {
-          index_name: unknown;
-        };
-        Returns: number;
-      };
+          index_name: unknown
+        }
+        Returns: number
+      }
       hypertable_size: {
         Args: {
-          hypertable: unknown;
-        };
-        Returns: number;
-      };
+          hypertable: unknown
+        }
+        Returns: number
+      }
       in_todo: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
       index_is_primary: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       index_is_unique: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       interpolate:
         | {
             Args: {
-              value: number;
-              prev?: Record<string, unknown>;
-              next?: Record<string, unknown>;
-            };
-            Returns: number;
+              value: number
+              prev?: Record<string, unknown>
+              next?: Record<string, unknown>
+            }
+            Returns: number
           }
         | {
             Args: {
-              value: number;
-              prev?: Record<string, unknown>;
-              next?: Record<string, unknown>;
-            };
-            Returns: number;
+              value: number
+              prev?: Record<string, unknown>
+              next?: Record<string, unknown>
+            }
+            Returns: number
           }
         | {
             Args: {
-              value: number;
-              prev?: Record<string, unknown>;
-              next?: Record<string, unknown>;
-            };
-            Returns: number;
+              value: number
+              prev?: Record<string, unknown>
+              next?: Record<string, unknown>
+            }
+            Returns: number
           }
         | {
             Args: {
-              value: number;
-              prev?: Record<string, unknown>;
-              next?: Record<string, unknown>;
-            };
-            Returns: number;
+              value: number
+              prev?: Record<string, unknown>
+              next?: Record<string, unknown>
+            }
+            Returns: number
           }
         | {
             Args: {
-              value: number;
-              prev?: Record<string, unknown>;
-              next?: Record<string, unknown>;
-            };
-            Returns: number;
-          };
+              value: number
+              prev?: Record<string, unknown>
+              next?: Record<string, unknown>
+            }
+            Returns: number
+          }
       is_agent_of: {
         Args: {
-          id: number;
-        };
-        Returns: boolean;
-      };
+          id: number
+        }
+        Returns: boolean
+      }
       is_aggregate: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       is_any_role_on: {
         Args: {
-          id: number;
-        };
-        Returns: boolean;
-      };
+          id: number
+        }
+        Returns: boolean
+      }
       is_authenticated: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
       is_bucket_writer: {
         Args: {
-          id: string;
-        };
-        Returns: boolean;
-      };
+          id: string
+        }
+        Returns: boolean
+      }
       is_clustered: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       is_definer: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       is_empty: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       is_normal_function: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       is_partitioned: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       is_procedure: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       is_referent_of: {
         Args: {
-          id: number;
-        };
-        Returns: boolean;
-      };
+          id: number
+        }
+        Returns: boolean
+      }
       is_service_role: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
       is_strict: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       is_superuser: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       is_window: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       isnt_aggregate: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       isnt_definer: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       isnt_empty: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       isnt_normal_function: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       isnt_partitioned: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       isnt_procedure: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       isnt_strict: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       isnt_superuser: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       isnt_window: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       json_matches_schema: {
         Args: {
-          schema: Json;
-          instance: Json;
-        };
-        Returns: boolean;
-      };
+          schema: Json
+          instance: Json
+        }
+        Returns: boolean
+      }
       jsonb_matches_schema: {
         Args: {
-          schema: Json;
-          instance: Json;
-        };
-        Returns: boolean;
-      };
+          schema: Json
+          instance: Json
+        }
+        Returns: boolean
+      }
       labellisation_cloturer_audit: {
         Args: {
-          audit_id: number;
-          date_fin?: string;
-        };
+          audit_id: number
+          date_fin?: string
+        }
         Returns: {
-          collectivite_id: number;
-          date_debut: string | null;
-          date_fin: string | null;
-          demande_id: number | null;
-          id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          valide: boolean;
-        };
-      };
+          collectivite_id: number
+          date_debut: string | null
+          date_fin: string | null
+          demande_id: number | null
+          id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          valide: boolean
+        }
+      }
       labellisation_commencer_audit: {
         Args: {
-          audit_id: number;
-          date_debut?: string;
-        };
+          audit_id: number
+          date_debut?: string
+        }
         Returns: {
-          collectivite_id: number;
-          date_debut: string | null;
-          date_fin: string | null;
-          demande_id: number | null;
-          id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          valide: boolean;
-        };
-      };
+          collectivite_id: number
+          date_debut: string | null
+          date_fin: string | null
+          demande_id: number | null
+          id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          valide: boolean
+        }
+      }
       labellisation_demande: {
         Args: {
-          collectivite_id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
+          collectivite_id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
         Returns: {
-          collectivite_id: number;
-          date: string;
-          demandeur: string | null;
-          en_cours: boolean;
-          envoyee_le: string | null;
-          etoiles: Database["labellisation"]["Enums"]["etoile"] | null;
-          id: number;
-          modified_at: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"];
-        };
-      };
+          collectivite_id: number
+          date: string
+          demandeur: string | null
+          en_cours: boolean
+          envoyee_le: string | null
+          etoiles: Database["labellisation"]["Enums"]["etoile"] | null
+          id: number
+          modified_at: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"]
+        }
+      }
       labellisation_parcours: {
         Args: {
-          collectivite_id: number;
-        };
+          collectivite_id: number
+        }
         Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          etoiles: Database["labellisation"]["Enums"]["etoile"];
-          completude_ok: boolean;
-          critere_score: Json;
-          criteres_action: Json;
-          rempli: boolean;
-          calendrier: string;
-          demande: Json;
-          labellisation: Json;
-          audit: Json;
-        }[];
-      };
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          etoiles: Database["labellisation"]["Enums"]["etoile"]
+          completude_ok: boolean
+          critere_score: Json
+          criteres_action: Json
+          rempli: boolean
+          calendrier: string
+          demande: Json
+          labellisation: Json
+          audit: Json
+        }[]
+      }
       labellisation_peut_commencer_audit: {
         Args: {
-          collectivite_id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Returns: boolean;
-      };
+          collectivite_id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Returns: boolean
+      }
       labellisation_submit_demande: {
         Args: {
-          collectivite_id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"];
-          etoiles?: Database["labellisation"]["Enums"]["etoile"];
-        };
+          collectivite_id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"]
+          etoiles?: Database["labellisation"]["Enums"]["etoile"]
+        }
         Returns: {
-          collectivite_id: number;
-          date: string;
-          demandeur: string | null;
-          en_cours: boolean;
-          envoyee_le: string | null;
-          etoiles: Database["labellisation"]["Enums"]["etoile"] | null;
-          id: number;
-          modified_at: string | null;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"];
-        };
-      };
+          collectivite_id: number
+          date: string
+          demandeur: string | null
+          en_cours: boolean
+          envoyee_le: string | null
+          etoiles: Database["labellisation"]["Enums"]["etoile"] | null
+          id: number
+          modified_at: string | null
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"]
+        }
+      }
       language_is_trusted: {
         Args: {
-          "": unknown;
-        };
-        Returns: string;
-      };
+          "": unknown
+        }
+        Returns: string
+      }
       languages_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       lives_ok: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       locf: {
         Args: {
-          value: unknown;
-          prev?: unknown;
-          treat_null_as_missing?: boolean;
-        };
-        Returns: unknown;
-      };
+          value: unknown
+          prev?: unknown
+          treat_null_as_missing?: boolean
+        }
+        Returns: unknown
+      }
       materialized_views_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       move_chunk: {
         Args: {
-          chunk: unknown;
-          destination_tablespace: unknown;
-          index_destination_tablespace?: unknown;
-          reorder_index?: unknown;
-          verbose?: boolean;
-        };
-        Returns: undefined;
-      };
+          chunk: unknown
+          destination_tablespace: unknown
+          index_destination_tablespace?: unknown
+          reorder_index?: unknown
+          verbose?: boolean
+        }
+        Returns: undefined
+      }
       naturalsort: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       navigation_plans: {
         Args: {
-          collectivite_id: number;
-        };
-        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][];
-      };
+          collectivite_id: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
+      }
       no_plan: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean[];
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean[]
+      }
       num_failed: {
-        Args: Record<PropertyKey, never>;
-        Returns: number;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
       ok: {
         Args: {
-          "": boolean;
-        };
-        Returns: string;
-      };
+          "": boolean
+        }
+        Returns: string
+      }
       opclasses_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       operators_are: {
         Args: {
-          "": string[];
-        };
-        Returns: string;
-      };
+          "": string[]
+        }
+        Returns: string
+      }
       os_name: {
-        Args: Record<PropertyKey, never>;
-        Returns: string;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
       pass:
         | {
             Args: {
-              "": string;
-            };
-            Returns: string;
+              "": string
+            }
+            Returns: string
           }
         | {
-            Args: Record<PropertyKey, never>;
-            Returns: string;
-          };
+            Args: Record<PropertyKey, never>
+            Returns: string
+          }
       personnes_collectivite: {
         Args: {
-          collectivite_id: number;
-        };
-        Returns: Database["public"]["CompositeTypes"]["personne"][];
-      };
+          collectivite_id: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["personne"][]
+      }
       peut_lire_la_fiche: {
         Args: {
-          fiche_id: number;
-        };
-        Returns: boolean;
-      };
+          fiche_id: number
+        }
+        Returns: boolean
+      }
       peut_modifier_la_fiche: {
         Args: {
-          fiche_id: number;
-        };
-        Returns: boolean;
-      };
+          fiche_id: number
+        }
+        Returns: boolean
+      }
       pg_version: {
-        Args: Record<PropertyKey, never>;
-        Returns: string;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
       pg_version_num: {
-        Args: Record<PropertyKey, never>;
-        Returns: number;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
       pgtap_version: {
-        Args: Record<PropertyKey, never>;
-        Returns: number;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
       plan: {
         Args: {
-          "": number;
-        };
-        Returns: string;
-      };
+          "": number
+        }
+        Returns: string
+      }
       plan_action: {
         Args: {
-          id: number;
-        };
-        Returns: Json;
-      };
+          id: number
+        }
+        Returns: Json
+      }
       plan_action_export: {
         Args: {
-          id: number;
-        };
-        Returns: Database["public"]["CompositeTypes"]["fiche_action_export"][];
-      };
+          id: number
+        }
+        Returns: Database["public"]["CompositeTypes"]["fiche_action_export"][]
+      }
       plan_action_profondeur: {
         Args: {
-          id: number;
-          profondeur: number;
-        };
-        Returns: Json;
-      };
+          id: number
+          profondeur: number
+        }
+        Returns: Json
+      }
       plan_action_tableau_de_bord: {
         Args: {
-          collectivite_id: number;
-          plan_id?: number;
-          sans_plan?: boolean;
-        };
-        Returns: Database["public"]["CompositeTypes"]["plan_action_tableau_de_bord"];
-      };
+          collectivite_id: number
+          plan_id?: number
+          sans_plan?: boolean
+        }
+        Returns: Database["public"]["CompositeTypes"]["plan_action_tableau_de_bord"]
+      }
       plans_action_collectivite: {
         Args: {
-          collectivite_id: number;
-        };
+          collectivite_id: number
+        }
         Returns: {
-          collectivite_id: number;
-          created_at: string;
-          id: number;
-          modified_at: string;
-          modified_by: string | null;
-          nom: string | null;
-          parent: number | null;
-        }[];
-      };
+          collectivite_id: number
+          created_at: string
+          id: number
+          modified_at: string
+          modified_by: string | null
+          nom: string | null
+          parent: number | null
+        }[]
+      }
       preuve_count: {
         Args: {
-          collectivite_id: number;
-          action_id: unknown;
-        };
-        Returns: number;
-      };
+          collectivite_id: number
+          action_id: unknown
+        }
+        Returns: number
+      }
       quit_collectivite: {
         Args: {
-          id: number;
-        };
-        Returns: Json;
-      };
+          id: number
+        }
+        Returns: Json
+      }
       referent_contact: {
         Args: {
-          id: number;
-        };
-        Returns: Json;
-      };
+          id: number
+        }
+        Returns: Json
+      }
       referent_contacts: {
         Args: {
-          id: number;
-        };
+          id: number
+        }
         Returns: {
-          prenom: string;
-          nom: string;
-          email: string;
-        }[];
-      };
+          prenom: string
+          nom: string
+          email: string
+        }[]
+      }
       referentiel_down_to_action: {
         Args: {
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
         Returns: {
-          children: unknown[] | null;
-          depth: number | null;
-          description: string | null;
-          have_contexte: boolean | null;
-          have_exemples: boolean | null;
-          have_perimetre_evaluation: boolean | null;
-          have_preuve: boolean | null;
-          have_questions: boolean | null;
-          have_reduction_potentiel: boolean | null;
-          have_ressources: boolean | null;
-          id: string | null;
-          identifiant: string | null;
-          nom: string | null;
-          phase: Database["public"]["Enums"]["action_categorie"] | null;
-          referentiel: Database["public"]["Enums"]["referentiel"] | null;
-          type: Database["public"]["Enums"]["action_type"] | null;
-        }[];
-      };
+          children: unknown[] | null
+          depth: number | null
+          description: string | null
+          have_contexte: boolean | null
+          have_exemples: boolean | null
+          have_perimetre_evaluation: boolean | null
+          have_preuve: boolean | null
+          have_questions: boolean | null
+          have_reduction_potentiel: boolean | null
+          have_ressources: boolean | null
+          id: string | null
+          identifiant: string | null
+          nom: string | null
+          phase: Database["public"]["Enums"]["action_categorie"] | null
+          referentiel: Database["public"]["Enums"]["referentiel"] | null
+          type: Database["public"]["Enums"]["action_type"] | null
+        }[]
+      }
       remove_compression_policy: {
         Args: {
-          hypertable: unknown;
-          if_exists?: boolean;
-        };
-        Returns: boolean;
-      };
+          hypertable: unknown
+          if_exists?: boolean
+        }
+        Returns: boolean
+      }
       remove_continuous_aggregate_policy: {
         Args: {
-          continuous_aggregate: unknown;
-          if_not_exists?: boolean;
-          if_exists?: boolean;
-        };
-        Returns: undefined;
-      };
+          continuous_aggregate: unknown
+          if_not_exists?: boolean
+          if_exists?: boolean
+        }
+        Returns: undefined
+      }
       remove_membre_from_collectivite: {
         Args: {
-          collectivite_id: number;
-          email: string;
-        };
-        Returns: Json;
-      };
+          collectivite_id: number
+          email: string
+        }
+        Returns: Json
+      }
       remove_reorder_policy: {
         Args: {
-          hypertable: unknown;
-          if_exists?: boolean;
-        };
-        Returns: undefined;
-      };
+          hypertable: unknown
+          if_exists?: boolean
+        }
+        Returns: undefined
+      }
       remove_retention_policy: {
         Args: {
-          relation: unknown;
-          if_exists?: boolean;
-        };
-        Returns: undefined;
-      };
+          relation: unknown
+          if_exists?: boolean
+        }
+        Returns: undefined
+      }
       reorder_chunk: {
         Args: {
-          chunk: unknown;
-          index?: unknown;
-          verbose?: boolean;
-        };
-        Returns: undefined;
-      };
+          chunk: unknown
+          index?: unknown
+          verbose?: boolean
+        }
+        Returns: undefined
+      }
       retool_user_list: {
-        Args: Record<PropertyKey, never>;
+        Args: Record<PropertyKey, never>
         Returns: {
-          droit_id: number;
-          nom: string;
-          prenom: string;
-          email: string;
-          collectivite: string;
-        }[];
-      };
+          droit_id: number
+          nom: string
+          prenom: string
+          email: string
+          collectivite: string
+        }[]
+      }
       roles_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       runtests:
         | {
             Args: {
-              "": unknown;
-            };
-            Returns: string[];
+              "": unknown
+            }
+            Returns: string[]
           }
         | {
             Args: {
-              "": string;
-            };
-            Returns: string[];
+              "": string
+            }
+            Returns: string[]
           }
         | {
-            Args: Record<PropertyKey, never>;
-            Returns: string[];
-          };
+            Args: Record<PropertyKey, never>
+            Returns: string[]
+          }
       save_reponse: {
         Args: {
-          "": Json;
-        };
-        Returns: undefined;
-      };
+          "": Json
+        }
+        Returns: undefined
+      }
       schemas_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       sequences_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       set_adaptive_chunking: {
         Args: {
-          hypertable: unknown;
-          chunk_target_size: string;
-        };
-        Returns: Record<string, unknown>;
-      };
+          hypertable: unknown
+          chunk_target_size: string
+        }
+        Returns: Record<string, unknown>
+      }
       set_chunk_time_interval: {
         Args: {
-          hypertable: unknown;
-          chunk_time_interval: unknown;
-          dimension_name?: unknown;
-        };
-        Returns: undefined;
-      };
+          hypertable: unknown
+          chunk_time_interval: unknown
+          dimension_name?: unknown
+        }
+        Returns: undefined
+      }
       set_integer_now_func: {
         Args: {
-          hypertable: unknown;
-          integer_now_func: unknown;
-          replace_if_exists?: boolean;
-        };
-        Returns: undefined;
-      };
+          hypertable: unknown
+          integer_now_func: unknown
+          replace_if_exists?: boolean
+        }
+        Returns: undefined
+      }
       set_number_partitions: {
         Args: {
-          hypertable: unknown;
-          number_partitions: number;
-          dimension_name?: unknown;
-        };
-        Returns: undefined;
-      };
+          hypertable: unknown
+          number_partitions: number
+          dimension_name?: unknown
+        }
+        Returns: undefined
+      }
       set_replication_factor: {
         Args: {
-          hypertable: unknown;
-          replication_factor: number;
-        };
-        Returns: undefined;
-      };
+          hypertable: unknown
+          replication_factor: number
+        }
+        Returns: undefined
+      }
       show_chunks: {
         Args: {
-          relation: unknown;
-          older_than?: unknown;
-          newer_than?: unknown;
-        };
-        Returns: unknown[];
-      };
+          relation: unknown
+          older_than?: unknown
+          newer_than?: unknown
+        }
+        Returns: unknown[]
+      }
       show_tablespaces: {
         Args: {
-          hypertable: unknown;
-        };
-        Returns: unknown[];
-      };
+          hypertable: unknown
+        }
+        Returns: unknown[]
+      }
       skip:
         | {
             Args: {
-              why: string;
-              how_many: number;
-            };
-            Returns: string;
+              why: string
+              how_many: number
+            }
+            Returns: string
           }
         | {
             Args: {
-              "": string;
-            };
-            Returns: string;
+              "": string
+            }
+            Returns: string
           }
         | {
             Args: {
-              "": number;
-            };
-            Returns: string;
-          };
+              "": number
+            }
+            Returns: string
+          }
       tables_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       tablespaces_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       teapot: {
-        Args: Record<PropertyKey, never>;
-        Returns: Json;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: Json
+      }
       test_add_random_user: {
         Args: {
-          collectivite_id: number;
-          niveau: Database["public"]["Enums"]["niveau_acces"];
-          cgu_acceptees?: boolean;
-        };
-        Returns: Record<string, unknown>;
-      };
+          collectivite_id: number
+          niveau: Database["public"]["Enums"]["niveau_acces"]
+          cgu_acceptees?: boolean
+        }
+        Returns: Record<string, unknown>
+      }
       test_attach_user: {
         Args: {
-          user_id: string;
-          collectivite_id: number;
-          niveau: Database["public"]["Enums"]["niveau_acces"];
-        };
-        Returns: undefined;
-      };
+          user_id: string
+          collectivite_id: number
+          niveau: Database["public"]["Enums"]["niveau_acces"]
+        }
+        Returns: undefined
+      }
       test_changer_acces_restreint_collectivite: {
         Args: {
-          collectivite_id: number;
-          access_restreint: boolean;
-        };
-        Returns: undefined;
-      };
+          collectivite_id: number
+          access_restreint: boolean
+        }
+        Returns: undefined
+      }
       test_clear_history: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_create_collectivite: {
         Args: {
-          nom: string;
-        };
+          nom: string
+        }
         Returns: {
-          collectivite_id: number | null;
-          id: number;
-          nom: string;
-        };
-      };
+          collectivite_id: number | null
+          id: number
+          nom: string
+        }
+      }
       test_create_user: {
         Args: {
-          user_id: string;
-          prenom: string;
-          nom: string;
-          email: string;
-        };
-        Returns: undefined;
-      };
+          user_id: string
+          prenom: string
+          nom: string
+          email: string
+        }
+        Returns: undefined
+      }
       test_disable_fake_score_generation: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_enable_fake_score_generation: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_fulfill: {
         Args: {
-          collectivite_id: number;
-          etoile: Database["labellisation"]["Enums"]["etoile"];
-        };
-        Returns: undefined;
-      };
+          collectivite_id: number
+          etoile: Database["labellisation"]["Enums"]["etoile"]
+        }
+        Returns: undefined
+      }
       test_generate_fake_scores: {
         Args: {
-          collectivite_id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-          statuts: unknown[];
-        };
-        Returns: Json;
-      };
+          collectivite_id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+          statuts: unknown[]
+        }
+        Returns: Json
+      }
       test_max_fulfill: {
         Args: {
-          collectivite_id: number;
-          referentiel: Database["public"]["Enums"]["referentiel"];
-        };
-        Returns: undefined;
-      };
+          collectivite_id: number
+          referentiel: Database["public"]["Enums"]["referentiel"]
+        }
+        Returns: undefined
+      }
       test_remove_user: {
         Args: {
-          email: string;
-        };
-        Returns: undefined;
-      };
+          email: string
+        }
+        Returns: undefined
+      }
       test_reset: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_action_statut_and_desc: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_audit: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_discussion_et_commentaires: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_droits: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_membres: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_plan_action: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_preuves: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_reponse: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_reset_users: {
-        Args: Record<PropertyKey, never>;
-        Returns: undefined;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       test_set_auditeur: {
         Args: {
-          demande_id: number;
-          user_id: string;
-          audit_en_cours?: boolean;
-        };
+          demande_id: number
+          user_id: string
+          audit_en_cours?: boolean
+        }
         Returns: {
-          audit_id: number;
-          auditeur: string;
-          created_at: string | null;
-        };
-      };
+          audit_id: number
+          auditeur: string
+          created_at: string | null
+        }
+      }
       test_set_cot: {
         Args: {
-          collectivite_id: number;
-          actif: boolean;
-        };
+          collectivite_id: number
+          actif: boolean
+        }
         Returns: {
-          actif: boolean;
-          collectivite_id: number;
-          signataire: number | null;
-        };
-      };
+          actif: boolean
+          collectivite_id: number
+          signataire: number | null
+        }
+      }
       test_write_scores: {
         Args: {
-          collectivite_id: number;
-          scores?: unknown[];
-        };
-        Returns: undefined;
-      };
+          collectivite_id: number
+          scores?: unknown[]
+        }
+        Returns: undefined
+      }
       throws_ok: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       time_bucket:
         | {
             Args: {
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> d8b0e10a9 (update types)
               bucket_width: unknown
               ts: string
             }
             Returns: string
+<<<<<<< HEAD
           }
         | {
             Args: {
@@ -6543,47 +7157,58 @@ export interface Database {
             };
             Returns: string;
 >>>>>>> 55e9bca97 (MAJ database.types.ts)
+=======
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+>>>>>>> d8b0e10a9 (update types)
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              origin: string;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              origin: string;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              origin: string;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
           }
         | {
             Args: {
+              bucket_width: unknown
+              ts: string
+              offset: unknown
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+<<<<<<< HEAD
 <<<<<<< HEAD
               bucket_width: unknown
               ts: string
@@ -6598,181 +7223,189 @@ export interface Database {
             };
             Returns: string;
 >>>>>>> 55e9bca97 (MAJ database.types.ts)
+=======
+              bucket_width: unknown
+              ts: string
+              offset: unknown
+            }
+            Returns: string
+>>>>>>> d8b0e10a9 (update types)
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              offset: unknown;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+              offset: unknown
+            }
+            Returns: string
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              timezone: string;
-              origin?: string;
-              offset?: unknown;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+              timezone: string
+              origin?: string
+              offset?: unknown
+            }
+            Returns: string
           }
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-            };
-            Returns: number;
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
           }
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-            };
-            Returns: number;
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
           }
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-            };
-            Returns: number;
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
           }
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-              offset: number;
-            };
-            Returns: number;
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
           }
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-              offset: number;
-            };
-            Returns: number;
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
           }
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-              offset: number;
-            };
-            Returns: number;
-          };
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
       time_bucket_gapfill:
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-              start?: number;
-              finish?: number;
-            };
-            Returns: number;
+              bucket_width: number
+              ts: number
+              start?: number
+              finish?: number
+            }
+            Returns: number
           }
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-              start?: number;
-              finish?: number;
-            };
-            Returns: number;
+              bucket_width: number
+              ts: number
+              start?: number
+              finish?: number
+            }
+            Returns: number
           }
         | {
             Args: {
-              bucket_width: number;
-              ts: number;
-              start?: number;
-              finish?: number;
-            };
-            Returns: number;
+              bucket_width: number
+              ts: number
+              start?: number
+              finish?: number
+            }
+            Returns: number
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              start?: string;
-              finish?: string;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+              start?: string
+              finish?: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              start?: string;
-              finish?: string;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+              start?: string
+              finish?: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              start?: string;
-              finish?: string;
-            };
-            Returns: string;
+              bucket_width: unknown
+              ts: string
+              start?: string
+              finish?: string
+            }
+            Returns: string
           }
         | {
             Args: {
-              bucket_width: unknown;
-              ts: string;
-              timezone: string;
-              start?: string;
-              finish?: string;
-            };
-            Returns: string;
-          };
+              bucket_width: unknown
+              ts: string
+              timezone: string
+              start?: string
+              finish?: string
+            }
+            Returns: string
+          }
       timescaledb_fdw_handler: {
-        Args: Record<PropertyKey, never>;
-        Returns: unknown;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: unknown
+      }
       timescaledb_post_restore: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
       timescaledb_pre_restore: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean;
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
       todo:
         | {
             Args: {
-              why: string;
-              how_many: number;
-            };
-            Returns: boolean[];
+              why: string
+              how_many: number
+            }
+            Returns: boolean[]
           }
         | {
             Args: {
-              how_many: number;
-              why: string;
-            };
-            Returns: boolean[];
+              how_many: number
+              why: string
+            }
+            Returns: boolean[]
           }
         | {
             Args: {
-              why: string;
-            };
-            Returns: boolean[];
+              why: string
+            }
+            Returns: boolean[]
           }
         | {
             Args: {
-              how_many: number;
-            };
-            Returns: boolean[];
-          };
+              how_many: number
+            }
+            Returns: boolean[]
+          }
       todo_end: {
-        Args: Record<PropertyKey, never>;
-        Returns: boolean[];
-      };
+        Args: Record<PropertyKey, never>
+        Returns: boolean[]
+      }
       todo_start:
         | {
             Args: {
+<<<<<<< HEAD
 <<<<<<< HEAD
               "": string
             }
@@ -6792,103 +7425,113 @@ export interface Database {
             Returns: boolean[];
           };
 >>>>>>> 55e9bca97 (MAJ database.types.ts)
+=======
+              "": string
+            }
+            Returns: boolean[]
+          }
+        | {
+            Args: Record<PropertyKey, never>
+            Returns: boolean[]
+          }
+>>>>>>> d8b0e10a9 (update types)
       types_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       unaccent: {
         Args: {
-          "": string;
-        };
-        Returns: string;
-      };
+          "": string
+        }
+        Returns: string
+      }
       unaccent_init: {
         Args: {
-          "": unknown;
-        };
-        Returns: unknown;
-      };
+          "": unknown
+        }
+        Returns: unknown
+      }
       update_bibliotheque_fichier_filename: {
         Args: {
-          collectivite_id: number;
-          hash: string;
-          filename: string;
-        };
-        Returns: undefined;
-      };
+          collectivite_id: number
+          hash: string
+          filename: string
+        }
+        Returns: undefined
+      }
       update_collectivite_membre_champ_intervention: {
         Args: {
-          collectivite_id: number;
-          membre_id: string;
-          champ_intervention: Database["public"]["Enums"]["referentiel"][];
-        };
-        Returns: Json;
-      };
+          collectivite_id: number
+          membre_id: string
+          champ_intervention: Database["public"]["Enums"]["referentiel"][]
+        }
+        Returns: Json
+      }
       update_collectivite_membre_details_fonction: {
         Args: {
-          collectivite_id: number;
-          membre_id: string;
-          details_fonction: string;
-        };
-        Returns: Json;
-      };
+          collectivite_id: number
+          membre_id: string
+          details_fonction: string
+        }
+        Returns: Json
+      }
       update_collectivite_membre_fonction: {
         Args: {
-          collectivite_id: number;
-          membre_id: string;
-          fonction: Database["public"]["Enums"]["membre_fonction"];
-        };
-        Returns: Json;
-      };
+          collectivite_id: number
+          membre_id: string
+          fonction: Database["public"]["Enums"]["membre_fonction"]
+        }
+        Returns: Json
+      }
       update_collectivite_membre_niveau_acces: {
         Args: {
-          collectivite_id: number;
-          membre_id: string;
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"];
-        };
-        Returns: Json;
-      };
+          collectivite_id: number
+          membre_id: string
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"]
+        }
+        Returns: Json
+      }
       upsert_axe: {
         Args: {
-          nom: string;
-          collectivite_id: number;
-          parent: number;
-        };
-        Returns: number;
-      };
+          nom: string
+          collectivite_id: number
+          parent: number
+        }
+        Returns: number
+      }
       users_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
+          "": unknown[]
+        }
+        Returns: string
+      }
       views_are: {
         Args: {
-          "": unknown[];
-        };
-        Returns: string;
-      };
-    };
+          "": unknown[]
+        }
+        Returns: string
+      }
+    }
     Enums: {
-      action_categorie: "bases" | "mise en œuvre" | "effets";
-      action_discussion_statut: "ouvert" | "ferme";
+      action_categorie: "bases" | "mise en œuvre" | "effets"
+      action_discussion_statut: "ouvert" | "ferme"
       action_type:
         | "referentiel"
         | "axe"
         | "sous-axe"
         | "action"
         | "sous-action"
-        | "tache";
-      audit_statut: "non_audite" | "en_cours" | "audite";
+        | "tache"
+      audit_statut: "non_audite" | "en_cours" | "audite"
       avancement:
         | "fait"
         | "pas_fait"
         | "programme"
         | "non_renseigne"
-        | "detaille";
-      collectivite_filtre_type: "population" | "score" | "remplissage";
+        | "detaille"
+      collectivite_filtre_type: "population" | "score" | "remplissage"
       fiche_action_cibles:
         | "Grand public et associations"
         | "Public Scolaire"
@@ -6900,15 +7543,15 @@ export interface Database {
         | "Partenaires"
         | "Collectivité elle-même"
         | "Elus locaux"
-        | "Agents";
+        | "Agents"
       fiche_action_echeances:
         | "Action en amélioration continue"
         | "Sans échéance"
         | "Échéance dépassée"
         | "Échéance dans moins de trois mois"
         | "Échéance entre trois mois et 1 an"
-        | "Échéance dans plus d’un an";
-      fiche_action_niveaux_priorite: "Élevé" | "Moyen" | "Bas";
+        | "Échéance dans plus d’un an"
+      fiche_action_niveaux_priorite: "Élevé" | "Moyen" | "Bas"
       fiche_action_piliers_eci:
         | "Approvisionnement durable"
         | "Écoconception"
@@ -6916,7 +7559,7 @@ export interface Database {
         | "Économie de la fonctionnalité"
         | "Consommation responsable"
         | "Allongement de la durée d’usage"
-        | "Recyclage";
+        | "Recyclage"
       fiche_action_resultats_attendus:
         | "Adaptation au changement climatique"
         | "Allongement de la durée d’usage"
@@ -6928,13 +7571,13 @@ export interface Database {
         | "Réduction des déchets"
         | "Réduction des émissions de gaz à effet de serre"
         | "Réduction des polluants atmosphériques"
-        | "Sobriété énergétique";
+        | "Sobriété énergétique"
       fiche_action_statuts:
         | "À venir"
         | "En cours"
         | "Réalisé"
         | "En pause"
-        | "Abandonné";
+        | "Abandonné"
       filterable_type_collectivite:
         | "commune"
         | "syndicat"
@@ -6944,14 +7587,14 @@ export interface Database {
         | "METRO"
         | "CA"
         | "EPT"
-        | "PETR";
-      indicateur_group: "cae" | "crte" | "eci";
+        | "PETR"
+      indicateur_group: "cae" | "crte" | "eci"
       membre_fonction:
         | "referent"
         | "conseiller"
         | "technique"
         | "politique"
-        | "partenaire";
+        | "partenaire"
       nature:
         | "SMF"
         | "CU"
@@ -6963,14 +7606,17 @@ export interface Database {
         | "CA"
         | "EPT"
         | "SIVU"
-        | "PETR";
-      niveau_acces: "admin" | "edition" | "lecture";
+        | "PETR"
+      niveau_acces: "admin" | "edition" | "lecture"
       preuve_type:
         | "complementaire"
         | "reglementaire"
         | "labellisation"
         | "audit"
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> a342e9c9a (update types)
         | "rapport"
       question_type: "choix" | "binaire" | "proportion"
       referentiel: "eci" | "cae"
@@ -6978,6 +7624,7 @@ export interface Database {
       role_name: "agent" | "referent" | "conseiller" | "auditeur" | "aucun"
       thematique_completude: "complete" | "a_completer"
       type_collectivite: "EPCI" | "commune" | "syndicat"
+<<<<<<< HEAD
       usage_action:
         | "clic"
         | "vue"
@@ -6995,6 +7642,9 @@ export interface Database {
       type_collectivite: "EPCI" | "commune" | "syndicat";
       usage_action: "clic" | "vue" | "telechargement" | "saisie" | "selection";
 >>>>>>> d1c38935a (MAJ database.types.ts)
+=======
+      usage_action: "clic" | "vue" | "telechargement" | "saisie" | "selection"
+>>>>>>> a342e9c9a (update types)
       usage_fonction:
         | "aide"
         | "preuve"
@@ -7017,6 +7667,7 @@ export interface Database {
         | "cta_plan"
         | "cta_indicateur"
 <<<<<<< HEAD
+<<<<<<< HEAD
         | "cta_labellisation"
         | "cta_plan_creation"
         | "cta_plan_maj"
@@ -7025,6 +7676,9 @@ export interface Database {
 =======
         | "cta_labellisation";
 >>>>>>> d1c38935a (MAJ database.types.ts)
+=======
+        | "cta_labellisation"
+>>>>>>> a342e9c9a (update types)
       visite_onglet:
         | "progression"
         | "priorisation"
@@ -7036,7 +7690,7 @@ export interface Database {
         | "comparaison"
         | "critere"
         | "informations"
-        | "commentaires";
+        | "commentaires"
       visite_page:
         | "autre"
         | "signin"
@@ -7065,6 +7719,7 @@ export interface Database {
         | "nouveau_plan_import"
         | "nouveau_plan_creation"
 <<<<<<< HEAD
+<<<<<<< HEAD
         | "indicateurs"
 <<<<<<< HEAD
 =======
@@ -7072,7 +7727,13 @@ export interface Database {
 =======
         | "indicateurs";
 >>>>>>> 55e9bca97 (MAJ database.types.ts)
+<<<<<<< HEAD
 >>>>>>> 5eb3065f1 (MAJ database.types.ts)
+=======
+=======
+        | "indicateurs"
+>>>>>>> d8b0e10a9 (update types)
+>>>>>>> 75edc2a5d (update types)
       visite_tag:
         | "cae"
         | "eci"
@@ -7081,6 +7742,7 @@ export interface Database {
         | "thematique"
         | "personnalise"
         | "clef"
+<<<<<<< HEAD
 <<<<<<< HEAD
         | "tous"
         | "statuts"
@@ -7093,69 +7755,74 @@ export interface Database {
         | "tous";
     };
 >>>>>>> 55e9bca97 (MAJ database.types.ts)
+=======
+        | "tous"
+    }
+>>>>>>> d8b0e10a9 (update types)
     CompositeTypes: {
       fiche_action_export: {
-        axe_id: number;
-        axe_nom: string;
-        axe_path: unknown;
-        fiche: Json;
-      };
+        axe_id: number
+        axe_nom: string
+        axe_path: unknown
+        fiche: Json
+      }
       financeur_montant: {
-        financeur_tag: unknown;
-        montant_ttc: number;
-        id: number;
-      };
+        financeur_tag: unknown
+        montant_ttc: number
+        id: number
+      }
       flat_axe_node: {
-        id: number;
-        nom: string;
-        fiches: unknown;
-        ancestors: unknown;
-        depth: number;
-        sort_path: string;
-      };
+        id: number
+        nom: string
+        fiches: unknown
+        ancestors: unknown
+        depth: number
+        sort_path: string
+      }
       graphique_tranche: {
-        id: string;
-        value: number;
-      };
+        id: string
+        value: number
+      }
       indicateur_generique: {
-        indicateur_id: unknown;
-        indicateur_personnalise_id: number;
-        nom: string;
-        description: string;
-        unite: string;
-      };
+        indicateur_id: unknown
+        indicateur_personnalise_id: number
+        nom: string
+        description: string
+        unite: string
+      }
       personne: {
-        nom: string;
-        collectivite_id: number;
-        tag_id: number;
-        user_id: string;
-      };
+        nom: string
+        collectivite_id: number
+        tag_id: number
+        user_id: string
+      }
       plan_action_tableau_de_bord: {
-        collectivite_id: number;
-        plan_id: number;
-        statuts: unknown;
-        pilotes: unknown;
-        referents: unknown;
-        priorites: unknown;
-        echeances: unknown;
-      };
+        collectivite_id: number
+        plan_id: number
+        statuts: unknown
+        pilotes: unknown
+        referents: unknown
+        priorites: unknown
+        echeances: unknown
+      }
       tabular_score: {
-        referentiel: Database["public"]["Enums"]["referentiel"];
-        action_id: unknown;
-        score_realise: number;
-        score_programme: number;
-        score_realise_plus_programme: number;
-        score_pas_fait: number;
-        score_non_renseigne: number;
-        points_restants: number;
-        points_realises: number;
-        points_programmes: number;
-        points_max_personnalises: number;
-        points_max_referentiel: number;
-        avancement: Database["public"]["Enums"]["avancement"];
-        concerne: boolean;
-        desactive: boolean;
-      };
-    };
-  };
+        referentiel: Database["public"]["Enums"]["referentiel"]
+        action_id: unknown
+        score_realise: number
+        score_programme: number
+        score_realise_plus_programme: number
+        score_pas_fait: number
+        score_non_renseigne: number
+        points_restants: number
+        points_realises: number
+        points_programmes: number
+        points_max_personnalises: number
+        points_max_referentiel: number
+        avancement: Database["public"]["Enums"]["avancement"]
+        concerne: boolean
+        desactive: boolean
+      }
+    }
+  }
 }
+

--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -224,10 +224,13 @@ export interface Database {
       audit_evaluation_payload: {
         Args: {
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 <<<<<<< HEAD
 <<<<<<< HEAD
 >>>>>>> a342e9c9a (update types)
+=======
+>>>>>>> 40ccc466c (Mise à jours des types)
           audit: unknown
           pre_audit: boolean
         }
@@ -241,6 +244,7 @@ export interface Database {
         }
         Returns: Json
       }
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 =======
@@ -270,6 +274,8 @@ export interface Database {
       }
 >>>>>>> d8b0e10a9 (update types)
 >>>>>>> a342e9c9a (update types)
+=======
+>>>>>>> 40ccc466c (Mise à jours des types)
       critere_action: {
         Args: {
           collectivite_id: number
@@ -339,20 +345,19 @@ export interface Database {
       evaluate_audit_statuts: {
         Args: {
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 <<<<<<< HEAD
 <<<<<<< HEAD
 >>>>>>> a342e9c9a (update types)
+=======
+>>>>>>> 40ccc466c (Mise à jours des types)
           audit_id: number
           pre_audit: boolean
-=======
-          audit_id: number
->>>>>>> d8b0e10a9 (update types)
           scores_table: string
         }
         Returns: number
       }
-<<<<<<< HEAD
       json_action_statuts_at: {
         Args: {
           collectivite_id: number
@@ -368,6 +373,7 @@ export interface Database {
         }
         Returns: Json
       }
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 =======
@@ -399,6 +405,8 @@ export interface Database {
       }
 >>>>>>> d8b0e10a9 (update types)
 >>>>>>> a342e9c9a (update types)
+=======
+>>>>>>> 40ccc466c (Mise à jours des types)
       referentiel_score: {
         Args: {
           collectivite_id: number
@@ -2327,16 +2335,11 @@ export interface Database {
           nom: string
         }
         Update: {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d8b0e10a9 (update types)
           collectivite_id?: number
           id?: number
           nom?: string
         }
       }
-<<<<<<< HEAD
       post_audit_scores: {
         Row: {
           audit_id: number
@@ -2364,6 +2367,7 @@ export interface Database {
         }
       }
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 =======
           collectivite_id?: number;
@@ -2375,6 +2379,8 @@ export interface Database {
 =======
 >>>>>>> d8b0e10a9 (update types)
 >>>>>>> a342e9c9a (update types)
+=======
+>>>>>>> 40ccc466c (Mise à jours des types)
       pre_audit_scores: {
         Row: {
           audit_id: number
@@ -3433,18 +3439,20 @@ export interface Database {
         }
         Update: {
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 <<<<<<< HEAD
 <<<<<<< HEAD
 =======
 >>>>>>> d8b0e10a9 (update types)
 >>>>>>> a342e9c9a (update types)
+=======
+>>>>>>> 40ccc466c (Mise à jours des types)
           code?: string | null
           libelle?: string | null
           region_code?: string | null
         }
       }
-<<<<<<< HEAD
       export_score_audit: {
         Row: {
           collectivite: string | null
@@ -3462,6 +3470,7 @@ export interface Database {
         }
       }
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 =======
           code?: string | null;
@@ -3473,6 +3482,8 @@ export interface Database {
 =======
 >>>>>>> d8b0e10a9 (update types)
 >>>>>>> a342e9c9a (update types)
+=======
+>>>>>>> 40ccc466c (Mise à jours des types)
       fiche_action_personne_pilote: {
         Row: {
           collectivite_id: number | null
@@ -7079,18 +7090,6 @@ export interface Database {
       time_bucket:
         | {
             Args: {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d8b0e10a9 (update types)
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-<<<<<<< HEAD
-          }
-        | {
-            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -7102,70 +7101,6 @@ export interface Database {
               ts: string
             }
             Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              offset: unknown
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-<<<<<<< HEAD
-=======
-            }
-            Returns: string
-=======
-              bucket_width: unknown;
-              ts: string;
-              offset: unknown;
-            };
-            Returns: string;
-          }
-        | {
-            Args: {
-              bucket_width: unknown;
-              ts: string;
-            };
-            Returns: string;
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-=======
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
->>>>>>> d8b0e10a9 (update types)
           }
         | {
             Args: {
@@ -7208,28 +7143,11 @@ export interface Database {
           }
         | {
             Args: {
-<<<<<<< HEAD
-<<<<<<< HEAD
-              bucket_width: unknown
-              ts: string
->>>>>>> bd0b6d67b (MAJ database.types.ts)
-              offset: unknown
-            }
-            Returns: string
-=======
-              bucket_width: unknown;
-              ts: string;
-              offset: unknown;
-            };
-            Returns: string;
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-=======
               bucket_width: unknown
               ts: string
               offset: unknown
             }
             Returns: string
->>>>>>> d8b0e10a9 (update types)
           }
         | {
             Args: {
@@ -7405,8 +7323,6 @@ export interface Database {
       todo_start:
         | {
             Args: {
-<<<<<<< HEAD
-<<<<<<< HEAD
               "": string
             }
             Returns: boolean[]
@@ -7415,26 +7331,6 @@ export interface Database {
             Args: Record<PropertyKey, never>
             Returns: boolean[]
           }
-=======
-              "": string;
-            };
-            Returns: boolean[];
-          }
-        | {
-            Args: Record<PropertyKey, never>;
-            Returns: boolean[];
-          };
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-=======
-              "": string
-            }
-            Returns: boolean[]
-          }
-        | {
-            Args: Record<PropertyKey, never>
-            Returns: boolean[]
-          }
->>>>>>> d8b0e10a9 (update types)
       types_are: {
         Args: {
           "": unknown[]
@@ -7718,12 +7614,11 @@ export interface Database {
         | "nouveau_plan"
         | "nouveau_plan_import"
         | "nouveau_plan_creation"
-<<<<<<< HEAD
-<<<<<<< HEAD
         | "indicateurs"
 <<<<<<< HEAD
 =======
         | "synthese"
+<<<<<<< HEAD
 =======
         | "indicateurs";
 >>>>>>> 55e9bca97 (MAJ database.types.ts)
@@ -7734,6 +7629,8 @@ export interface Database {
         | "indicateurs"
 >>>>>>> d8b0e10a9 (update types)
 >>>>>>> 75edc2a5d (update types)
+=======
+>>>>>>> dedef088a (Mise à jours des types)
       visite_tag:
         | "cae"
         | "eci"
@@ -7742,8 +7639,6 @@ export interface Database {
         | "thematique"
         | "personnalise"
         | "clef"
-<<<<<<< HEAD
-<<<<<<< HEAD
         | "tous"
         | "statuts"
         | "pilotes"
@@ -7751,14 +7646,6 @@ export interface Database {
         | "priorites"
         | "echeances"
     }
-=======
-        | "tous";
-    };
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-=======
-        | "tous"
-    }
->>>>>>> d8b0e10a9 (update types)
     CompositeTypes: {
       fiche_action_export: {
         axe_id: number

--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -4,223 +4,227 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json }
-  | Json[]
+  | Json[];
 
 export interface Database {
   labellisation: {
     Tables: {
       action_audit_state: {
         Row: {
-          action_id: string
-          audit_id: number | null
-          avis: string
-          collectivite_id: number
-          id: number
-          modified_at: string
-          modified_by: string
-          ordre_du_jour: boolean
-          statut: Database["public"]["Enums"]["audit_statut"]
-        }
+          action_id: string;
+          audit_id: number | null;
+          avis: string;
+          collectivite_id: number;
+          id: number;
+          modified_at: string;
+          modified_by: string;
+          ordre_du_jour: boolean;
+          statut: Database["public"]["Enums"]["audit_statut"];
+        };
         Insert: {
-          action_id: string
-          audit_id?: number | null
-          avis?: string
-          collectivite_id: number
-          id?: number
-          modified_at?: string
-          modified_by?: string
-          ordre_du_jour?: boolean
-          statut?: Database["public"]["Enums"]["audit_statut"]
-        }
+          action_id: string;
+          audit_id?: number | null;
+          avis?: string;
+          collectivite_id: number;
+          id?: number;
+          modified_at?: string;
+          modified_by?: string;
+          ordre_du_jour?: boolean;
+          statut?: Database["public"]["Enums"]["audit_statut"];
+        };
         Update: {
-          action_id?: string
-          audit_id?: number | null
-          avis?: string
-          collectivite_id?: number
-          id?: number
-          modified_at?: string
-          modified_by?: string
-          ordre_du_jour?: boolean
-          statut?: Database["public"]["Enums"]["audit_statut"]
-        }
-      }
+          action_id?: string;
+          audit_id?: number | null;
+          avis?: string;
+          collectivite_id?: number;
+          id?: number;
+          modified_at?: string;
+          modified_by?: string;
+          ordre_du_jour?: boolean;
+          statut?: Database["public"]["Enums"]["audit_statut"];
+        };
+      };
       audit: {
         Row: {
-          collectivite_id: number
-          date_debut: string | null
-          date_fin: string | null
-          demande_id: number | null
-          id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          valide: boolean
-        }
+          collectivite_id: number;
+          date_debut: string | null;
+          date_fin: string | null;
+          demande_id: number | null;
+          id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          valide: boolean;
+        };
         Insert: {
-          collectivite_id: number
-          date_debut?: string | null
-          date_fin?: string | null
-          demande_id?: number | null
-          id?: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          valide?: boolean
-        }
+          collectivite_id: number;
+          date_debut?: string | null;
+          date_fin?: string | null;
+          demande_id?: number | null;
+          id?: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          valide?: boolean;
+        };
         Update: {
-          collectivite_id?: number
-          date_debut?: string | null
-          date_fin?: string | null
-          demande_id?: number | null
-          id?: number
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-          valide?: boolean
-        }
-      }
+          collectivite_id?: number;
+          date_debut?: string | null;
+          date_fin?: string | null;
+          demande_id?: number | null;
+          id?: number;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+          valide?: boolean;
+        };
+      };
       bibliotheque_fichier: {
         Row: {
-          collectivite_id: number | null
-          filename: string | null
-          hash: string | null
-          id: number
-        }
+          collectivite_id: number | null;
+          filename: string | null;
+          hash: string | null;
+          id: number;
+        };
         Insert: {
-          collectivite_id?: number | null
-          filename?: string | null
-          hash?: string | null
-          id?: number
-        }
+          collectivite_id?: number | null;
+          filename?: string | null;
+          hash?: string | null;
+          id?: number;
+        };
         Update: {
-          collectivite_id?: number | null
-          filename?: string | null
-          hash?: string | null
-          id?: number
-        }
-      }
+          collectivite_id?: number | null;
+          filename?: string | null;
+          hash?: string | null;
+          id?: number;
+        };
+      };
       demande: {
         Row: {
-          collectivite_id: number
-          date: string
-          demandeur: string | null
-          en_cours: boolean
-          envoyee_le: string | null
-          etoiles: Database["labellisation"]["Enums"]["etoile"] | null
-          id: number
-          modified_at: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"]
-        }
+          collectivite_id: number;
+          date: string;
+          demandeur: string | null;
+          en_cours: boolean;
+          envoyee_le: string | null;
+          etoiles: Database["labellisation"]["Enums"]["etoile"] | null;
+          id: number;
+          modified_at: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"];
+        };
         Insert: {
-          collectivite_id: number
-          date?: string
-          demandeur?: string | null
-          en_cours?: boolean
-          envoyee_le?: string | null
-          etoiles?: Database["labellisation"]["Enums"]["etoile"] | null
-          id?: number
-          modified_at?: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          sujet?: Database["labellisation"]["Enums"]["sujet_demande"]
-        }
+          collectivite_id: number;
+          date?: string;
+          demandeur?: string | null;
+          en_cours?: boolean;
+          envoyee_le?: string | null;
+          etoiles?: Database["labellisation"]["Enums"]["etoile"] | null;
+          id?: number;
+          modified_at?: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          sujet?: Database["labellisation"]["Enums"]["sujet_demande"];
+        };
         Update: {
-          collectivite_id?: number
-          date?: string
-          demandeur?: string | null
-          en_cours?: boolean
-          envoyee_le?: string | null
-          etoiles?: Database["labellisation"]["Enums"]["etoile"] | null
-          id?: number
-          modified_at?: string | null
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-          sujet?: Database["labellisation"]["Enums"]["sujet_demande"]
-        }
-      }
+          collectivite_id?: number;
+          date?: string;
+          demandeur?: string | null;
+          en_cours?: boolean;
+          envoyee_le?: string | null;
+          etoiles?: Database["labellisation"]["Enums"]["etoile"] | null;
+          id?: number;
+          modified_at?: string | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+          sujet?: Database["labellisation"]["Enums"]["sujet_demande"];
+        };
+      };
       etoile_meta: {
         Row: {
-          etoile: Database["labellisation"]["Enums"]["etoile"]
-          long_label: string
-          min_realise_percentage: number
-          min_realise_score: number | null
-          prochaine_etoile: Database["labellisation"]["Enums"]["etoile"] | null
-          short_label: string
-        }
+          etoile: Database["labellisation"]["Enums"]["etoile"];
+          long_label: string;
+          min_realise_percentage: number;
+          min_realise_score: number | null;
+          prochaine_etoile: Database["labellisation"]["Enums"]["etoile"] | null;
+          short_label: string;
+        };
         Insert: {
-          etoile: Database["labellisation"]["Enums"]["etoile"]
-          long_label: string
-          min_realise_percentage: number
-          min_realise_score?: number | null
-          prochaine_etoile?: Database["labellisation"]["Enums"]["etoile"] | null
-          short_label: string
-        }
+          etoile: Database["labellisation"]["Enums"]["etoile"];
+          long_label: string;
+          min_realise_percentage: number;
+          min_realise_score?: number | null;
+          prochaine_etoile?:
+            | Database["labellisation"]["Enums"]["etoile"]
+            | null;
+          short_label: string;
+        };
         Update: {
-          etoile?: Database["labellisation"]["Enums"]["etoile"]
-          long_label?: string
-          min_realise_percentage?: number
-          min_realise_score?: number | null
-          prochaine_etoile?: Database["labellisation"]["Enums"]["etoile"] | null
-          short_label?: string
-        }
-      }
+          etoile?: Database["labellisation"]["Enums"]["etoile"];
+          long_label?: string;
+          min_realise_percentage?: number;
+          min_realise_score?: number | null;
+          prochaine_etoile?:
+            | Database["labellisation"]["Enums"]["etoile"]
+            | null;
+          short_label?: string;
+        };
+      };
       preuve_base: {
         Row: {
-          collectivite_id: number
-          commentaire: string
-          fichier_id: number | null
-          lien: Json | null
-          modified_at: string
-          modified_by: string
-          titre: string
-          url: string | null
-        }
+          collectivite_id: number;
+          commentaire: string;
+          fichier_id: number | null;
+          lien: Json | null;
+          modified_at: string;
+          modified_by: string;
+          titre: string;
+          url: string | null;
+        };
         Insert: {
-          collectivite_id: number
-          commentaire?: string
-          fichier_id?: number | null
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
+          collectivite_id: number;
+          commentaire?: string;
+          fichier_id?: number | null;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
         Update: {
-          collectivite_id?: number
-          commentaire?: string
-          fichier_id?: number | null
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
-      }
-    }
+          collectivite_id?: number;
+          commentaire?: string;
+          fichier_id?: number | null;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
+      };
+    };
     Views: {
       action_snippet: {
         Row: {
-          action_id: string | null
-          collectivite_id: number | null
-          snippet: Json | null
-        }
-      }
+          action_id: string | null;
+          collectivite_id: number | null;
+          snippet: Json | null;
+        };
+      };
       bibliotheque_fichier_snippet: {
         Row: {
-          id: number | null
-          snippet: Json | null
-        }
-      }
-    }
+          id: number | null;
+          snippet: Json | null;
+        };
+      };
+    };
     Functions: {
       active_audit: {
         Args: {
-          collectivite_id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          collectivite_id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Returns: {
-          collectivite_id: number
-          date_debut: string | null
-          date_fin: string | null
-          demande_id: number | null
-          id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          valide: boolean
-        }
-      }
+          collectivite_id: number;
+          date_debut: string | null;
+          date_fin: string | null;
+          demande_id: number | null;
+          id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          valide: boolean;
+        };
+      };
       audit_evaluation_payload: {
         Args: {
           audit: unknown
@@ -238,70 +242,70 @@ export interface Database {
       }
       critere_action: {
         Args: {
-          collectivite_id: number
-        }
+          collectivite_id: number;
+        };
         Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          etoiles: Database["labellisation"]["Enums"]["etoile"]
-          action_id: unknown
-          formulation: string
-          score_realise: number
-          min_score_realise: number
-          score_programme: number
-          min_score_programme: number
-          atteint: boolean
-          prio: number
-        }[]
-      }
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          etoiles: Database["labellisation"]["Enums"]["etoile"];
+          action_id: unknown;
+          formulation: string;
+          score_realise: number;
+          min_score_realise: number;
+          score_programme: number;
+          min_score_programme: number;
+          atteint: boolean;
+          prio: number;
+        }[];
+      };
       critere_fichier: {
         Args: {
-          collectivite_id: number
-        }
+          collectivite_id: number;
+        };
         Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          preuve_nombre: number
-          atteint: boolean
-        }[]
-      }
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          preuve_nombre: number;
+          atteint: boolean;
+        }[];
+      };
       critere_score_global: {
         Args: {
-          collectivite_id: number
-        }
+          collectivite_id: number;
+        };
         Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          etoile_objectif: Database["labellisation"]["Enums"]["etoile"]
-          score_a_realiser: number
-          score_fait: number
-          atteint: boolean
-        }[]
-      }
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          etoile_objectif: Database["labellisation"]["Enums"]["etoile"];
+          score_a_realiser: number;
+          score_fait: number;
+          atteint: boolean;
+        }[];
+      };
       current_audit: {
         Args: {
-          col: number
-          ref: Database["public"]["Enums"]["referentiel"]
-        }
+          col: number;
+          ref: Database["public"]["Enums"]["referentiel"];
+        };
         Returns: {
-          collectivite_id: number
-          date_debut: string | null
-          date_fin: string | null
-          demande_id: number | null
-          id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          valide: boolean
-        }
-      }
+          collectivite_id: number;
+          date_debut: string | null;
+          date_fin: string | null;
+          demande_id: number | null;
+          id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          valide: boolean;
+        };
+      };
       etoiles: {
         Args: {
-          collectivite_id: number
-        }
+          collectivite_id: number;
+        };
         Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          etoile_labellise: Database["labellisation"]["Enums"]["etoile"]
-          prochaine_etoile_labellisation: Database["labellisation"]["Enums"]["etoile"]
-          etoile_score_possible: Database["labellisation"]["Enums"]["etoile"]
-          etoile_objectif: Database["labellisation"]["Enums"]["etoile"]
-        }[]
-      }
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          etoile_labellise: Database["labellisation"]["Enums"]["etoile"];
+          prochaine_etoile_labellisation: Database["labellisation"]["Enums"]["etoile"];
+          etoile_score_possible: Database["labellisation"]["Enums"]["etoile"];
+          etoile_objectif: Database["labellisation"]["Enums"]["etoile"];
+        }[];
+      };
       evaluate_audit_statuts: {
         Args: {
           audit_id: number
@@ -327,1432 +331,1432 @@ export interface Database {
       }
       referentiel_score: {
         Args: {
-          collectivite_id: number
-        }
+          collectivite_id: number;
+        };
         Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          score_fait: number
-          score_programme: number
-          completude: number
-          complet: boolean
-        }[]
-      }
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          score_fait: number;
+          score_programme: number;
+          completude: number;
+          complet: boolean;
+        }[];
+      };
       upsert_preuves_reglementaire: {
         Args: {
-          preuves: Json
-        }
-        Returns: undefined
-      }
-    }
+          preuves: Json;
+        };
+        Returns: undefined;
+      };
+    };
     Enums: {
-      etoile: "1" | "2" | "3" | "4" | "5"
-      sujet_demande: "labellisation" | "labellisation_cot" | "cot"
-    }
+      etoile: "1" | "2" | "3" | "4" | "5";
+      sujet_demande: "labellisation" | "labellisation_cot" | "cot";
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       abstract_any_indicateur_value: {
         Row: {
-          annee: number
-          modified_at: string
-          valeur: number | null
-        }
+          annee: number;
+          modified_at: string;
+          valeur: number | null;
+        };
         Insert: {
-          annee: number
-          modified_at?: string
-          valeur?: number | null
-        }
+          annee: number;
+          modified_at?: string;
+          valeur?: number | null;
+        };
         Update: {
-          annee?: number
-          modified_at?: string
-          valeur?: number | null
-        }
-      }
+          annee?: number;
+          modified_at?: string;
+          valeur?: number | null;
+        };
+      };
       abstract_modified_at: {
         Row: {
-          modified_at: string
-        }
+          modified_at: string;
+        };
         Insert: {
-          modified_at?: string
-        }
+          modified_at?: string;
+        };
         Update: {
-          modified_at?: string
-        }
-      }
+          modified_at?: string;
+        };
+      };
       action_commentaire: {
         Row: {
-          action_id: string
-          collectivite_id: number
-          commentaire: string
-          modified_at: string
-          modified_by: string
-        }
+          action_id: string;
+          collectivite_id: number;
+          commentaire: string;
+          modified_at: string;
+          modified_by: string;
+        };
         Insert: {
-          action_id: string
-          collectivite_id: number
-          commentaire: string
-          modified_at?: string
-          modified_by?: string
-        }
+          action_id: string;
+          collectivite_id: number;
+          commentaire: string;
+          modified_at?: string;
+          modified_by?: string;
+        };
         Update: {
-          action_id?: string
-          collectivite_id?: number
-          commentaire?: string
-          modified_at?: string
-          modified_by?: string
-        }
-      }
+          action_id?: string;
+          collectivite_id?: number;
+          commentaire?: string;
+          modified_at?: string;
+          modified_by?: string;
+        };
+      };
       action_computed_points: {
         Row: {
-          action_id: string
-          modified_at: string
-          value: number
-        }
+          action_id: string;
+          modified_at: string;
+          value: number;
+        };
         Insert: {
-          action_id: string
-          modified_at?: string
-          value: number
-        }
+          action_id: string;
+          modified_at?: string;
+          value: number;
+        };
         Update: {
-          action_id?: string
-          modified_at?: string
-          value?: number
-        }
-      }
+          action_id?: string;
+          modified_at?: string;
+          value?: number;
+        };
+      };
       action_definition: {
         Row: {
-          action_id: string
-          categorie: Database["public"]["Enums"]["action_categorie"] | null
-          contexte: string
-          description: string
-          exemples: string
-          identifiant: string
-          modified_at: string
-          nom: string
-          perimetre_evaluation: string
-          points: number | null
-          pourcentage: number | null
-          preuve: string | null
-          reduction_potentiel: string
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          ressources: string
-        }
+          action_id: string;
+          categorie: Database["public"]["Enums"]["action_categorie"] | null;
+          contexte: string;
+          description: string;
+          exemples: string;
+          identifiant: string;
+          modified_at: string;
+          nom: string;
+          perimetre_evaluation: string;
+          points: number | null;
+          pourcentage: number | null;
+          preuve: string | null;
+          reduction_potentiel: string;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          ressources: string;
+        };
         Insert: {
-          action_id: string
-          categorie?: Database["public"]["Enums"]["action_categorie"] | null
-          contexte: string
-          description: string
-          exemples: string
-          identifiant: string
-          modified_at?: string
-          nom: string
-          perimetre_evaluation: string
-          points?: number | null
-          pourcentage?: number | null
-          preuve?: string | null
-          reduction_potentiel: string
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          ressources: string
-        }
+          action_id: string;
+          categorie?: Database["public"]["Enums"]["action_categorie"] | null;
+          contexte: string;
+          description: string;
+          exemples: string;
+          identifiant: string;
+          modified_at?: string;
+          nom: string;
+          perimetre_evaluation: string;
+          points?: number | null;
+          pourcentage?: number | null;
+          preuve?: string | null;
+          reduction_potentiel: string;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          ressources: string;
+        };
         Update: {
-          action_id?: string
-          categorie?: Database["public"]["Enums"]["action_categorie"] | null
-          contexte?: string
-          description?: string
-          exemples?: string
-          identifiant?: string
-          modified_at?: string
-          nom?: string
-          perimetre_evaluation?: string
-          points?: number | null
-          pourcentage?: number | null
-          preuve?: string | null
-          reduction_potentiel?: string
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-          ressources?: string
-        }
-      }
+          action_id?: string;
+          categorie?: Database["public"]["Enums"]["action_categorie"] | null;
+          contexte?: string;
+          description?: string;
+          exemples?: string;
+          identifiant?: string;
+          modified_at?: string;
+          nom?: string;
+          perimetre_evaluation?: string;
+          points?: number | null;
+          pourcentage?: number | null;
+          preuve?: string | null;
+          reduction_potentiel?: string;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+          ressources?: string;
+        };
+      };
       action_discussion: {
         Row: {
-          action_id: string
-          collectivite_id: number
-          created_at: string
-          created_by: string
-          id: number
-          modified_at: string
-          status: Database["public"]["Enums"]["action_discussion_statut"]
-        }
+          action_id: string;
+          collectivite_id: number;
+          created_at: string;
+          created_by: string;
+          id: number;
+          modified_at: string;
+          status: Database["public"]["Enums"]["action_discussion_statut"];
+        };
         Insert: {
-          action_id: string
-          collectivite_id: number
-          created_at?: string
-          created_by?: string
-          id?: number
-          modified_at?: string
-          status?: Database["public"]["Enums"]["action_discussion_statut"]
-        }
+          action_id: string;
+          collectivite_id: number;
+          created_at?: string;
+          created_by?: string;
+          id?: number;
+          modified_at?: string;
+          status?: Database["public"]["Enums"]["action_discussion_statut"];
+        };
         Update: {
-          action_id?: string
-          collectivite_id?: number
-          created_at?: string
-          created_by?: string
-          id?: number
-          modified_at?: string
-          status?: Database["public"]["Enums"]["action_discussion_statut"]
-        }
-      }
+          action_id?: string;
+          collectivite_id?: number;
+          created_at?: string;
+          created_by?: string;
+          id?: number;
+          modified_at?: string;
+          status?: Database["public"]["Enums"]["action_discussion_statut"];
+        };
+      };
       action_discussion_commentaire: {
         Row: {
-          created_at: string
-          created_by: string
-          discussion_id: number
-          id: number
-          message: string
-        }
+          created_at: string;
+          created_by: string;
+          discussion_id: number;
+          id: number;
+          message: string;
+        };
         Insert: {
-          created_at?: string
-          created_by?: string
-          discussion_id: number
-          id?: number
-          message: string
-        }
+          created_at?: string;
+          created_by?: string;
+          discussion_id: number;
+          id?: number;
+          message: string;
+        };
         Update: {
-          created_at?: string
-          created_by?: string
-          discussion_id?: number
-          id?: number
-          message?: string
-        }
-      }
+          created_at?: string;
+          created_by?: string;
+          discussion_id?: number;
+          id?: number;
+          message?: string;
+        };
+      };
       action_relation: {
         Row: {
-          id: string
-          parent: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          id: string;
+          parent: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Insert: {
-          id: string
-          parent?: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          id: string;
+          parent?: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Update: {
-          id?: string
-          parent?: string | null
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-        }
-      }
+          id?: string;
+          parent?: string | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+        };
+      };
       action_statut: {
         Row: {
-          action_id: string
-          avancement: Database["public"]["Enums"]["avancement"]
-          avancement_detaille: number[] | null
-          collectivite_id: number
-          concerne: boolean
-          modified_at: string
-          modified_by: string
-        }
+          action_id: string;
+          avancement: Database["public"]["Enums"]["avancement"];
+          avancement_detaille: number[] | null;
+          collectivite_id: number;
+          concerne: boolean;
+          modified_at: string;
+          modified_by: string;
+        };
         Insert: {
-          action_id: string
-          avancement: Database["public"]["Enums"]["avancement"]
-          avancement_detaille?: number[] | null
-          collectivite_id: number
-          concerne: boolean
-          modified_at?: string
-          modified_by?: string
-        }
+          action_id: string;
+          avancement: Database["public"]["Enums"]["avancement"];
+          avancement_detaille?: number[] | null;
+          collectivite_id: number;
+          concerne: boolean;
+          modified_at?: string;
+          modified_by?: string;
+        };
         Update: {
-          action_id?: string
-          avancement?: Database["public"]["Enums"]["avancement"]
-          avancement_detaille?: number[] | null
-          collectivite_id?: number
-          concerne?: boolean
-          modified_at?: string
-          modified_by?: string
-        }
-      }
+          action_id?: string;
+          avancement?: Database["public"]["Enums"]["avancement"];
+          avancement_detaille?: number[] | null;
+          collectivite_id?: number;
+          concerne?: boolean;
+          modified_at?: string;
+          modified_by?: string;
+        };
+      };
       annexe: {
         Row: {
-          collectivite_id: number
-          commentaire: string
-          fiche_id: number
-          fichier_id: number | null
-          id: number
-          lien: Json | null
-          modified_at: string
-          modified_by: string
-          titre: string
-          url: string | null
-        }
+          collectivite_id: number;
+          commentaire: string;
+          fiche_id: number;
+          fichier_id: number | null;
+          id: number;
+          lien: Json | null;
+          modified_at: string;
+          modified_by: string;
+          titre: string;
+          url: string | null;
+        };
         Insert: {
-          collectivite_id: number
-          commentaire?: string
-          fiche_id: number
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
+          collectivite_id: number;
+          commentaire?: string;
+          fiche_id: number;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
         Update: {
-          collectivite_id?: number
-          commentaire?: string
-          fiche_id?: number
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
-      }
+          collectivite_id?: number;
+          commentaire?: string;
+          fiche_id?: number;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
+      };
       audit_auditeur: {
         Row: {
-          audit_id: number
-          auditeur: string
-          created_at: string | null
-        }
+          audit_id: number;
+          auditeur: string;
+          created_at: string | null;
+        };
         Insert: {
-          audit_id: number
-          auditeur: string
-          created_at?: string | null
-        }
+          audit_id: number;
+          auditeur: string;
+          created_at?: string | null;
+        };
         Update: {
-          audit_id?: number
-          auditeur?: string
-          created_at?: string | null
-        }
-      }
+          audit_id?: number;
+          auditeur?: string;
+          created_at?: string | null;
+        };
+      };
       axe: {
         Row: {
-          collectivite_id: number
-          created_at: string
-          id: number
-          modified_at: string
-          modified_by: string | null
-          nom: string | null
-          parent: number | null
-        }
+          collectivite_id: number;
+          created_at: string;
+          id: number;
+          modified_at: string;
+          modified_by: string | null;
+          nom: string | null;
+          parent: number | null;
+        };
         Insert: {
-          collectivite_id: number
-          created_at?: string
-          id?: number
-          modified_at?: string
-          modified_by?: string | null
-          nom?: string | null
-          parent?: number | null
-        }
+          collectivite_id: number;
+          created_at?: string;
+          id?: number;
+          modified_at?: string;
+          modified_by?: string | null;
+          nom?: string | null;
+          parent?: number | null;
+        };
         Update: {
-          collectivite_id?: number
-          created_at?: string
-          id?: number
-          modified_at?: string
-          modified_by?: string | null
-          nom?: string | null
-          parent?: number | null
-        }
-      }
+          collectivite_id?: number;
+          created_at?: string;
+          id?: number;
+          modified_at?: string;
+          modified_by?: string | null;
+          nom?: string | null;
+          parent?: number | null;
+        };
+      };
       client_scores: {
         Row: {
-          collectivite_id: number
-          modified_at: string
-          payload_timestamp: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          scores: Json
-        }
+          collectivite_id: number;
+          modified_at: string;
+          payload_timestamp: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          scores: Json;
+        };
         Insert: {
-          collectivite_id: number
-          modified_at: string
-          payload_timestamp?: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          scores: Json
-        }
+          collectivite_id: number;
+          modified_at: string;
+          payload_timestamp?: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          scores: Json;
+        };
         Update: {
-          collectivite_id?: number
-          modified_at?: string
-          payload_timestamp?: string | null
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-          scores?: Json
-        }
-      }
+          collectivite_id?: number;
+          modified_at?: string;
+          payload_timestamp?: string | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+          scores?: Json;
+        };
+      };
       client_scores_update: {
         Row: {
-          collectivite_id: number
-          modified_at: string
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          collectivite_id: number;
+          modified_at: string;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Insert: {
-          collectivite_id: number
-          modified_at: string
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          collectivite_id: number;
+          modified_at: string;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Update: {
-          collectivite_id?: number
-          modified_at?: string
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-        }
-      }
+          collectivite_id?: number;
+          modified_at?: string;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+        };
+      };
       collectivite: {
         Row: {
-          access_restreint: boolean
-          created_at: string
-          id: number
-          modified_at: string
-        }
+          access_restreint: boolean;
+          created_at: string;
+          id: number;
+          modified_at: string;
+        };
         Insert: {
-          access_restreint?: boolean
-          created_at?: string
-          id?: number
-          modified_at?: string
-        }
+          access_restreint?: boolean;
+          created_at?: string;
+          id?: number;
+          modified_at?: string;
+        };
         Update: {
-          access_restreint?: boolean
-          created_at?: string
-          id?: number
-          modified_at?: string
-        }
-      }
+          access_restreint?: boolean;
+          created_at?: string;
+          id?: number;
+          modified_at?: string;
+        };
+      };
       collectivite_bucket: {
         Row: {
-          bucket_id: string
-          collectivite_id: number
-        }
+          bucket_id: string;
+          collectivite_id: number;
+        };
         Insert: {
-          bucket_id: string
-          collectivite_id: number
-        }
+          bucket_id: string;
+          collectivite_id: number;
+        };
         Update: {
-          bucket_id?: string
-          collectivite_id?: number
-        }
-      }
+          bucket_id?: string;
+          collectivite_id?: number;
+        };
+      };
       collectivite_test: {
         Row: {
-          collectivite_id: number | null
-          id: number
-          nom: string
-        }
+          collectivite_id: number | null;
+          id: number;
+          nom: string;
+        };
         Insert: {
-          collectivite_id?: number | null
-          id?: number
-          nom: string
-        }
+          collectivite_id?: number | null;
+          id?: number;
+          nom: string;
+        };
         Update: {
-          collectivite_id?: number | null
-          id?: number
-          nom?: string
-        }
-      }
+          collectivite_id?: number | null;
+          id?: number;
+          nom?: string;
+        };
+      };
       commune: {
         Row: {
-          code: string
-          collectivite_id: number | null
-          id: number
-          nom: string
-        }
+          code: string;
+          collectivite_id: number | null;
+          id: number;
+          nom: string;
+        };
         Insert: {
-          code: string
-          collectivite_id?: number | null
-          id?: number
-          nom: string
-        }
+          code: string;
+          collectivite_id?: number | null;
+          id?: number;
+          nom: string;
+        };
         Update: {
-          code?: string
-          collectivite_id?: number | null
-          id?: number
-          nom?: string
-        }
-      }
+          code?: string;
+          collectivite_id?: number | null;
+          id?: number;
+          nom?: string;
+        };
+      };
       cot: {
         Row: {
-          actif: boolean
-          collectivite_id: number
-          signataire: number | null
-        }
+          actif: boolean;
+          collectivite_id: number;
+          signataire: number | null;
+        };
         Insert: {
-          actif: boolean
-          collectivite_id: number
-          signataire?: number | null
-        }
+          actif: boolean;
+          collectivite_id: number;
+          signataire?: number | null;
+        };
         Update: {
-          actif?: boolean
-          collectivite_id?: number
-          signataire?: number | null
-        }
-      }
+          actif?: boolean;
+          collectivite_id?: number;
+          signataire?: number | null;
+        };
+      };
       dcp: {
         Row: {
-          cgu_acceptees_le: string | null
-          created_at: string
-          deleted: boolean
-          email: string
-          limited: boolean
-          modified_at: string
-          nom: string
-          prenom: string
-          telephone: string | null
-          user_id: string
-        }
+          cgu_acceptees_le: string | null;
+          created_at: string;
+          deleted: boolean;
+          email: string;
+          limited: boolean;
+          modified_at: string;
+          nom: string;
+          prenom: string;
+          telephone: string | null;
+          user_id: string;
+        };
         Insert: {
-          cgu_acceptees_le?: string | null
-          created_at?: string
-          deleted?: boolean
-          email: string
-          limited?: boolean
-          modified_at?: string
-          nom: string
-          prenom: string
-          telephone?: string | null
-          user_id: string
-        }
+          cgu_acceptees_le?: string | null;
+          created_at?: string;
+          deleted?: boolean;
+          email: string;
+          limited?: boolean;
+          modified_at?: string;
+          nom: string;
+          prenom: string;
+          telephone?: string | null;
+          user_id: string;
+        };
         Update: {
-          cgu_acceptees_le?: string | null
-          created_at?: string
-          deleted?: boolean
-          email?: string
-          limited?: boolean
-          modified_at?: string
-          nom?: string
-          prenom?: string
-          telephone?: string | null
-          user_id?: string
-        }
-      }
+          cgu_acceptees_le?: string | null;
+          created_at?: string;
+          deleted?: boolean;
+          email?: string;
+          limited?: boolean;
+          modified_at?: string;
+          nom?: string;
+          prenom?: string;
+          telephone?: string | null;
+          user_id?: string;
+        };
+      };
       epci: {
         Row: {
-          collectivite_id: number | null
-          id: number
-          nature: Database["public"]["Enums"]["nature"]
-          nom: string
-          siren: string
-        }
+          collectivite_id: number | null;
+          id: number;
+          nature: Database["public"]["Enums"]["nature"];
+          nom: string;
+          siren: string;
+        };
         Insert: {
-          collectivite_id?: number | null
-          id?: number
-          nature: Database["public"]["Enums"]["nature"]
-          nom: string
-          siren: string
-        }
+          collectivite_id?: number | null;
+          id?: number;
+          nature: Database["public"]["Enums"]["nature"];
+          nom: string;
+          siren: string;
+        };
         Update: {
-          collectivite_id?: number | null
-          id?: number
-          nature?: Database["public"]["Enums"]["nature"]
-          nom?: string
-          siren?: string
-        }
-      }
+          collectivite_id?: number | null;
+          id?: number;
+          nature?: Database["public"]["Enums"]["nature"];
+          nom?: string;
+          siren?: string;
+        };
+      };
       fiche_action: {
         Row: {
-          amelioration_continue: boolean | null
-          budget_previsionnel: number | null
-          calendrier: string | null
-          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null
-          collectivite_id: number
-          created_at: string
-          date_debut: string | null
-          date_fin_provisoire: string | null
-          description: string | null
-          financements: string | null
-          id: number
-          maj_termine: boolean | null
-          modified_at: string
-          modified_by: string | null
+          amelioration_continue: boolean | null;
+          budget_previsionnel: number | null;
+          calendrier: string | null;
+          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null;
+          collectivite_id: number;
+          created_at: string;
+          date_debut: string | null;
+          date_fin_provisoire: string | null;
+          description: string | null;
+          financements: string | null;
+          id: number;
+          maj_termine: boolean | null;
+          modified_at: string;
+          modified_by: string | null;
           niveau_priorite:
             | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null
-          notes_complementaires: string | null
-          objectifs: string | null
+            | null;
+          notes_complementaires: string | null;
+          objectifs: string | null;
           piliers_eci:
             | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null
-          ressources: string | null
+            | null;
+          ressources: string | null;
           resultats_attendus:
             | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          titre: string | null
-        }
+            | null;
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
+          titre: string | null;
+        };
         Insert: {
-          amelioration_continue?: boolean | null
-          budget_previsionnel?: number | null
-          calendrier?: string | null
-          cibles?: Database["public"]["Enums"]["fiche_action_cibles"][] | null
-          collectivite_id: number
-          created_at?: string
-          date_debut?: string | null
-          date_fin_provisoire?: string | null
-          description?: string | null
-          financements?: string | null
-          id?: number
-          maj_termine?: boolean | null
-          modified_at?: string
-          modified_by?: string | null
+          amelioration_continue?: boolean | null;
+          budget_previsionnel?: number | null;
+          calendrier?: string | null;
+          cibles?: Database["public"]["Enums"]["fiche_action_cibles"][] | null;
+          collectivite_id: number;
+          created_at?: string;
+          date_debut?: string | null;
+          date_fin_provisoire?: string | null;
+          description?: string | null;
+          financements?: string | null;
+          id?: number;
+          maj_termine?: boolean | null;
+          modified_at?: string;
+          modified_by?: string | null;
           niveau_priorite?:
             | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null
-          notes_complementaires?: string | null
-          objectifs?: string | null
+            | null;
+          notes_complementaires?: string | null;
+          objectifs?: string | null;
           piliers_eci?:
             | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null
-          ressources?: string | null
+            | null;
+          ressources?: string | null;
           resultats_attendus?:
             | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null
-          statut?: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          titre?: string | null
-        }
+            | null;
+          statut?: Database["public"]["Enums"]["fiche_action_statuts"] | null;
+          titre?: string | null;
+        };
         Update: {
-          amelioration_continue?: boolean | null
-          budget_previsionnel?: number | null
-          calendrier?: string | null
-          cibles?: Database["public"]["Enums"]["fiche_action_cibles"][] | null
-          collectivite_id?: number
-          created_at?: string
-          date_debut?: string | null
-          date_fin_provisoire?: string | null
-          description?: string | null
-          financements?: string | null
-          id?: number
-          maj_termine?: boolean | null
-          modified_at?: string
-          modified_by?: string | null
+          amelioration_continue?: boolean | null;
+          budget_previsionnel?: number | null;
+          calendrier?: string | null;
+          cibles?: Database["public"]["Enums"]["fiche_action_cibles"][] | null;
+          collectivite_id?: number;
+          created_at?: string;
+          date_debut?: string | null;
+          date_fin_provisoire?: string | null;
+          description?: string | null;
+          financements?: string | null;
+          id?: number;
+          maj_termine?: boolean | null;
+          modified_at?: string;
+          modified_by?: string | null;
           niveau_priorite?:
             | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null
-          notes_complementaires?: string | null
-          objectifs?: string | null
+            | null;
+          notes_complementaires?: string | null;
+          objectifs?: string | null;
           piliers_eci?:
             | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null
-          ressources?: string | null
+            | null;
+          ressources?: string | null;
           resultats_attendus?:
             | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null
-          statut?: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          titre?: string | null
-        }
-      }
+            | null;
+          statut?: Database["public"]["Enums"]["fiche_action_statuts"] | null;
+          titre?: string | null;
+        };
+      };
       fiche_action_action: {
         Row: {
-          action_id: string
-          fiche_id: number
-          fiche_resume: unknown | null
-        }
+          action_id: string;
+          fiche_id: number;
+          fiche_resume: unknown | null;
+        };
         Insert: {
-          action_id: string
-          fiche_id: number
-        }
+          action_id: string;
+          fiche_id: number;
+        };
         Update: {
-          action_id?: string
-          fiche_id?: number
-        }
-      }
+          action_id?: string;
+          fiche_id?: number;
+        };
+      };
       fiche_action_axe: {
         Row: {
-          axe_id: number
-          fiche_id: number
-        }
+          axe_id: number;
+          fiche_id: number;
+        };
         Insert: {
-          axe_id: number
-          fiche_id: number
-        }
+          axe_id: number;
+          fiche_id: number;
+        };
         Update: {
-          axe_id?: number
-          fiche_id?: number
-        }
-      }
+          axe_id?: number;
+          fiche_id?: number;
+        };
+      };
       fiche_action_financeur_tag: {
         Row: {
-          fiche_id: number
-          financeur_tag_id: number
-          id: number
-          montant_ttc: number | null
-        }
+          fiche_id: number;
+          financeur_tag_id: number;
+          id: number;
+          montant_ttc: number | null;
+        };
         Insert: {
-          fiche_id: number
-          financeur_tag_id: number
-          id?: number
-          montant_ttc?: number | null
-        }
+          fiche_id: number;
+          financeur_tag_id: number;
+          id?: number;
+          montant_ttc?: number | null;
+        };
         Update: {
-          fiche_id?: number
-          financeur_tag_id?: number
-          id?: number
-          montant_ttc?: number | null
-        }
-      }
+          fiche_id?: number;
+          financeur_tag_id?: number;
+          id?: number;
+          montant_ttc?: number | null;
+        };
+      };
       fiche_action_import_csv: {
         Row: {
-          amelioration_continue: string | null
-          axe: string | null
-          budget: string | null
-          calendrier: string | null
-          cibles: string | null
-          collectivite_id: string | null
-          date_debut: string | null
-          date_fin: string | null
-          description: string | null
-          elu_referent: string | null
-          financements: string | null
-          financeur_deux: string | null
-          financeur_trois: string | null
-          financeur_un: string | null
-          montant_deux: string | null
-          montant_trois: string | null
-          montant_un: string | null
-          moyens: string | null
-          notes: string | null
-          num_action: string | null
-          objectifs: string | null
-          partenaires: string | null
-          personne_referente: string | null
-          plan_nom: string | null
-          priorite: string | null
-          resultats_attendus: string | null
-          service: string | null
-          sous_axe: string | null
-          sous_sous_axe: string | null
-          statut: string | null
-          structure_pilote: string | null
-          titre: string | null
-        }
+          amelioration_continue: string | null;
+          axe: string | null;
+          budget: string | null;
+          calendrier: string | null;
+          cibles: string | null;
+          collectivite_id: string | null;
+          date_debut: string | null;
+          date_fin: string | null;
+          description: string | null;
+          elu_referent: string | null;
+          financements: string | null;
+          financeur_deux: string | null;
+          financeur_trois: string | null;
+          financeur_un: string | null;
+          montant_deux: string | null;
+          montant_trois: string | null;
+          montant_un: string | null;
+          moyens: string | null;
+          notes: string | null;
+          num_action: string | null;
+          objectifs: string | null;
+          partenaires: string | null;
+          personne_referente: string | null;
+          plan_nom: string | null;
+          priorite: string | null;
+          resultats_attendus: string | null;
+          service: string | null;
+          sous_axe: string | null;
+          sous_sous_axe: string | null;
+          statut: string | null;
+          structure_pilote: string | null;
+          titre: string | null;
+        };
         Insert: {
-          amelioration_continue?: string | null
-          axe?: string | null
-          budget?: string | null
-          calendrier?: string | null
-          cibles?: string | null
-          collectivite_id?: string | null
-          date_debut?: string | null
-          date_fin?: string | null
-          description?: string | null
-          elu_referent?: string | null
-          financements?: string | null
-          financeur_deux?: string | null
-          financeur_trois?: string | null
-          financeur_un?: string | null
-          montant_deux?: string | null
-          montant_trois?: string | null
-          montant_un?: string | null
-          moyens?: string | null
-          notes?: string | null
-          num_action?: string | null
-          objectifs?: string | null
-          partenaires?: string | null
-          personne_referente?: string | null
-          plan_nom?: string | null
-          priorite?: string | null
-          resultats_attendus?: string | null
-          service?: string | null
-          sous_axe?: string | null
-          sous_sous_axe?: string | null
-          statut?: string | null
-          structure_pilote?: string | null
-          titre?: string | null
-        }
+          amelioration_continue?: string | null;
+          axe?: string | null;
+          budget?: string | null;
+          calendrier?: string | null;
+          cibles?: string | null;
+          collectivite_id?: string | null;
+          date_debut?: string | null;
+          date_fin?: string | null;
+          description?: string | null;
+          elu_referent?: string | null;
+          financements?: string | null;
+          financeur_deux?: string | null;
+          financeur_trois?: string | null;
+          financeur_un?: string | null;
+          montant_deux?: string | null;
+          montant_trois?: string | null;
+          montant_un?: string | null;
+          moyens?: string | null;
+          notes?: string | null;
+          num_action?: string | null;
+          objectifs?: string | null;
+          partenaires?: string | null;
+          personne_referente?: string | null;
+          plan_nom?: string | null;
+          priorite?: string | null;
+          resultats_attendus?: string | null;
+          service?: string | null;
+          sous_axe?: string | null;
+          sous_sous_axe?: string | null;
+          statut?: string | null;
+          structure_pilote?: string | null;
+          titre?: string | null;
+        };
         Update: {
-          amelioration_continue?: string | null
-          axe?: string | null
-          budget?: string | null
-          calendrier?: string | null
-          cibles?: string | null
-          collectivite_id?: string | null
-          date_debut?: string | null
-          date_fin?: string | null
-          description?: string | null
-          elu_referent?: string | null
-          financements?: string | null
-          financeur_deux?: string | null
-          financeur_trois?: string | null
-          financeur_un?: string | null
-          montant_deux?: string | null
-          montant_trois?: string | null
-          montant_un?: string | null
-          moyens?: string | null
-          notes?: string | null
-          num_action?: string | null
-          objectifs?: string | null
-          partenaires?: string | null
-          personne_referente?: string | null
-          plan_nom?: string | null
-          priorite?: string | null
-          resultats_attendus?: string | null
-          service?: string | null
-          sous_axe?: string | null
-          sous_sous_axe?: string | null
-          statut?: string | null
-          structure_pilote?: string | null
-          titre?: string | null
-        }
-      }
+          amelioration_continue?: string | null;
+          axe?: string | null;
+          budget?: string | null;
+          calendrier?: string | null;
+          cibles?: string | null;
+          collectivite_id?: string | null;
+          date_debut?: string | null;
+          date_fin?: string | null;
+          description?: string | null;
+          elu_referent?: string | null;
+          financements?: string | null;
+          financeur_deux?: string | null;
+          financeur_trois?: string | null;
+          financeur_un?: string | null;
+          montant_deux?: string | null;
+          montant_trois?: string | null;
+          montant_un?: string | null;
+          moyens?: string | null;
+          notes?: string | null;
+          num_action?: string | null;
+          objectifs?: string | null;
+          partenaires?: string | null;
+          personne_referente?: string | null;
+          plan_nom?: string | null;
+          priorite?: string | null;
+          resultats_attendus?: string | null;
+          service?: string | null;
+          sous_axe?: string | null;
+          sous_sous_axe?: string | null;
+          statut?: string | null;
+          structure_pilote?: string | null;
+          titre?: string | null;
+        };
+      };
       fiche_action_indicateur: {
         Row: {
-          fiche_id: number
-          indicateur_id: string | null
-          indicateur_personnalise_id: number | null
-        }
+          fiche_id: number;
+          indicateur_id: string | null;
+          indicateur_personnalise_id: number | null;
+        };
         Insert: {
-          fiche_id: number
-          indicateur_id?: string | null
-          indicateur_personnalise_id?: number | null
-        }
+          fiche_id: number;
+          indicateur_id?: string | null;
+          indicateur_personnalise_id?: number | null;
+        };
         Update: {
-          fiche_id?: number
-          indicateur_id?: string | null
-          indicateur_personnalise_id?: number | null
-        }
-      }
+          fiche_id?: number;
+          indicateur_id?: string | null;
+          indicateur_personnalise_id?: number | null;
+        };
+      };
       fiche_action_lien: {
         Row: {
-          fiche_deux: number
-          fiche_une: number
-        }
+          fiche_deux: number;
+          fiche_une: number;
+        };
         Insert: {
-          fiche_deux: number
-          fiche_une: number
-        }
+          fiche_deux: number;
+          fiche_une: number;
+        };
         Update: {
-          fiche_deux?: number
-          fiche_une?: number
-        }
-      }
+          fiche_deux?: number;
+          fiche_une?: number;
+        };
+      };
       fiche_action_partenaire_tag: {
         Row: {
-          fiche_id: number
-          partenaire_tag_id: number
-        }
+          fiche_id: number;
+          partenaire_tag_id: number;
+        };
         Insert: {
-          fiche_id: number
-          partenaire_tag_id: number
-        }
+          fiche_id: number;
+          partenaire_tag_id: number;
+        };
         Update: {
-          fiche_id?: number
-          partenaire_tag_id?: number
-        }
-      }
+          fiche_id?: number;
+          partenaire_tag_id?: number;
+        };
+      };
       fiche_action_pilote: {
         Row: {
-          fiche_id: number
-          tag_id: number | null
-          user_id: string | null
-        }
+          fiche_id: number;
+          tag_id: number | null;
+          user_id: string | null;
+        };
         Insert: {
-          fiche_id: number
-          tag_id?: number | null
-          user_id?: string | null
-        }
+          fiche_id: number;
+          tag_id?: number | null;
+          user_id?: string | null;
+        };
         Update: {
-          fiche_id?: number
-          tag_id?: number | null
-          user_id?: string | null
-        }
-      }
+          fiche_id?: number;
+          tag_id?: number | null;
+          user_id?: string | null;
+        };
+      };
       fiche_action_referent: {
         Row: {
-          fiche_id: number
-          tag_id: number | null
-          user_id: string | null
-        }
+          fiche_id: number;
+          tag_id: number | null;
+          user_id: string | null;
+        };
         Insert: {
-          fiche_id: number
-          tag_id?: number | null
-          user_id?: string | null
-        }
+          fiche_id: number;
+          tag_id?: number | null;
+          user_id?: string | null;
+        };
         Update: {
-          fiche_id?: number
-          tag_id?: number | null
-          user_id?: string | null
-        }
-      }
+          fiche_id?: number;
+          tag_id?: number | null;
+          user_id?: string | null;
+        };
+      };
       fiche_action_service_tag: {
         Row: {
-          fiche_id: number
-          service_tag_id: number
-        }
+          fiche_id: number;
+          service_tag_id: number;
+        };
         Insert: {
-          fiche_id: number
-          service_tag_id: number
-        }
+          fiche_id: number;
+          service_tag_id: number;
+        };
         Update: {
-          fiche_id?: number
-          service_tag_id?: number
-        }
-      }
+          fiche_id?: number;
+          service_tag_id?: number;
+        };
+      };
       fiche_action_sous_thematique: {
         Row: {
-          fiche_id: number
-          thematique_id: number
-        }
+          fiche_id: number;
+          thematique_id: number;
+        };
         Insert: {
-          fiche_id: number
-          thematique_id: number
-        }
+          fiche_id: number;
+          thematique_id: number;
+        };
         Update: {
-          fiche_id?: number
-          thematique_id?: number
-        }
-      }
+          fiche_id?: number;
+          thematique_id?: number;
+        };
+      };
       fiche_action_structure_tag: {
         Row: {
-          fiche_id: number
-          structure_tag_id: number
-        }
+          fiche_id: number;
+          structure_tag_id: number;
+        };
         Insert: {
-          fiche_id: number
-          structure_tag_id: number
-        }
+          fiche_id: number;
+          structure_tag_id: number;
+        };
         Update: {
-          fiche_id?: number
-          structure_tag_id?: number
-        }
-      }
+          fiche_id?: number;
+          structure_tag_id?: number;
+        };
+      };
       fiche_action_thematique: {
         Row: {
-          fiche_id: number
-          thematique: string
-        }
+          fiche_id: number;
+          thematique: string;
+        };
         Insert: {
-          fiche_id: number
-          thematique: string
-        }
+          fiche_id: number;
+          thematique: string;
+        };
         Update: {
-          fiche_id?: number
-          thematique?: string
-        }
-      }
+          fiche_id?: number;
+          thematique?: string;
+        };
+      };
       filtre_intervalle: {
         Row: {
-          id: string
-          intervalle: unknown
-          libelle: string
-          type: Database["public"]["Enums"]["collectivite_filtre_type"]
-        }
+          id: string;
+          intervalle: unknown;
+          libelle: string;
+          type: Database["public"]["Enums"]["collectivite_filtre_type"];
+        };
         Insert: {
-          id: string
-          intervalle: unknown
-          libelle: string
-          type: Database["public"]["Enums"]["collectivite_filtre_type"]
-        }
+          id: string;
+          intervalle: unknown;
+          libelle: string;
+          type: Database["public"]["Enums"]["collectivite_filtre_type"];
+        };
         Update: {
-          id?: string
-          intervalle?: unknown
-          libelle?: string
-          type?: Database["public"]["Enums"]["collectivite_filtre_type"]
-        }
-      }
+          id?: string;
+          intervalle?: unknown;
+          libelle?: string;
+          type?: Database["public"]["Enums"]["collectivite_filtre_type"];
+        };
+      };
       financeur_tag: {
         Row: {
-          collectivite_id: number
-          id: number
-          nom: string
-        }
+          collectivite_id: number;
+          id: number;
+          nom: string;
+        };
         Insert: {
-          collectivite_id: number
-          id?: number
-          nom: string
-        }
+          collectivite_id: number;
+          id?: number;
+          nom: string;
+        };
         Update: {
-          collectivite_id?: number
-          id?: number
-          nom?: string
-        }
-      }
+          collectivite_id?: number;
+          id?: number;
+          nom?: string;
+        };
+      };
       indicateur_action: {
         Row: {
-          action_id: string
-          indicateur_id: string
-          modified_at: string
-        }
+          action_id: string;
+          indicateur_id: string;
+          modified_at: string;
+        };
         Insert: {
-          action_id: string
-          indicateur_id: string
-          modified_at?: string
-        }
+          action_id: string;
+          indicateur_id: string;
+          modified_at?: string;
+        };
         Update: {
-          action_id?: string
-          indicateur_id?: string
-          modified_at?: string
-        }
-      }
+          action_id?: string;
+          indicateur_id?: string;
+          modified_at?: string;
+        };
+      };
       indicateur_commentaire: {
         Row: {
-          collectivite_id: number
-          commentaire: string
-          indicateur_id: string
-          modified_at: string
-          modified_by: string
-        }
+          collectivite_id: number;
+          commentaire: string;
+          indicateur_id: string;
+          modified_at: string;
+          modified_by: string;
+        };
         Insert: {
-          collectivite_id: number
-          commentaire: string
-          indicateur_id: string
-          modified_at?: string
-          modified_by?: string
-        }
+          collectivite_id: number;
+          commentaire: string;
+          indicateur_id: string;
+          modified_at?: string;
+          modified_by?: string;
+        };
         Update: {
-          collectivite_id?: number
-          commentaire?: string
-          indicateur_id?: string
-          modified_at?: string
-          modified_by?: string
-        }
-      }
+          collectivite_id?: number;
+          commentaire?: string;
+          indicateur_id?: string;
+          modified_at?: string;
+          modified_by?: string;
+        };
+      };
       indicateur_definition: {
         Row: {
-          description: string
-          id: string
-          identifiant: string
-          indicateur_group: Database["public"]["Enums"]["indicateur_group"]
-          modified_at: string
-          nom: string
-          obligation_eci: boolean
-          parent: number | null
-          unite: string
-          valeur_indicateur: string | null
-        }
+          description: string;
+          id: string;
+          identifiant: string;
+          indicateur_group: Database["public"]["Enums"]["indicateur_group"];
+          modified_at: string;
+          nom: string;
+          obligation_eci: boolean;
+          parent: number | null;
+          unite: string;
+          valeur_indicateur: string | null;
+        };
         Insert: {
-          description: string
-          id: string
-          identifiant: string
-          indicateur_group: Database["public"]["Enums"]["indicateur_group"]
-          modified_at?: string
-          nom: string
-          obligation_eci: boolean
-          parent?: number | null
-          unite: string
-          valeur_indicateur?: string | null
-        }
+          description: string;
+          id: string;
+          identifiant: string;
+          indicateur_group: Database["public"]["Enums"]["indicateur_group"];
+          modified_at?: string;
+          nom: string;
+          obligation_eci: boolean;
+          parent?: number | null;
+          unite: string;
+          valeur_indicateur?: string | null;
+        };
         Update: {
-          description?: string
-          id?: string
-          identifiant?: string
-          indicateur_group?: Database["public"]["Enums"]["indicateur_group"]
-          modified_at?: string
-          nom?: string
-          obligation_eci?: boolean
-          parent?: number | null
-          unite?: string
-          valeur_indicateur?: string | null
-        }
-      }
+          description?: string;
+          id?: string;
+          identifiant?: string;
+          indicateur_group?: Database["public"]["Enums"]["indicateur_group"];
+          modified_at?: string;
+          nom?: string;
+          obligation_eci?: boolean;
+          parent?: number | null;
+          unite?: string;
+          valeur_indicateur?: string | null;
+        };
+      };
       indicateur_objectif: {
         Row: {
-          annee: number
-          collectivite_id: number
-          indicateur_id: string
-          modified_at: string
-          valeur: number | null
-        }
+          annee: number;
+          collectivite_id: number;
+          indicateur_id: string;
+          modified_at: string;
+          valeur: number | null;
+        };
         Insert: {
-          annee: number
-          collectivite_id: number
-          indicateur_id: string
-          modified_at?: string
-          valeur?: number | null
-        }
+          annee: number;
+          collectivite_id: number;
+          indicateur_id: string;
+          modified_at?: string;
+          valeur?: number | null;
+        };
         Update: {
-          annee?: number
-          collectivite_id?: number
-          indicateur_id?: string
-          modified_at?: string
-          valeur?: number | null
-        }
-      }
+          annee?: number;
+          collectivite_id?: number;
+          indicateur_id?: string;
+          modified_at?: string;
+          valeur?: number | null;
+        };
+      };
       indicateur_parent: {
         Row: {
-          id: number
-          nom: string
-          numero: string
-        }
+          id: number;
+          nom: string;
+          numero: string;
+        };
         Insert: {
-          id?: number
-          nom: string
-          numero: string
-        }
+          id?: number;
+          nom: string;
+          numero: string;
+        };
         Update: {
-          id?: number
-          nom?: string
-          numero?: string
-        }
-      }
+          id?: number;
+          nom?: string;
+          numero?: string;
+        };
+      };
       indicateur_personnalise_definition: {
         Row: {
-          collectivite_id: number | null
-          commentaire: string
-          description: string
-          id: number
-          modified_at: string
-          modified_by: string
-          titre: string
-          unite: string
-        }
+          collectivite_id: number | null;
+          commentaire: string;
+          description: string;
+          id: number;
+          modified_at: string;
+          modified_by: string;
+          titre: string;
+          unite: string;
+        };
         Insert: {
-          collectivite_id?: number | null
-          commentaire: string
-          description: string
-          id?: number
-          modified_at?: string
-          modified_by?: string
-          titre: string
-          unite: string
-        }
+          collectivite_id?: number | null;
+          commentaire: string;
+          description: string;
+          id?: number;
+          modified_at?: string;
+          modified_by?: string;
+          titre: string;
+          unite: string;
+        };
         Update: {
-          collectivite_id?: number | null
-          commentaire?: string
-          description?: string
-          id?: number
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          unite?: string
-        }
-      }
+          collectivite_id?: number | null;
+          commentaire?: string;
+          description?: string;
+          id?: number;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          unite?: string;
+        };
+      };
       indicateur_personnalise_objectif: {
         Row: {
-          annee: number
-          collectivite_id: number
-          indicateur_id: number
-          modified_at: string
-          valeur: number | null
-        }
+          annee: number;
+          collectivite_id: number;
+          indicateur_id: number;
+          modified_at: string;
+          valeur: number | null;
+        };
         Insert: {
-          annee: number
-          collectivite_id: number
-          indicateur_id: number
-          modified_at?: string
-          valeur?: number | null
-        }
+          annee: number;
+          collectivite_id: number;
+          indicateur_id: number;
+          modified_at?: string;
+          valeur?: number | null;
+        };
         Update: {
-          annee?: number
-          collectivite_id?: number
-          indicateur_id?: number
-          modified_at?: string
-          valeur?: number | null
-        }
-      }
+          annee?: number;
+          collectivite_id?: number;
+          indicateur_id?: number;
+          modified_at?: string;
+          valeur?: number | null;
+        };
+      };
       indicateur_personnalise_resultat: {
         Row: {
-          annee: number
-          collectivite_id: number
-          indicateur_id: number
-          modified_at: string
-          valeur: number | null
-        }
+          annee: number;
+          collectivite_id: number;
+          indicateur_id: number;
+          modified_at: string;
+          valeur: number | null;
+        };
         Insert: {
-          annee: number
-          collectivite_id: number
-          indicateur_id: number
-          modified_at?: string
-          valeur?: number | null
-        }
+          annee: number;
+          collectivite_id: number;
+          indicateur_id: number;
+          modified_at?: string;
+          valeur?: number | null;
+        };
         Update: {
-          annee?: number
-          collectivite_id?: number
-          indicateur_id?: number
-          modified_at?: string
-          valeur?: number | null
-        }
-      }
+          annee?: number;
+          collectivite_id?: number;
+          indicateur_id?: number;
+          modified_at?: string;
+          valeur?: number | null;
+        };
+      };
       indicateur_resultat: {
         Row: {
-          annee: number
-          collectivite_id: number
-          indicateur_id: string
-          modified_at: string
-          valeur: number | null
-        }
+          annee: number;
+          collectivite_id: number;
+          indicateur_id: string;
+          modified_at: string;
+          valeur: number | null;
+        };
         Insert: {
-          annee: number
-          collectivite_id: number
-          indicateur_id: string
-          modified_at?: string
-          valeur?: number | null
-        }
+          annee: number;
+          collectivite_id: number;
+          indicateur_id: string;
+          modified_at?: string;
+          valeur?: number | null;
+        };
         Update: {
-          annee?: number
-          collectivite_id?: number
-          indicateur_id?: string
-          modified_at?: string
-          valeur?: number | null
-        }
-      }
+          annee?: number;
+          collectivite_id?: number;
+          indicateur_id?: string;
+          modified_at?: string;
+          valeur?: number | null;
+        };
+      };
       indicateur_terristory_json: {
         Row: {
-          created_at: string
-          indicateurs: Json
-        }
+          created_at: string;
+          indicateurs: Json;
+        };
         Insert: {
-          created_at?: string
-          indicateurs: Json
-        }
+          created_at?: string;
+          indicateurs: Json;
+        };
         Update: {
-          created_at?: string
-          indicateurs?: Json
-        }
-      }
+          created_at?: string;
+          indicateurs?: Json;
+        };
+      };
       indicateurs_json: {
         Row: {
-          created_at: string
-          indicateurs: Json
-        }
+          created_at: string;
+          indicateurs: Json;
+        };
         Insert: {
-          created_at?: string
-          indicateurs: Json
-        }
+          created_at?: string;
+          indicateurs: Json;
+        };
         Update: {
-          created_at?: string
-          indicateurs?: Json
-        }
-      }
+          created_at?: string;
+          indicateurs?: Json;
+        };
+      };
       justification: {
         Row: {
-          collectivite_id: number
-          modified_at: string
-          modified_by: string
-          question_id: string
-          texte: string
-        }
+          collectivite_id: number;
+          modified_at: string;
+          modified_by: string;
+          question_id: string;
+          texte: string;
+        };
         Insert: {
-          collectivite_id: number
-          modified_at: string
-          modified_by?: string
-          question_id: string
-          texte: string
-        }
+          collectivite_id: number;
+          modified_at: string;
+          modified_by?: string;
+          question_id: string;
+          texte: string;
+        };
         Update: {
-          collectivite_id?: number
-          modified_at?: string
-          modified_by?: string
-          question_id?: string
-          texte?: string
-        }
-      }
+          collectivite_id?: number;
+          modified_at?: string;
+          modified_by?: string;
+          question_id?: string;
+          texte?: string;
+        };
+      };
       labellisation: {
         Row: {
-          annee: number | null
-          collectivite_id: number | null
-          etoiles: number
-          id: number
-          obtenue_le: string
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          score_programme: number | null
-          score_realise: number | null
-        }
+          annee: number | null;
+          collectivite_id: number | null;
+          etoiles: number;
+          id: number;
+          obtenue_le: string;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          score_programme: number | null;
+          score_realise: number | null;
+        };
         Insert: {
-          annee?: number | null
-          collectivite_id?: number | null
-          etoiles: number
-          id?: number
-          obtenue_le: string
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          score_programme?: number | null
-          score_realise?: number | null
-        }
+          annee?: number | null;
+          collectivite_id?: number | null;
+          etoiles: number;
+          id?: number;
+          obtenue_le: string;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          score_programme?: number | null;
+          score_realise?: number | null;
+        };
         Update: {
-          annee?: number | null
-          collectivite_id?: number | null
-          etoiles?: number
-          id?: number
-          obtenue_le?: string
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-          score_programme?: number | null
-          score_realise?: number | null
-        }
-      }
+          annee?: number | null;
+          collectivite_id?: number | null;
+          etoiles?: number;
+          id?: number;
+          obtenue_le?: string;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+          score_programme?: number | null;
+          score_realise?: number | null;
+        };
+      };
       labellisation_action_critere: {
         Row: {
-          action_id: string
-          etoile: Database["labellisation"]["Enums"]["etoile"]
-          formulation: string
-          min_programme_percentage: number | null
-          min_programme_score: number | null
-          min_realise_percentage: number | null
-          min_realise_score: number | null
-          prio: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          action_id: string;
+          etoile: Database["labellisation"]["Enums"]["etoile"];
+          formulation: string;
+          min_programme_percentage: number | null;
+          min_programme_score: number | null;
+          min_realise_percentage: number | null;
+          min_realise_score: number | null;
+          prio: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Insert: {
-          action_id: string
-          etoile: Database["labellisation"]["Enums"]["etoile"]
-          formulation: string
-          min_programme_percentage?: number | null
-          min_programme_score?: number | null
-          min_realise_percentage?: number | null
-          min_realise_score?: number | null
-          prio: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          action_id: string;
+          etoile: Database["labellisation"]["Enums"]["etoile"];
+          formulation: string;
+          min_programme_percentage?: number | null;
+          min_programme_score?: number | null;
+          min_realise_percentage?: number | null;
+          min_realise_score?: number | null;
+          prio: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Update: {
-          action_id?: string
-          etoile?: Database["labellisation"]["Enums"]["etoile"]
-          formulation?: string
-          min_programme_percentage?: number | null
-          min_programme_score?: number | null
-          min_realise_percentage?: number | null
-          min_realise_score?: number | null
-          prio?: number
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-        }
-      }
+          action_id?: string;
+          etoile?: Database["labellisation"]["Enums"]["etoile"];
+          formulation?: string;
+          min_programme_percentage?: number | null;
+          min_programme_score?: number | null;
+          min_realise_percentage?: number | null;
+          min_realise_score?: number | null;
+          prio?: number;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+        };
+      };
       labellisation_calendrier: {
         Row: {
-          information: string
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          information: string;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Insert: {
-          information: string
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          information: string;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Update: {
-          information?: string
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-        }
-      }
+          information?: string;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+        };
+      };
       labellisation_fichier_critere: {
         Row: {
-          description: string
-          etoile: Database["labellisation"]["Enums"]["etoile"]
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          description: string;
+          etoile: Database["labellisation"]["Enums"]["etoile"];
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Insert: {
-          description: string
-          etoile: Database["labellisation"]["Enums"]["etoile"]
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          description: string;
+          etoile: Database["labellisation"]["Enums"]["etoile"];
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Update: {
-          description?: string
-          etoile?: Database["labellisation"]["Enums"]["etoile"]
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-        }
-      }
+          description?: string;
+          etoile?: Database["labellisation"]["Enums"]["etoile"];
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+        };
+      };
       maintenance: {
         Row: {
-          begins_at: string
-          ends_at: string
-          id: number
-        }
+          begins_at: string;
+          ends_at: string;
+          id: number;
+        };
         Insert: {
-          begins_at: string
-          ends_at: string
-          id?: number
-        }
+          begins_at: string;
+          ends_at: string;
+          id?: number;
+        };
         Update: {
-          begins_at?: string
-          ends_at?: string
-          id?: number
-        }
-      }
+          begins_at?: string;
+          ends_at?: string;
+          id?: number;
+        };
+      };
       partenaire_tag: {
         Row: {
-          collectivite_id: number
-          id: number
-          nom: string
-        }
+          collectivite_id: number;
+          id: number;
+          nom: string;
+        };
         Insert: {
-          collectivite_id: number
-          id?: number
-          nom: string
-        }
+          collectivite_id: number;
+          id?: number;
+          nom: string;
+        };
         Update: {
-          collectivite_id?: number
-          id?: number
-          nom?: string
-        }
-      }
+          collectivite_id?: number;
+          id?: number;
+          nom?: string;
+        };
+      };
       personnalisation: {
         Row: {
-          action_id: string
-          description: string
-          titre: string
-        }
+          action_id: string;
+          description: string;
+          titre: string;
+        };
         Insert: {
-          action_id: string
-          description: string
-          titre: string
-        }
+          action_id: string;
+          description: string;
+          titre: string;
+        };
         Update: {
-          action_id?: string
-          description?: string
-          titre?: string
-        }
-      }
+          action_id?: string;
+          description?: string;
+          titre?: string;
+        };
+      };
       personnalisation_consequence: {
         Row: {
-          collectivite_id: number
-          consequences: Json
-          modified_at: string
-          payload_timestamp: string | null
-        }
+          collectivite_id: number;
+          consequences: Json;
+          modified_at: string;
+          payload_timestamp: string | null;
+        };
         Insert: {
-          collectivite_id: number
-          consequences: Json
-          modified_at?: string
-          payload_timestamp?: string | null
-        }
+          collectivite_id: number;
+          consequences: Json;
+          modified_at?: string;
+          payload_timestamp?: string | null;
+        };
         Update: {
-          collectivite_id?: number
-          consequences?: Json
-          modified_at?: string
-          payload_timestamp?: string | null
-        }
-      }
+          collectivite_id?: number;
+          consequences?: Json;
+          modified_at?: string;
+          payload_timestamp?: string | null;
+        };
+      };
       personnalisation_regle: {
         Row: {
-          action_id: string
-          description: string
-          formule: string
-          modified_at: string
-          type: Database["public"]["Enums"]["regle_type"]
-        }
+          action_id: string;
+          description: string;
+          formule: string;
+          modified_at: string;
+          type: Database["public"]["Enums"]["regle_type"];
+        };
         Insert: {
-          action_id: string
-          description: string
-          formule: string
-          modified_at?: string
-          type: Database["public"]["Enums"]["regle_type"]
-        }
+          action_id: string;
+          description: string;
+          formule: string;
+          modified_at?: string;
+          type: Database["public"]["Enums"]["regle_type"];
+        };
         Update: {
-          action_id?: string
-          description?: string
-          formule?: string
-          modified_at?: string
-          type?: Database["public"]["Enums"]["regle_type"]
-        }
-      }
+          action_id?: string;
+          description?: string;
+          formule?: string;
+          modified_at?: string;
+          type?: Database["public"]["Enums"]["regle_type"];
+        };
+      };
       personnalisations_json: {
         Row: {
-          created_at: string
-          questions: Json
-          regles: Json
-        }
+          created_at: string;
+          questions: Json;
+          regles: Json;
+        };
         Insert: {
-          created_at?: string
-          questions: Json
-          regles: Json
-        }
+          created_at?: string;
+          questions: Json;
+          regles: Json;
+        };
         Update: {
-          created_at?: string
-          questions?: Json
-          regles?: Json
-        }
-      }
+          created_at?: string;
+          questions?: Json;
+          regles?: Json;
+        };
+      };
       personne_tag: {
         Row: {
-          collectivite_id: number
-          id: number
-          nom: string
-        }
+          collectivite_id: number;
+          id: number;
+          nom: string;
+        };
         Insert: {
-          collectivite_id: number
-          id?: number
-          nom: string
-        }
+          collectivite_id: number;
+          id?: number;
+          nom: string;
+        };
         Update: {
           collectivite_id?: number
           id?: number
@@ -1787,1060 +1791,1062 @@ export interface Database {
       }
       pre_audit_scores: {
         Row: {
-          audit_id: number
-          collectivite_id: number
-          modified_at: string
-          payload_timestamp: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          scores: Json
-        }
+          audit_id: number;
+          collectivite_id: number;
+          modified_at: string;
+          payload_timestamp: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          scores: Json;
+        };
         Insert: {
-          audit_id: number
-          collectivite_id: number
-          modified_at: string
-          payload_timestamp?: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          scores: Json
-        }
+          audit_id: number;
+          collectivite_id: number;
+          modified_at: string;
+          payload_timestamp?: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          scores: Json;
+        };
         Update: {
-          audit_id?: number
-          collectivite_id?: number
-          modified_at?: string
-          payload_timestamp?: string | null
-          referentiel?: Database["public"]["Enums"]["referentiel"]
-          scores?: Json
-        }
-      }
+          audit_id?: number;
+          collectivite_id?: number;
+          modified_at?: string;
+          payload_timestamp?: string | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"];
+          scores?: Json;
+        };
+      };
       preuve_action: {
         Row: {
-          action_id: string
-          preuve_id: string
-        }
+          action_id: string;
+          preuve_id: string;
+        };
         Insert: {
-          action_id: string
-          preuve_id: string
-        }
+          action_id: string;
+          preuve_id: string;
+        };
         Update: {
-          action_id?: string
-          preuve_id?: string
-        }
-      }
+          action_id?: string;
+          preuve_id?: string;
+        };
+      };
       preuve_audit: {
         Row: {
-          audit_id: number
-          collectivite_id: number
-          commentaire: string
-          fichier_id: number | null
-          id: number
-          lien: Json | null
-          modified_at: string
-          modified_by: string
-          titre: string
-          url: string | null
-        }
+          audit_id: number;
+          collectivite_id: number;
+          commentaire: string;
+          fichier_id: number | null;
+          id: number;
+          lien: Json | null;
+          modified_at: string;
+          modified_by: string;
+          titre: string;
+          url: string | null;
+        };
         Insert: {
-          audit_id: number
-          collectivite_id: number
-          commentaire?: string
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
+          audit_id: number;
+          collectivite_id: number;
+          commentaire?: string;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
         Update: {
-          audit_id?: number
-          collectivite_id?: number
-          commentaire?: string
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
-      }
+          audit_id?: number;
+          collectivite_id?: number;
+          commentaire?: string;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
+      };
       preuve_complementaire: {
         Row: {
-          action_id: string
-          collectivite_id: number
-          commentaire: string
-          fichier_id: number | null
-          id: number
-          lien: Json | null
-          modified_at: string
-          modified_by: string
-          titre: string
-          url: string | null
-        }
+          action_id: string;
+          collectivite_id: number;
+          commentaire: string;
+          fichier_id: number | null;
+          id: number;
+          lien: Json | null;
+          modified_at: string;
+          modified_by: string;
+          titre: string;
+          url: string | null;
+        };
         Insert: {
-          action_id: string
-          collectivite_id: number
-          commentaire?: string
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
+          action_id: string;
+          collectivite_id: number;
+          commentaire?: string;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
         Update: {
-          action_id?: string
-          collectivite_id?: number
-          commentaire?: string
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
-      }
+          action_id?: string;
+          collectivite_id?: number;
+          commentaire?: string;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
+      };
       preuve_labellisation: {
         Row: {
-          collectivite_id: number
-          commentaire: string
-          demande_id: number
-          fichier_id: number | null
-          id: number
-          lien: Json | null
-          modified_at: string
-          modified_by: string
-          titre: string
-          url: string | null
-        }
+          collectivite_id: number;
+          commentaire: string;
+          demande_id: number;
+          fichier_id: number | null;
+          id: number;
+          lien: Json | null;
+          modified_at: string;
+          modified_by: string;
+          titre: string;
+          url: string | null;
+        };
         Insert: {
-          collectivite_id: number
-          commentaire?: string
-          demande_id: number
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
+          collectivite_id: number;
+          commentaire?: string;
+          demande_id: number;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
         Update: {
-          collectivite_id?: number
-          commentaire?: string
-          demande_id?: number
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
-      }
+          collectivite_id?: number;
+          commentaire?: string;
+          demande_id?: number;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
+      };
       preuve_rapport: {
         Row: {
-          collectivite_id: number
-          commentaire: string
-          date: string
-          fichier_id: number | null
-          id: number
-          lien: Json | null
-          modified_at: string
-          modified_by: string
-          titre: string
-          url: string | null
-        }
+          collectivite_id: number;
+          commentaire: string;
+          date: string;
+          fichier_id: number | null;
+          id: number;
+          lien: Json | null;
+          modified_at: string;
+          modified_by: string;
+          titre: string;
+          url: string | null;
+        };
         Insert: {
-          collectivite_id: number
-          commentaire?: string
-          date: string
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
+          collectivite_id: number;
+          commentaire?: string;
+          date: string;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
         Update: {
-          collectivite_id?: number
-          commentaire?: string
-          date?: string
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          titre?: string
-          url?: string | null
-        }
-      }
+          collectivite_id?: number;
+          commentaire?: string;
+          date?: string;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          titre?: string;
+          url?: string | null;
+        };
+      };
       preuve_reglementaire: {
         Row: {
-          collectivite_id: number
-          commentaire: string
-          fichier_id: number | null
-          id: number
-          lien: Json | null
-          modified_at: string
-          modified_by: string
-          preuve_id: string
-          titre: string
-          url: string | null
-        }
+          collectivite_id: number;
+          commentaire: string;
+          fichier_id: number | null;
+          id: number;
+          lien: Json | null;
+          modified_at: string;
+          modified_by: string;
+          preuve_id: string;
+          titre: string;
+          url: string | null;
+        };
         Insert: {
-          collectivite_id: number
-          commentaire?: string
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          preuve_id: string
-          titre?: string
-          url?: string | null
-        }
+          collectivite_id: number;
+          commentaire?: string;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          preuve_id: string;
+          titre?: string;
+          url?: string | null;
+        };
         Update: {
-          collectivite_id?: number
-          commentaire?: string
-          fichier_id?: number | null
-          id?: number
-          lien?: Json | null
-          modified_at?: string
-          modified_by?: string
-          preuve_id?: string
-          titre?: string
-          url?: string | null
-        }
-      }
+          collectivite_id?: number;
+          commentaire?: string;
+          fichier_id?: number | null;
+          id?: number;
+          lien?: Json | null;
+          modified_at?: string;
+          modified_by?: string;
+          preuve_id?: string;
+          titre?: string;
+          url?: string | null;
+        };
+      };
       preuve_reglementaire_definition: {
         Row: {
-          description: string
-          id: string
-          nom: string
-        }
+          description: string;
+          id: string;
+          nom: string;
+        };
         Insert: {
-          description: string
-          id: string
-          nom: string
-        }
+          description: string;
+          id: string;
+          nom: string;
+        };
         Update: {
-          description?: string
-          id?: string
-          nom?: string
-        }
-      }
+          description?: string;
+          id?: string;
+          nom?: string;
+        };
+      };
       preuve_reglementaire_json: {
         Row: {
-          created_at: string
-          preuves: Json
-        }
+          created_at: string;
+          preuves: Json;
+        };
         Insert: {
-          created_at?: string
-          preuves: Json
-        }
+          created_at?: string;
+          preuves: Json;
+        };
         Update: {
-          created_at?: string
-          preuves?: Json
-        }
-      }
+          created_at?: string;
+          preuves?: Json;
+        };
+      };
       private_collectivite_membre: {
         Row: {
           champ_intervention:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
-          collectivite_id: number
-          created_at: string
-          details_fonction: string | null
-          fonction: Database["public"]["Enums"]["membre_fonction"] | null
-          modified_at: string
-          user_id: string
-        }
+            | null;
+          collectivite_id: number;
+          created_at: string;
+          details_fonction: string | null;
+          fonction: Database["public"]["Enums"]["membre_fonction"] | null;
+          modified_at: string;
+          user_id: string;
+        };
         Insert: {
           champ_intervention?:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
-          collectivite_id: number
-          created_at?: string
-          details_fonction?: string | null
-          fonction?: Database["public"]["Enums"]["membre_fonction"] | null
-          modified_at?: string
-          user_id: string
-        }
+            | null;
+          collectivite_id: number;
+          created_at?: string;
+          details_fonction?: string | null;
+          fonction?: Database["public"]["Enums"]["membre_fonction"] | null;
+          modified_at?: string;
+          user_id: string;
+        };
         Update: {
           champ_intervention?:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
-          collectivite_id?: number
-          created_at?: string
-          details_fonction?: string | null
-          fonction?: Database["public"]["Enums"]["membre_fonction"] | null
-          modified_at?: string
-          user_id?: string
-        }
-      }
+            | null;
+          collectivite_id?: number;
+          created_at?: string;
+          details_fonction?: string | null;
+          fonction?: Database["public"]["Enums"]["membre_fonction"] | null;
+          modified_at?: string;
+          user_id?: string;
+        };
+      };
       private_utilisateur_droit: {
         Row: {
-          active: boolean
-          collectivite_id: number
-          created_at: string
-          id: number
-          invitation_id: string | null
-          modified_at: string
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"]
-          user_id: string
-        }
+          active: boolean;
+          collectivite_id: number;
+          created_at: string;
+          id: number;
+          invitation_id: string | null;
+          modified_at: string;
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"];
+          user_id: string;
+        };
         Insert: {
-          active: boolean
-          collectivite_id: number
-          created_at?: string
-          id?: number
-          invitation_id?: string | null
-          modified_at?: string
-          niveau_acces?: Database["public"]["Enums"]["niveau_acces"]
-          user_id: string
-        }
+          active: boolean;
+          collectivite_id: number;
+          created_at?: string;
+          id?: number;
+          invitation_id?: string | null;
+          modified_at?: string;
+          niveau_acces?: Database["public"]["Enums"]["niveau_acces"];
+          user_id: string;
+        };
         Update: {
-          active?: boolean
-          collectivite_id?: number
-          created_at?: string
-          id?: number
-          invitation_id?: string | null
-          modified_at?: string
-          niveau_acces?: Database["public"]["Enums"]["niveau_acces"]
-          user_id?: string
-        }
-      }
+          active?: boolean;
+          collectivite_id?: number;
+          created_at?: string;
+          id?: number;
+          invitation_id?: string | null;
+          modified_at?: string;
+          niveau_acces?: Database["public"]["Enums"]["niveau_acces"];
+          user_id?: string;
+        };
+      };
       question: {
         Row: {
-          description: string
-          formulation: string
-          id: string
-          ordonnancement: number | null
-          thematique_id: string | null
-          type: Database["public"]["Enums"]["question_type"]
+          description: string;
+          formulation: string;
+          id: string;
+          ordonnancement: number | null;
+          thematique_id: string | null;
+          type: Database["public"]["Enums"]["question_type"];
           types_collectivites_concernees:
             | Database["public"]["Enums"]["type_collectivite"][]
-            | null
-        }
+            | null;
+        };
         Insert: {
-          description: string
-          formulation: string
-          id: string
-          ordonnancement?: number | null
-          thematique_id?: string | null
-          type: Database["public"]["Enums"]["question_type"]
+          description: string;
+          formulation: string;
+          id: string;
+          ordonnancement?: number | null;
+          thematique_id?: string | null;
+          type: Database["public"]["Enums"]["question_type"];
           types_collectivites_concernees?:
             | Database["public"]["Enums"]["type_collectivite"][]
-            | null
-        }
+            | null;
+        };
         Update: {
-          description?: string
-          formulation?: string
-          id?: string
-          ordonnancement?: number | null
-          thematique_id?: string | null
-          type?: Database["public"]["Enums"]["question_type"]
+          description?: string;
+          formulation?: string;
+          id?: string;
+          ordonnancement?: number | null;
+          thematique_id?: string | null;
+          type?: Database["public"]["Enums"]["question_type"];
           types_collectivites_concernees?:
             | Database["public"]["Enums"]["type_collectivite"][]
-            | null
-        }
-      }
+            | null;
+        };
+      };
       question_action: {
         Row: {
-          action_id: string
-          question_id: string
-        }
+          action_id: string;
+          question_id: string;
+        };
         Insert: {
-          action_id: string
-          question_id: string
-        }
+          action_id: string;
+          question_id: string;
+        };
         Update: {
-          action_id?: string
-          question_id?: string
-        }
-      }
+          action_id?: string;
+          question_id?: string;
+        };
+      };
       question_choix: {
         Row: {
-          formulation: string | null
-          id: string
-          ordonnancement: number | null
-          question_id: string | null
-        }
+          formulation: string | null;
+          id: string;
+          ordonnancement: number | null;
+          question_id: string | null;
+        };
         Insert: {
-          formulation?: string | null
-          id: string
-          ordonnancement?: number | null
-          question_id?: string | null
-        }
+          formulation?: string | null;
+          id: string;
+          ordonnancement?: number | null;
+          question_id?: string | null;
+        };
         Update: {
-          formulation?: string | null
-          id?: string
-          ordonnancement?: number | null
-          question_id?: string | null
-        }
-      }
+          formulation?: string | null;
+          id?: string;
+          ordonnancement?: number | null;
+          question_id?: string | null;
+        };
+      };
       question_thematique: {
         Row: {
-          id: string
-          nom: string | null
-        }
+          id: string;
+          nom: string | null;
+        };
         Insert: {
-          id: string
-          nom?: string | null
-        }
+          id: string;
+          nom?: string | null;
+        };
         Update: {
-          id?: string
-          nom?: string | null
-        }
-      }
+          id?: string;
+          nom?: string | null;
+        };
+      };
       referentiel_json: {
         Row: {
-          children: Json
-          created_at: string
-          definitions: Json
-        }
+          children: Json;
+          created_at: string;
+          definitions: Json;
+        };
         Insert: {
-          children: Json
-          created_at?: string
-          definitions: Json
-        }
+          children: Json;
+          created_at?: string;
+          definitions: Json;
+        };
         Update: {
-          children?: Json
-          created_at?: string
-          definitions?: Json
-        }
-      }
+          children?: Json;
+          created_at?: string;
+          definitions?: Json;
+        };
+      };
       reponse_binaire: {
         Row: {
-          collectivite_id: number
-          modified_at: string
-          question_id: string
-          reponse: boolean | null
-        }
+          collectivite_id: number;
+          modified_at: string;
+          question_id: string;
+          reponse: boolean | null;
+        };
         Insert: {
-          collectivite_id: number
-          modified_at?: string
-          question_id: string
-          reponse?: boolean | null
-        }
+          collectivite_id: number;
+          modified_at?: string;
+          question_id: string;
+          reponse?: boolean | null;
+        };
         Update: {
-          collectivite_id?: number
-          modified_at?: string
-          question_id?: string
-          reponse?: boolean | null
-        }
-      }
+          collectivite_id?: number;
+          modified_at?: string;
+          question_id?: string;
+          reponse?: boolean | null;
+        };
+      };
       reponse_choix: {
         Row: {
-          collectivite_id: number
-          modified_at: string
-          question_id: string
-          reponse: string | null
-        }
+          collectivite_id: number;
+          modified_at: string;
+          question_id: string;
+          reponse: string | null;
+        };
         Insert: {
-          collectivite_id: number
-          modified_at?: string
-          question_id: string
-          reponse?: string | null
-        }
+          collectivite_id: number;
+          modified_at?: string;
+          question_id: string;
+          reponse?: string | null;
+        };
         Update: {
-          collectivite_id?: number
-          modified_at?: string
-          question_id?: string
-          reponse?: string | null
-        }
-      }
+          collectivite_id?: number;
+          modified_at?: string;
+          question_id?: string;
+          reponse?: string | null;
+        };
+      };
       reponse_proportion: {
         Row: {
-          collectivite_id: number
-          modified_at: string
-          question_id: string
-          reponse: number | null
-        }
+          collectivite_id: number;
+          modified_at: string;
+          question_id: string;
+          reponse: number | null;
+        };
         Insert: {
-          collectivite_id: number
-          modified_at?: string
-          question_id: string
-          reponse?: number | null
-        }
+          collectivite_id: number;
+          modified_at?: string;
+          question_id: string;
+          reponse?: number | null;
+        };
         Update: {
-          collectivite_id?: number
-          modified_at?: string
-          question_id?: string
-          reponse?: number | null
-        }
-      }
+          collectivite_id?: number;
+          modified_at?: string;
+          question_id?: string;
+          reponse?: number | null;
+        };
+      };
       service_tag: {
         Row: {
-          collectivite_id: number
-          id: number
-          nom: string
-        }
+          collectivite_id: number;
+          id: number;
+          nom: string;
+        };
         Insert: {
-          collectivite_id: number
-          id?: number
-          nom: string
-        }
+          collectivite_id: number;
+          id?: number;
+          nom: string;
+        };
         Update: {
-          collectivite_id?: number
-          id?: number
-          nom?: string
-        }
-      }
+          collectivite_id?: number;
+          id?: number;
+          nom?: string;
+        };
+      };
       sous_thematique: {
         Row: {
-          id: number
-          sous_thematique: string
-          thematique: string
-        }
+          id: number;
+          sous_thematique: string;
+          thematique: string;
+        };
         Insert: {
-          id?: number
-          sous_thematique: string
-          thematique: string
-        }
+          id?: number;
+          sous_thematique: string;
+          thematique: string;
+        };
         Update: {
-          id?: number
-          sous_thematique?: string
-          thematique?: string
-        }
-      }
+          id?: number;
+          sous_thematique?: string;
+          thematique?: string;
+        };
+      };
       structure_tag: {
         Row: {
-          collectivite_id: number
-          id: number
-          nom: string
-        }
+          collectivite_id: number;
+          id: number;
+          nom: string;
+        };
         Insert: {
-          collectivite_id: number
-          id?: number
-          nom: string
-        }
+          collectivite_id: number;
+          id?: number;
+          nom: string;
+        };
         Update: {
-          collectivite_id?: number
-          id?: number
-          nom?: string
-        }
-      }
+          collectivite_id?: number;
+          id?: number;
+          nom?: string;
+        };
+      };
       thematique: {
         Row: {
-          thematique: string
-        }
+          thematique: string;
+        };
         Insert: {
-          thematique: string
-        }
+          thematique: string;
+        };
         Update: {
-          thematique?: string
-        }
-      }
+          thematique?: string;
+        };
+      };
       type_tabular_score: {
         Row: {
-          action_id: string | null
-          avancement: Database["public"]["Enums"]["avancement"] | null
-          concerne: boolean | null
-          desactive: boolean | null
-          points_max_personnalises: number | null
-          points_max_referentiel: number | null
-          points_programmes: number | null
-          points_realises: number | null
-          points_restants: number | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          score_non_renseigne: number | null
-          score_pas_fait: number | null
-          score_programme: number | null
-          score_realise: number | null
-          score_realise_plus_programme: number | null
-        }
+          action_id: string | null;
+          avancement: Database["public"]["Enums"]["avancement"] | null;
+          concerne: boolean | null;
+          desactive: boolean | null;
+          points_max_personnalises: number | null;
+          points_max_referentiel: number | null;
+          points_programmes: number | null;
+          points_realises: number | null;
+          points_restants: number | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          score_non_renseigne: number | null;
+          score_pas_fait: number | null;
+          score_programme: number | null;
+          score_realise: number | null;
+          score_realise_plus_programme: number | null;
+        };
         Insert: {
-          action_id?: string | null
-          avancement?: Database["public"]["Enums"]["avancement"] | null
-          concerne?: boolean | null
-          desactive?: boolean | null
-          points_max_personnalises?: number | null
-          points_max_referentiel?: number | null
-          points_programmes?: number | null
-          points_realises?: number | null
-          points_restants?: number | null
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null
-          score_non_renseigne?: number | null
-          score_pas_fait?: number | null
-          score_programme?: number | null
-          score_realise?: number | null
-          score_realise_plus_programme?: number | null
-        }
+          action_id?: string | null;
+          avancement?: Database["public"]["Enums"]["avancement"] | null;
+          concerne?: boolean | null;
+          desactive?: boolean | null;
+          points_max_personnalises?: number | null;
+          points_max_referentiel?: number | null;
+          points_programmes?: number | null;
+          points_realises?: number | null;
+          points_restants?: number | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
+          score_non_renseigne?: number | null;
+          score_pas_fait?: number | null;
+          score_programme?: number | null;
+          score_realise?: number | null;
+          score_realise_plus_programme?: number | null;
+        };
         Update: {
-          action_id?: string | null
-          avancement?: Database["public"]["Enums"]["avancement"] | null
-          concerne?: boolean | null
-          desactive?: boolean | null
-          points_max_personnalises?: number | null
-          points_max_referentiel?: number | null
-          points_programmes?: number | null
-          points_realises?: number | null
-          points_restants?: number | null
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null
-          score_non_renseigne?: number | null
-          score_pas_fait?: number | null
-          score_programme?: number | null
-          score_realise?: number | null
-          score_realise_plus_programme?: number | null
-        }
-      }
+          action_id?: string | null;
+          avancement?: Database["public"]["Enums"]["avancement"] | null;
+          concerne?: boolean | null;
+          desactive?: boolean | null;
+          points_max_personnalises?: number | null;
+          points_max_referentiel?: number | null;
+          points_programmes?: number | null;
+          points_realises?: number | null;
+          points_restants?: number | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
+          score_non_renseigne?: number | null;
+          score_pas_fait?: number | null;
+          score_programme?: number | null;
+          score_realise?: number | null;
+          score_realise_plus_programme?: number | null;
+        };
+      };
       usage: {
         Row: {
-          action: Database["public"]["Enums"]["usage_action"]
-          collectivite_id: number | null
-          fonction: Database["public"]["Enums"]["usage_fonction"]
-          page: Database["public"]["Enums"]["visite_page"] | null
-          time: string
-          user_id: string | null
-        }
+          action: Database["public"]["Enums"]["usage_action"];
+          collectivite_id: number | null;
+          fonction: Database["public"]["Enums"]["usage_fonction"];
+          page: Database["public"]["Enums"]["visite_page"] | null;
+          time: string;
+          user_id: string | null;
+        };
         Insert: {
-          action: Database["public"]["Enums"]["usage_action"]
-          collectivite_id?: number | null
-          fonction: Database["public"]["Enums"]["usage_fonction"]
-          page?: Database["public"]["Enums"]["visite_page"] | null
-          time?: string
-          user_id?: string | null
-        }
+          action: Database["public"]["Enums"]["usage_action"];
+          collectivite_id?: number | null;
+          fonction: Database["public"]["Enums"]["usage_fonction"];
+          page?: Database["public"]["Enums"]["visite_page"] | null;
+          time?: string;
+          user_id?: string | null;
+        };
         Update: {
-          action?: Database["public"]["Enums"]["usage_action"]
-          collectivite_id?: number | null
-          fonction?: Database["public"]["Enums"]["usage_fonction"]
-          page?: Database["public"]["Enums"]["visite_page"] | null
-          time?: string
-          user_id?: string | null
-        }
-      }
+          action?: Database["public"]["Enums"]["usage_action"];
+          collectivite_id?: number | null;
+          fonction?: Database["public"]["Enums"]["usage_fonction"];
+          page?: Database["public"]["Enums"]["visite_page"] | null;
+          time?: string;
+          user_id?: string | null;
+        };
+      };
       visite: {
         Row: {
-          collectivite_id: number | null
-          onglet: Database["public"]["Enums"]["visite_onglet"] | null
-          page: Database["public"]["Enums"]["visite_page"]
-          tag: Database["public"]["Enums"]["visite_tag"] | null
-          time: string
-          user_id: string | null
-        }
+          collectivite_id: number | null;
+          onglet: Database["public"]["Enums"]["visite_onglet"] | null;
+          page: Database["public"]["Enums"]["visite_page"];
+          tag: Database["public"]["Enums"]["visite_tag"] | null;
+          time: string;
+          user_id: string | null;
+        };
         Insert: {
-          collectivite_id?: number | null
-          onglet?: Database["public"]["Enums"]["visite_onglet"] | null
-          page: Database["public"]["Enums"]["visite_page"]
-          tag?: Database["public"]["Enums"]["visite_tag"] | null
-          time?: string
-          user_id?: string | null
-        }
+          collectivite_id?: number | null;
+          onglet?: Database["public"]["Enums"]["visite_onglet"] | null;
+          page: Database["public"]["Enums"]["visite_page"];
+          tag?: Database["public"]["Enums"]["visite_tag"] | null;
+          time?: string;
+          user_id?: string | null;
+        };
         Update: {
-          collectivite_id?: number | null
-          onglet?: Database["public"]["Enums"]["visite_onglet"] | null
-          page?: Database["public"]["Enums"]["visite_page"]
-          tag?: Database["public"]["Enums"]["visite_tag"] | null
-          time?: string
-          user_id?: string | null
-        }
-      }
-    }
+          collectivite_id?: number | null;
+          onglet?: Database["public"]["Enums"]["visite_onglet"] | null;
+          page?: Database["public"]["Enums"]["visite_page"];
+          tag?: Database["public"]["Enums"]["visite_tag"] | null;
+          time?: string;
+          user_id?: string | null;
+        };
+      };
+    };
     Views: {
       action_audit_state: {
         Row: {
-          action_id: string | null
-          audit_id: number | null
-          avis: string | null
-          collectivite_id: number | null
-          ordre_du_jour: boolean | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          state_id: number | null
-          statut: Database["public"]["Enums"]["audit_statut"] | null
-        }
-      }
+          action_id: string | null;
+          audit_id: number | null;
+          avis: string | null;
+          collectivite_id: number | null;
+          ordre_du_jour: boolean | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          state_id: number | null;
+          statut: Database["public"]["Enums"]["audit_statut"] | null;
+        };
+      };
       action_children: {
         Row: {
-          children: unknown[] | null
-          depth: number | null
-          id: string | null
-        }
-      }
+          children: unknown[] | null;
+          depth: number | null;
+          id: string | null;
+        };
+      };
       action_definition_summary: {
         Row: {
-          children: unknown[] | null
-          depth: number | null
-          description: string | null
-          have_contexte: boolean | null
-          have_exemples: boolean | null
-          have_perimetre_evaluation: boolean | null
-          have_preuve: boolean | null
-          have_questions: boolean | null
-          have_reduction_potentiel: boolean | null
-          have_ressources: boolean | null
-          id: string | null
-          identifiant: string | null
-          nom: string | null
-          phase: Database["public"]["Enums"]["action_categorie"] | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          type: Database["public"]["Enums"]["action_type"] | null
-        }
-      }
+          children: unknown[] | null;
+          depth: number | null;
+          description: string | null;
+          have_contexte: boolean | null;
+          have_exemples: boolean | null;
+          have_perimetre_evaluation: boolean | null;
+          have_preuve: boolean | null;
+          have_questions: boolean | null;
+          have_reduction_potentiel: boolean | null;
+          have_ressources: boolean | null;
+          id: string | null;
+          identifiant: string | null;
+          nom: string | null;
+          phase: Database["public"]["Enums"]["action_categorie"] | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          type: Database["public"]["Enums"]["action_type"] | null;
+        };
+      };
       action_discussion_feed: {
         Row: {
-          action_id: string | null
-          collectivite_id: number | null
-          commentaires: Json[] | null
-          created_at: string | null
-          created_by: string | null
-          id: number | null
-          modified_at: string | null
-          status: Database["public"]["Enums"]["action_discussion_statut"] | null
-        }
-      }
+          action_id: string | null;
+          collectivite_id: number | null;
+          commentaires: Json[] | null;
+          created_at: string | null;
+          created_by: string | null;
+          id: number | null;
+          modified_at: string | null;
+          status:
+            | Database["public"]["Enums"]["action_discussion_statut"]
+            | null;
+        };
+      };
       action_statuts: {
         Row: {
-          action_id: string | null
-          ascendants: unknown[] | null
-          avancement: Database["public"]["Enums"]["avancement"] | null
+          action_id: string | null;
+          ascendants: unknown[] | null;
+          avancement: Database["public"]["Enums"]["avancement"] | null;
           avancement_descendants:
             | Database["public"]["Enums"]["avancement"][]
-            | null
-          avancement_detaille: number[] | null
-          collectivite_id: number | null
-          concerne: boolean | null
-          depth: number | null
-          desactive: boolean | null
-          descendants: unknown[] | null
-          description: string | null
-          have_children: boolean | null
-          have_contexte: boolean | null
-          have_exemples: boolean | null
-          have_perimetre_evaluation: boolean | null
-          have_preuve: boolean | null
-          have_reduction_potentiel: boolean | null
-          have_ressources: boolean | null
-          identifiant: string | null
-          nom: string | null
-          non_concerne: boolean | null
-          phase: Database["public"]["Enums"]["action_categorie"] | null
-          points_max_personnalises: number | null
-          points_max_referentiel: number | null
-          points_programmes: number | null
-          points_realises: number | null
-          points_restants: number | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          score_non_renseigne: number | null
-          score_pas_fait: number | null
-          score_programme: number | null
-          score_realise: number | null
-          score_realise_plus_programme: number | null
-          type: Database["public"]["Enums"]["action_type"] | null
-        }
-      }
+            | null;
+          avancement_detaille: number[] | null;
+          collectivite_id: number | null;
+          concerne: boolean | null;
+          depth: number | null;
+          desactive: boolean | null;
+          descendants: unknown[] | null;
+          description: string | null;
+          have_children: boolean | null;
+          have_contexte: boolean | null;
+          have_exemples: boolean | null;
+          have_perimetre_evaluation: boolean | null;
+          have_preuve: boolean | null;
+          have_reduction_potentiel: boolean | null;
+          have_ressources: boolean | null;
+          identifiant: string | null;
+          nom: string | null;
+          non_concerne: boolean | null;
+          phase: Database["public"]["Enums"]["action_categorie"] | null;
+          points_max_personnalises: number | null;
+          points_max_referentiel: number | null;
+          points_programmes: number | null;
+          points_realises: number | null;
+          points_restants: number | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          score_non_renseigne: number | null;
+          score_pas_fait: number | null;
+          score_programme: number | null;
+          score_realise: number | null;
+          score_realise_plus_programme: number | null;
+          type: Database["public"]["Enums"]["action_type"] | null;
+        };
+      };
       action_title: {
         Row: {
-          children: unknown[] | null
-          id: string | null
-          identifiant: string | null
-          nom: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          type: Database["public"]["Enums"]["action_type"] | null
-        }
-      }
+          children: unknown[] | null;
+          id: string | null;
+          identifiant: string | null;
+          nom: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          type: Database["public"]["Enums"]["action_type"] | null;
+        };
+      };
       active_collectivite: {
         Row: {
-          collectivite_id: number | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          nom: string | null;
+        };
+      };
       audit: {
         Row: {
-          collectivite_id: number | null
-          date_debut: string | null
-          date_fin: string | null
-          demande_id: number | null
-          id: number | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          valide: boolean | null
-        }
+          collectivite_id: number | null;
+          date_debut: string | null;
+          date_fin: string | null;
+          demande_id: number | null;
+          id: number | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          valide: boolean | null;
+        };
         Insert: {
-          collectivite_id?: number | null
-          date_debut?: string | null
-          date_fin?: string | null
-          demande_id?: number | null
-          id?: number | null
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null
-          valide?: boolean | null
-        }
+          collectivite_id?: number | null;
+          date_debut?: string | null;
+          date_fin?: string | null;
+          demande_id?: number | null;
+          id?: number | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
+          valide?: boolean | null;
+        };
         Update: {
-          collectivite_id?: number | null
-          date_debut?: string | null
-          date_fin?: string | null
-          demande_id?: number | null
-          id?: number | null
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null
-          valide?: boolean | null
-        }
-      }
+          collectivite_id?: number | null;
+          date_debut?: string | null;
+          date_fin?: string | null;
+          demande_id?: number | null;
+          id?: number | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
+          valide?: boolean | null;
+        };
+      };
       audit_en_cours: {
         Row: {
-          collectivite_id: number | null
-          date_debut: string | null
-          date_fin: string | null
-          demande_id: number | null
-          id: number | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          valide: boolean | null
-        }
+          collectivite_id: number | null;
+          date_debut: string | null;
+          date_fin: string | null;
+          demande_id: number | null;
+          id: number | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          valide: boolean | null;
+        };
         Insert: {
-          collectivite_id?: number | null
-          date_debut?: string | null
-          date_fin?: string | null
-          demande_id?: number | null
-          id?: number | null
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null
-          valide?: boolean | null
-        }
+          collectivite_id?: number | null;
+          date_debut?: string | null;
+          date_fin?: string | null;
+          demande_id?: number | null;
+          id?: number | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
+          valide?: boolean | null;
+        };
         Update: {
-          collectivite_id?: number | null
-          date_debut?: string | null
-          date_fin?: string | null
-          demande_id?: number | null
-          id?: number | null
-          referentiel?: Database["public"]["Enums"]["referentiel"] | null
-          valide?: boolean | null
-        }
-      }
+          collectivite_id?: number | null;
+          date_debut?: string | null;
+          date_fin?: string | null;
+          demande_id?: number | null;
+          id?: number | null;
+          referentiel?: Database["public"]["Enums"]["referentiel"] | null;
+          valide?: boolean | null;
+        };
+      };
       auditeurs: {
         Row: {
-          audit_id: number | null
-          collectivite_id: number | null
-          noms: Json | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-        }
-      }
+          audit_id: number | null;
+          collectivite_id: number | null;
+          noms: Json | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+        };
+      };
       audits: {
         Row: {
-          audit: unknown | null
-          collectivite_id: number | null
-          demande: unknown | null
-          is_cot: boolean | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-        }
-      }
+          audit: unknown | null;
+          collectivite_id: number | null;
+          demande: unknown | null;
+          is_cot: boolean | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+        };
+      };
       axe_descendants: {
         Row: {
-          axe_id: number | null
-          depth: number | null
-          descendants: number[] | null
-          parents: number[] | null
-        }
-      }
+          axe_id: number | null;
+          depth: number | null;
+          descendants: number[] | null;
+          parents: number[] | null;
+        };
+      };
       bibliotheque_annexe: {
         Row: {
-          collectivite_id: number | null
-          commentaire: string | null
-          created_at: string | null
-          created_by: string | null
-          created_by_nom: string | null
-          fiche_id: number | null
-          fichier: Json | null
-          id: number | null
-          lien: Json | null
-          plan_ids: number[] | null
-        }
-      }
+          collectivite_id: number | null;
+          commentaire: string | null;
+          created_at: string | null;
+          created_by: string | null;
+          created_by_nom: string | null;
+          fiche_id: number | null;
+          fichier: Json | null;
+          id: number | null;
+          lien: Json | null;
+          plan_ids: number[] | null;
+        };
+      };
       bibliotheque_fichier: {
         Row: {
-          bucket_id: string | null
-          collectivite_id: number | null
-          file_id: string | null
-          filename: string | null
-          filesize: number | null
-          hash: string | null
-          id: number | null
-        }
-      }
+          bucket_id: string | null;
+          collectivite_id: number | null;
+          file_id: string | null;
+          filename: string | null;
+          filesize: number | null;
+          hash: string | null;
+          id: number | null;
+        };
+      };
       business_action_children: {
         Row: {
-          children: unknown[] | null
-          id: string | null
-          parent: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-        }
-      }
+          children: unknown[] | null;
+          id: string | null;
+          parent: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+        };
+      };
       business_action_statut: {
         Row: {
-          action_id: string | null
-          avancement: Database["public"]["Enums"]["avancement"] | null
-          avancement_detaille: number[] | null
-          collectivite_id: number | null
-          concerne: boolean | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-        }
-      }
+          action_id: string | null;
+          avancement: Database["public"]["Enums"]["avancement"] | null;
+          avancement_detaille: number[] | null;
+          collectivite_id: number | null;
+          concerne: boolean | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+        };
+      };
       business_reponse: {
         Row: {
-          collectivite_id: number | null
-          reponses: Json[] | null
-        }
-      }
+          collectivite_id: number | null;
+          reponses: Json[] | null;
+        };
+      };
       client_action_statut: {
         Row: {
-          action_id: string | null
-          avancement: Database["public"]["Enums"]["avancement"] | null
-          collectivite_id: number | null
-          concerne: boolean | null
-          modified_by: string | null
-        }
+          action_id: string | null;
+          avancement: Database["public"]["Enums"]["avancement"] | null;
+          collectivite_id: number | null;
+          concerne: boolean | null;
+          modified_by: string | null;
+        };
         Insert: {
-          action_id?: string | null
-          avancement?: Database["public"]["Enums"]["avancement"] | null
-          collectivite_id?: number | null
-          concerne?: boolean | null
-          modified_by?: string | null
-        }
+          action_id?: string | null;
+          avancement?: Database["public"]["Enums"]["avancement"] | null;
+          collectivite_id?: number | null;
+          concerne?: boolean | null;
+          modified_by?: string | null;
+        };
         Update: {
-          action_id?: string | null
-          avancement?: Database["public"]["Enums"]["avancement"] | null
-          collectivite_id?: number | null
-          concerne?: boolean | null
-          modified_by?: string | null
-        }
-      }
+          action_id?: string | null;
+          avancement?: Database["public"]["Enums"]["avancement"] | null;
+          collectivite_id?: number | null;
+          concerne?: boolean | null;
+          modified_by?: string | null;
+        };
+      };
       collectivite_carte_identite: {
         Row: {
-          code_siren_insee: string | null
-          collectivite_id: number | null
-          departement_name: string | null
-          is_cot: boolean | null
-          nom: string | null
-          population_source: string | null
-          population_totale: number | null
-          region_name: string | null
+          code_siren_insee: string | null;
+          collectivite_id: number | null;
+          departement_name: string | null;
+          is_cot: boolean | null;
+          nom: string | null;
+          population_source: string | null;
+          population_totale: number | null;
+          region_name: string | null;
           type_collectivite:
             | Database["public"]["Enums"]["type_collectivite"]
-            | null
-        }
-      }
+            | null;
+        };
+      };
       collectivite_identite: {
         Row: {
-          id: number | null
-          localisation: string[] | null
-          population: string[] | null
-          type: Database["public"]["Enums"]["type_collectivite"][] | null
-        }
-      }
+          id: number | null;
+          localisation: string[] | null;
+          population: string[] | null;
+          type: Database["public"]["Enums"]["type_collectivite"][] | null;
+        };
+      };
       collectivite_niveau_acces: {
         Row: {
-          access_restreint: boolean | null
-          collectivite_id: number | null
-          est_auditeur: boolean | null
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null
-          nom: string | null
-        }
-      }
+          access_restreint: boolean | null;
+          collectivite_id: number | null;
+          est_auditeur: boolean | null;
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null;
+          nom: string | null;
+        };
+      };
       comparaison_scores_audit: {
         Row: {
-          action_id: string | null
-          collectivite_id: number | null
-          courant: Database["public"]["CompositeTypes"]["tabular_score"] | null
+          action_id: string | null;
+          collectivite_id: number | null;
+          courant: Database["public"]["CompositeTypes"]["tabular_score"] | null;
           pre_audit:
             | Database["public"]["CompositeTypes"]["tabular_score"]
-            | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-        }
-      }
+            | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+        };
+      };
       crm_collectivites: {
         Row: {
-          code_siren_insee: string | null
-          collectivite_id: number | null
-          cot: boolean | null
-          departement_code: string | null
-          departement_name: string | null
-          key: string | null
-          nature_collectivite: string | null
-          nom: string | null
-          population_totale: number | null
-          region_code: string | null
-          region_name: string | null
+          code_siren_insee: string | null;
+          collectivite_id: number | null;
+          cot: boolean | null;
+          departement_code: string | null;
+          departement_name: string | null;
+          key: string | null;
+          nature_collectivite: string | null;
+          nom: string | null;
+          population_totale: number | null;
+          region_code: string | null;
+          region_name: string | null;
           type_collectivite:
             | Database["public"]["Enums"]["type_collectivite"]
-            | null
-        }
-      }
+            | null;
+        };
+      };
       crm_droits: {
         Row: {
-          champ_intervention: string | null
-          collectivite_id: number | null
-          collectivite_key: string | null
-          details_fonction: string | null
-          fonction: Database["public"]["Enums"]["membre_fonction"] | null
-          key: string | null
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null
-          user_id: string | null
-          user_key: string | null
-        }
-      }
+          champ_intervention: string | null;
+          collectivite_id: number | null;
+          collectivite_key: string | null;
+          details_fonction: string | null;
+          fonction: Database["public"]["Enums"]["membre_fonction"] | null;
+          key: string | null;
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null;
+          user_id: string | null;
+          user_key: string | null;
+        };
+      };
       crm_labellisations: {
         Row: {
-          annee: number | null
-          collectivite_key: string | null
-          etoiles: number | null
-          id: number | null
-          obtenue_le: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          score_programme: number | null
-          score_realise: number | null
-        }
-      }
+          annee: number | null;
+          collectivite_key: string | null;
+          etoiles: number | null;
+          id: number | null;
+          obtenue_le: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          score_programme: number | null;
+          score_realise: number | null;
+        };
+      };
       crm_personnes: {
         Row: {
-          email: string | null
-          key: string | null
-          nom: string | null
-          prenom: string | null
-          telephone: string | null
-          user_id: string | null
-        }
+          email: string | null;
+          key: string | null;
+          nom: string | null;
+          prenom: string | null;
+          telephone: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          email?: never
-          key?: never
-          nom?: never
-          prenom?: never
-          telephone?: never
-          user_id?: string | null
-        }
+          email?: never;
+          key?: never;
+          nom?: never;
+          prenom?: never;
+          telephone?: never;
+          user_id?: string | null;
+        };
         Update: {
-          email?: never
-          key?: never
-          nom?: never
-          prenom?: never
-          telephone?: never
-          user_id?: string | null
-        }
-      }
+          email?: never;
+          key?: never;
+          nom?: never;
+          prenom?: never;
+          telephone?: never;
+          user_id?: string | null;
+        };
+      };
       crm_usages: {
         Row: {
-          collectivite_id: number | null
-          completude_cae: number | null
-          completude_eci: number | null
-          fiches: number | null
-          indicateurs_perso: number | null
-          key: string | null
-          plans: number | null
-          premier_rattachement: string | null
-          resultats_indicateurs: number | null
-          resultats_indicateurs_perso: number | null
-        }
-      }
+          collectivite_id: number | null;
+          completude_cae: number | null;
+          completude_eci: number | null;
+          fiches: number | null;
+          indicateurs_perso: number | null;
+          key: string | null;
+          plans: number | null;
+          premier_rattachement: string | null;
+          resultats_indicateurs: number | null;
+          resultats_indicateurs_perso: number | null;
+        };
+      };
       departement: {
         Row: {
-          code: string | null
-          libelle: string | null
-          region_code: string | null
-        }
+          code: string | null;
+          libelle: string | null;
+          region_code: string | null;
+        };
         Insert: {
-          code?: string | null
-          libelle?: string | null
-          region_code?: string | null
-        }
+          code?: string | null;
+          libelle?: string | null;
+          region_code?: string | null;
+        };
         Update: {
           code?: string | null
           libelle?: string | null
@@ -2865,3604 +2871,3605 @@ export interface Database {
       }
       fiche_action_personne_pilote: {
         Row: {
-          collectivite_id: number | null
-          nom: string | null
-          tag_id: number | null
-          user_id: string | null
-        }
-      }
+          collectivite_id: number | null;
+          nom: string | null;
+          tag_id: number | null;
+          user_id: string | null;
+        };
+      };
       fiche_action_personne_referente: {
         Row: {
-          collectivite_id: number | null
-          nom: string | null
-          tag_id: number | null
-          user_id: string | null
-        }
-      }
+          collectivite_id: number | null;
+          nom: string | null;
+          tag_id: number | null;
+          user_id: string | null;
+        };
+      };
       fiche_resume: {
         Row: {
-          collectivite_id: number | null
-          id: number | null
-          modified_at: string | null
-          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
-          plans: unknown[] | null
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          titre: string | null
-        }
-      }
+          collectivite_id: number | null;
+          id: number | null;
+          modified_at: string | null;
+          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null;
+          plans: unknown[] | null;
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
+          titre: string | null;
+        };
+      };
       fiches_action: {
         Row: {
-          actions: unknown[] | null
-          amelioration_continue: boolean | null
-          axes: unknown[] | null
-          budget_previsionnel: number | null
-          calendrier: string | null
-          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null
-          collectivite_id: number | null
-          created_at: string | null
-          date_debut: string | null
-          date_fin_provisoire: string | null
-          description: string | null
-          fiches_liees: unknown[] | null
-          financements: string | null
+          actions: unknown[] | null;
+          amelioration_continue: boolean | null;
+          axes: unknown[] | null;
+          budget_previsionnel: number | null;
+          calendrier: string | null;
+          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null;
+          collectivite_id: number | null;
+          created_at: string | null;
+          date_debut: string | null;
+          date_fin_provisoire: string | null;
+          description: string | null;
+          fiches_liees: unknown[] | null;
+          financements: string | null;
           financeurs:
             | Database["public"]["CompositeTypes"]["financeur_montant"][]
-            | null
-          id: number | null
+            | null;
+          id: number | null;
           indicateurs:
             | Database["public"]["CompositeTypes"]["indicateur_generique"][]
-            | null
-          maj_termine: boolean | null
-          modified_at: string | null
-          modified_by: string | null
+            | null;
+          maj_termine: boolean | null;
+          modified_at: string | null;
+          modified_by: string | null;
           niveau_priorite:
             | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null
-          notes_complementaires: string | null
-          objectifs: string | null
-          partenaires: unknown[] | null
+            | null;
+          notes_complementaires: string | null;
+          objectifs: string | null;
+          partenaires: unknown[] | null;
           piliers_eci:
             | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null
-          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
-          referents: Database["public"]["CompositeTypes"]["personne"][] | null
-          ressources: string | null
+            | null;
+          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null;
+          referents: Database["public"]["CompositeTypes"]["personne"][] | null;
+          ressources: string | null;
           resultats_attendus:
             | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null
-          services: unknown[] | null
-          sous_thematiques: unknown[] | null
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          structures: unknown[] | null
-          thematiques: unknown[] | null
-          titre: string | null
-        }
-      }
+            | null;
+          services: unknown[] | null;
+          sous_thematiques: unknown[] | null;
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
+          structures: unknown[] | null;
+          thematiques: unknown[] | null;
+          titre: string | null;
+        };
+      };
       fiches_liees_par_fiche: {
         Row: {
-          fiche_id: number | null
-          fiche_liee_id: number | null
-        }
-      }
+          fiche_id: number | null;
+          fiche_liee_id: number | null;
+        };
+      };
       historique: {
         Row: {
-          action_id: string | null
-          action_identifiant: string | null
-          action_ids: unknown[] | null
-          action_nom: string | null
-          avancement: Database["public"]["Enums"]["avancement"] | null
-          avancement_detaille: number[] | null
-          collectivite_id: number | null
-          concerne: boolean | null
-          justification: string | null
-          modified_at: string | null
-          modified_by_id: string | null
-          modified_by_nom: string | null
-          precision: string | null
-          previous_avancement: Database["public"]["Enums"]["avancement"] | null
-          previous_avancement_detaille: number[] | null
-          previous_concerne: boolean | null
-          previous_justification: string | null
-          previous_modified_at: string | null
-          previous_modified_by_id: string | null
-          previous_precision: string | null
-          previous_reponse: Json | null
-          question_formulation: string | null
-          question_id: string | null
-          question_type: Database["public"]["Enums"]["question_type"] | null
-          reponse: Json | null
-          tache_identifiant: string | null
-          tache_nom: string | null
-          thematique_id: string | null
-          thematique_nom: string | null
-          type: string | null
-        }
-      }
+          action_id: string | null;
+          action_identifiant: string | null;
+          action_ids: unknown[] | null;
+          action_nom: string | null;
+          avancement: Database["public"]["Enums"]["avancement"] | null;
+          avancement_detaille: number[] | null;
+          collectivite_id: number | null;
+          concerne: boolean | null;
+          justification: string | null;
+          modified_at: string | null;
+          modified_by_id: string | null;
+          modified_by_nom: string | null;
+          precision: string | null;
+          previous_avancement: Database["public"]["Enums"]["avancement"] | null;
+          previous_avancement_detaille: number[] | null;
+          previous_concerne: boolean | null;
+          previous_justification: string | null;
+          previous_modified_at: string | null;
+          previous_modified_by_id: string | null;
+          previous_precision: string | null;
+          previous_reponse: Json | null;
+          question_formulation: string | null;
+          question_id: string | null;
+          question_type: Database["public"]["Enums"]["question_type"] | null;
+          reponse: Json | null;
+          tache_identifiant: string | null;
+          tache_nom: string | null;
+          thematique_id: string | null;
+          thematique_nom: string | null;
+          type: string | null;
+        };
+      };
       historique_utilisateur: {
         Row: {
-          collectivite_id: number | null
-          modified_by_id: string | null
-          modified_by_nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          modified_by_id: string | null;
+          modified_by_nom: string | null;
+        };
+      };
       indicateur_summary: {
         Row: {
-          collectivite_id: number | null
+          collectivite_id: number | null;
           indicateur_group:
             | Database["public"]["Enums"]["indicateur_group"]
-            | null
-          indicateur_id: string | null
-          resultats: number | null
-        }
-      }
+            | null;
+          indicateur_id: string | null;
+          resultats: number | null;
+        };
+      };
       indicateurs_collectivite: {
         Row: {
-          collectivite_id: number | null
-          description: string | null
-          indicateur_id: string | null
-          indicateur_personnalise_id: number | null
-          nom: string | null
-          unite: string | null
-        }
-      }
+          collectivite_id: number | null;
+          description: string | null;
+          indicateur_id: string | null;
+          indicateur_personnalise_id: number | null;
+          nom: string | null;
+          unite: string | null;
+        };
+      };
       mes_collectivites: {
         Row: {
-          collectivite_id: number | null
-          est_auditeur: boolean | null
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          est_auditeur: boolean | null;
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null;
+          nom: string | null;
+        };
+      };
       named_collectivite: {
         Row: {
-          collectivite_id: number | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          nom: string | null;
+        };
+      };
       ongoing_maintenance: {
         Row: {
-          begins_at: string | null
-          ends_at: string | null
-          now: string | null
-        }
-      }
+          begins_at: string | null;
+          ends_at: string | null;
+          now: string | null;
+        };
+      };
       pg_all_foreign_keys: {
         Row: {
-          fk_columns: unknown[] | null
-          fk_constraint_name: unknown | null
-          fk_schema_name: unknown | null
-          fk_table_name: unknown | null
-          fk_table_oid: unknown | null
-          is_deferrable: boolean | null
-          is_deferred: boolean | null
-          match_type: string | null
-          on_delete: string | null
-          on_update: string | null
-          pk_columns: unknown[] | null
-          pk_constraint_name: unknown | null
-          pk_index_name: unknown | null
-          pk_schema_name: unknown | null
-          pk_table_name: unknown | null
-          pk_table_oid: unknown | null
-        }
-      }
+          fk_columns: unknown[] | null;
+          fk_constraint_name: unknown | null;
+          fk_schema_name: unknown | null;
+          fk_table_name: unknown | null;
+          fk_table_oid: unknown | null;
+          is_deferrable: boolean | null;
+          is_deferred: boolean | null;
+          match_type: string | null;
+          on_delete: string | null;
+          on_update: string | null;
+          pk_columns: unknown[] | null;
+          pk_constraint_name: unknown | null;
+          pk_index_name: unknown | null;
+          pk_schema_name: unknown | null;
+          pk_table_name: unknown | null;
+          pk_table_oid: unknown | null;
+        };
+      };
       plan_action: {
         Row: {
-          collectivite_id: number | null
-          id: number | null
-          plan: Json | null
-        }
+          collectivite_id: number | null;
+          id: number | null;
+          plan: Json | null;
+        };
         Insert: {
-          collectivite_id?: number | null
-          id?: number | null
-          plan?: never
-        }
+          collectivite_id?: number | null;
+          id?: number | null;
+          plan?: never;
+        };
         Update: {
-          collectivite_id?: number | null
-          id?: number | null
-          plan?: never
-        }
-      }
+          collectivite_id?: number | null;
+          id?: number | null;
+          plan?: never;
+        };
+      };
       plan_action_chemin: {
         Row: {
-          axe_id: number | null
-          chemin: unknown[] | null
-          collectivite_id: number | null
-          plan_id: number | null
-        }
-      }
+          axe_id: number | null;
+          chemin: unknown[] | null;
+          collectivite_id: number | null;
+          plan_id: number | null;
+        };
+      };
       plan_action_profondeur: {
         Row: {
-          collectivite_id: number | null
-          id: number | null
-          plan: Json | null
-        }
+          collectivite_id: number | null;
+          id: number | null;
+          plan: Json | null;
+        };
         Insert: {
-          collectivite_id?: number | null
-          id?: number | null
-          plan?: never
-        }
+          collectivite_id?: number | null;
+          id?: number | null;
+          plan?: never;
+        };
         Update: {
-          collectivite_id?: number | null
-          id?: number | null
-          plan?: never
-        }
-      }
+          collectivite_id?: number | null;
+          id?: number | null;
+          plan?: never;
+        };
+      };
       preuve: {
         Row: {
-          action: Json | null
-          audit: Json | null
-          collectivite_id: number | null
-          commentaire: string | null
-          created_at: string | null
-          created_by: string | null
-          created_by_nom: string | null
-          demande: Json | null
-          fichier: Json | null
-          id: number | null
-          lien: Json | null
-          preuve_reglementaire: Json | null
-          preuve_type: Database["public"]["Enums"]["preuve_type"] | null
-          rapport: Json | null
-        }
-      }
+          action: Json | null;
+          audit: Json | null;
+          collectivite_id: number | null;
+          commentaire: string | null;
+          created_at: string | null;
+          created_by: string | null;
+          created_by_nom: string | null;
+          demande: Json | null;
+          fichier: Json | null;
+          id: number | null;
+          lien: Json | null;
+          preuve_reglementaire: Json | null;
+          preuve_type: Database["public"]["Enums"]["preuve_type"] | null;
+          rapport: Json | null;
+        };
+      };
       question_display: {
         Row: {
-          action_ids: unknown[] | null
-          choix: Json[] | null
-          collectivite_id: number | null
-          description: string | null
-          formulation: string | null
-          id: string | null
-          localisation: string[] | null
-          ordonnancement: number | null
-          population: string[] | null
-          thematique_id: string | null
-          thematique_nom: string | null
-          type: Database["public"]["Enums"]["question_type"] | null
+          action_ids: unknown[] | null;
+          choix: Json[] | null;
+          collectivite_id: number | null;
+          description: string | null;
+          formulation: string | null;
+          id: string | null;
+          localisation: string[] | null;
+          ordonnancement: number | null;
+          population: string[] | null;
+          thematique_id: string | null;
+          thematique_nom: string | null;
+          type: Database["public"]["Enums"]["question_type"] | null;
           types_collectivites_concernees:
             | Database["public"]["Enums"]["type_collectivite"][]
-            | null
-        }
-      }
+            | null;
+        };
+      };
       question_engine: {
         Row: {
-          choix_ids: unknown[] | null
-          id: string | null
-          type: Database["public"]["Enums"]["question_type"] | null
-        }
-      }
+          choix_ids: unknown[] | null;
+          id: string | null;
+          type: Database["public"]["Enums"]["question_type"] | null;
+        };
+      };
       question_thematique_completude: {
         Row: {
-          collectivite_id: number | null
+          collectivite_id: number | null;
           completude:
             | Database["public"]["Enums"]["thematique_completude"]
-            | null
-          id: string | null
-          nom: string | null
-          referentiels: Database["public"]["Enums"]["referentiel"][] | null
-        }
-      }
+            | null;
+          id: string | null;
+          nom: string | null;
+          referentiels: Database["public"]["Enums"]["referentiel"][] | null;
+        };
+      };
       question_thematique_display: {
         Row: {
-          id: string | null
-          nom: string | null
-          referentiels: Database["public"]["Enums"]["referentiel"][] | null
-        }
-      }
+          id: string | null;
+          nom: string | null;
+          referentiels: Database["public"]["Enums"]["referentiel"][] | null;
+        };
+      };
       region: {
         Row: {
-          code: string | null
-          libelle: string | null
-        }
+          code: string | null;
+          libelle: string | null;
+        };
         Insert: {
-          code?: string | null
-          libelle?: string | null
-        }
+          code?: string | null;
+          libelle?: string | null;
+        };
         Update: {
-          code?: string | null
-          libelle?: string | null
-        }
-      }
+          code?: string | null;
+          libelle?: string | null;
+        };
+      };
       reponse_display: {
         Row: {
-          collectivite_id: number | null
-          justification: string | null
-          question_id: string | null
-          reponse: Json | null
-        }
-      }
+          collectivite_id: number | null;
+          justification: string | null;
+          question_id: string | null;
+          reponse: Json | null;
+        };
+      };
       retool_active_collectivite: {
         Row: {
-          collectivite_id: number | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          nom: string | null;
+        };
+      };
       retool_audit: {
         Row: {
-          collectivite_id: number | null
-          date_attribution: string | null
-          date_debut: string | null
-          date_fin: string | null
-          envoyee_le: string | null
-          nom: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          type_audit: string | null
-        }
-      }
+          collectivite_id: number | null;
+          date_attribution: string | null;
+          date_debut: string | null;
+          date_fin: string | null;
+          envoyee_le: string | null;
+          nom: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          type_audit: string | null;
+        };
+      };
       retool_completude: {
         Row: {
-          code_siren_insee: string | null
-          collectivite_id: number | null
-          completude_cae: number | null
-          completude_eci: number | null
-          departement_name: string | null
-          nom: string | null
-          population_totale: number | null
-          region_name: string | null
+          code_siren_insee: string | null;
+          collectivite_id: number | null;
+          completude_cae: number | null;
+          completude_eci: number | null;
+          departement_name: string | null;
+          nom: string | null;
+          population_totale: number | null;
+          region_name: string | null;
           type_collectivite:
             | Database["public"]["Enums"]["type_collectivite"]
-            | null
-        }
-      }
+            | null;
+        };
+      };
       retool_completude_compute: {
         Row: {
-          collectivite_id: number | null
-          completude_cae: number | null
-          completude_eci: number | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          completude_cae: number | null;
+          completude_eci: number | null;
+          nom: string | null;
+        };
+      };
       retool_labellisation: {
         Row: {
-          annee: number | null
-          collectivite_id: number | null
-          collectivite_nom: string | null
-          etoiles: number | null
-          id: number | null
-          obtenue_le: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          score_programme: number | null
-          score_realise: number | null
-        }
-      }
+          annee: number | null;
+          collectivite_id: number | null;
+          collectivite_nom: string | null;
+          etoiles: number | null;
+          id: number | null;
+          obtenue_le: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          score_programme: number | null;
+          score_realise: number | null;
+        };
+      };
       retool_labellisation_demande: {
         Row: {
-          collectivite_id: number | null
-          date: string | null
-          demandeur_email: string | null
+          collectivite_id: number | null;
+          date: string | null;
+          demandeur_email: string | null;
           demandeur_fonction:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
-          demandeur_nom: string | null
-          demandeur_prenom: string | null
-          en_cours: boolean | null
-          envoyee_le: string | null
-          etoiles: Database["labellisation"]["Enums"]["etoile"] | null
-          id: number | null
-          modified_at: string | null
-          nom: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"] | null
-        }
-      }
+            | null;
+          demandeur_nom: string | null;
+          demandeur_prenom: string | null;
+          en_cours: boolean | null;
+          envoyee_le: string | null;
+          etoiles: Database["labellisation"]["Enums"]["etoile"] | null;
+          id: number | null;
+          modified_at: string | null;
+          nom: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"] | null;
+        };
+      };
       retool_plan_action_hebdo: {
         Row: {
-          collectivite_id: number | null
-          contributeurs: string[] | null
-          date_range: string | null
-          day: string | null
-          nb_fiches: number | null
-          nb_plans: number | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          contributeurs: string[] | null;
+          date_range: string | null;
+          day: string | null;
+          nb_fiches: number | null;
+          nb_plans: number | null;
+          nom: string | null;
+        };
+      };
       retool_plan_action_premier_usage: {
         Row: {
-          collectivite_id: number | null
-          created_at: string | null
-          email: string | null
-          fiche: boolean | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          created_at: string | null;
+          email: string | null;
+          fiche: boolean | null;
+          nom: string | null;
+        };
+      };
       retool_plan_action_usage: {
         Row: {
-          collectivite_id: number | null
-          derniere_modif: string | null
-          nb_fiches: number | null
-          nb_plans: number | null
-          nb_utilisateurs: string | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          derniere_modif: string | null;
+          nb_fiches: number | null;
+          nb_plans: number | null;
+          nb_utilisateurs: string | null;
+          nom: string | null;
+        };
+      };
       retool_preuves: {
         Row: {
-          action: string | null
-          collectivite_id: number | null
-          created_at: string | null
-          fichier: string | null
-          lien: string | null
-          nom: string | null
-          preuve_type: Database["public"]["Enums"]["preuve_type"] | null
-          referentiel: string | null
-        }
-      }
+          action: string | null;
+          collectivite_id: number | null;
+          created_at: string | null;
+          fichier: string | null;
+          lien: string | null;
+          nom: string | null;
+          preuve_type: Database["public"]["Enums"]["preuve_type"] | null;
+          referentiel: string | null;
+        };
+      };
       retool_score: {
         Row: {
-          Avancement: string | null
-          Collectivité: string | null
-          collectivite_id: number | null
-          Commentaire: string | null
-          "Commentaires fusionnés": string | null
-          Identifiant: string | null
-          "Modifié le": string | null
-          "Points potentiels": number | null
-          "Points programmés": number | null
-          "Points realisés": number | null
-          "Pourcentage non renseigné": number | null
-          "Pourcentage programmé": number | null
-          "Pourcentage réalisé": number | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          Titre: string | null
-        }
-      }
+          Avancement: string | null;
+          Collectivité: string | null;
+          collectivite_id: number | null;
+          Commentaire: string | null;
+          "Commentaires fusionnés": string | null;
+          Identifiant: string | null;
+          "Modifié le": string | null;
+          "Points potentiels": number | null;
+          "Points programmés": number | null;
+          "Points realisés": number | null;
+          "Pourcentage non renseigné": number | null;
+          "Pourcentage programmé": number | null;
+          "Pourcentage réalisé": number | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          Titre: string | null;
+        };
+      };
       retool_stats_usages: {
         Row: {
           admin_champs_intervention_1:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_10:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_2:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_3:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_4:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_5:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_6:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_7:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_8:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
+            | null;
           admin_champs_intervention_9:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
-          admin_derniere_connexion_1: string | null
-          admin_derniere_connexion_10: string | null
-          admin_derniere_connexion_2: string | null
-          admin_derniere_connexion_3: string | null
-          admin_derniere_connexion_4: string | null
-          admin_derniere_connexion_5: string | null
-          admin_derniere_connexion_6: string | null
-          admin_derniere_connexion_7: string | null
-          admin_derniere_connexion_8: string | null
-          admin_derniere_connexion_9: string | null
-          admin_detail_fonction_1: string | null
-          admin_detail_fonction_10: string | null
-          admin_detail_fonction_2: string | null
-          admin_detail_fonction_3: string | null
-          admin_detail_fonction_4: string | null
-          admin_detail_fonction_5: string | null
-          admin_detail_fonction_6: string | null
-          admin_detail_fonction_7: string | null
-          admin_detail_fonction_8: string | null
-          admin_detail_fonction_9: string | null
-          admin_email_1: string | null
-          admin_email_10: string | null
-          admin_email_2: string | null
-          admin_email_3: string | null
-          admin_email_4: string | null
-          admin_email_5: string | null
-          admin_email_6: string | null
-          admin_email_7: string | null
-          admin_email_8: string | null
-          admin_email_9: string | null
+            | null;
+          admin_derniere_connexion_1: string | null;
+          admin_derniere_connexion_10: string | null;
+          admin_derniere_connexion_2: string | null;
+          admin_derniere_connexion_3: string | null;
+          admin_derniere_connexion_4: string | null;
+          admin_derniere_connexion_5: string | null;
+          admin_derniere_connexion_6: string | null;
+          admin_derniere_connexion_7: string | null;
+          admin_derniere_connexion_8: string | null;
+          admin_derniere_connexion_9: string | null;
+          admin_detail_fonction_1: string | null;
+          admin_detail_fonction_10: string | null;
+          admin_detail_fonction_2: string | null;
+          admin_detail_fonction_3: string | null;
+          admin_detail_fonction_4: string | null;
+          admin_detail_fonction_5: string | null;
+          admin_detail_fonction_6: string | null;
+          admin_detail_fonction_7: string | null;
+          admin_detail_fonction_8: string | null;
+          admin_detail_fonction_9: string | null;
+          admin_email_1: string | null;
+          admin_email_10: string | null;
+          admin_email_2: string | null;
+          admin_email_3: string | null;
+          admin_email_4: string | null;
+          admin_email_5: string | null;
+          admin_email_6: string | null;
+          admin_email_7: string | null;
+          admin_email_8: string | null;
+          admin_email_9: string | null;
           admin_fonction_1:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_10:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_2:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_3:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_4:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_5:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_6:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_7:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_8:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
+            | null;
           admin_fonction_9:
             | Database["public"]["Enums"]["membre_fonction"]
-            | null
-          admin_nom_1: string | null
-          admin_nom_10: string | null
-          admin_nom_2: string | null
-          admin_nom_3: string | null
-          admin_nom_4: string | null
-          admin_nom_5: string | null
-          admin_nom_6: string | null
-          admin_nom_7: string | null
-          admin_nom_8: string | null
-          admin_nom_9: string | null
-          admin_prenom_1: string | null
-          admin_prenom_10: string | null
-          admin_prenom_2: string | null
-          admin_prenom_3: string | null
-          admin_prenom_4: string | null
-          admin_prenom_5: string | null
-          admin_prenom_6: string | null
-          admin_prenom_7: string | null
-          admin_prenom_8: string | null
-          admin_prenom_9: string | null
-          admin_telephone_1: string | null
-          admin_telephone_10: string | null
-          admin_telephone_2: string | null
-          admin_telephone_3: string | null
-          admin_telephone_4: string | null
-          admin_telephone_5: string | null
-          admin_telephone_6: string | null
-          admin_telephone_7: string | null
-          admin_telephone_8: string | null
-          admin_telephone_9: string | null
-          code_siren_insee: string | null
-          collectivite_id: number | null
-          completude_cae: number | null
-          completude_eci: number | null
-          cot: boolean | null
-          date_activation: string | null
-          departement_code: string | null
-          departement_name: string | null
-          nature_collectivite: Database["public"]["Enums"]["nature"] | null
-          nb_admin: number | null
-          nb_ecriture: number | null
-          nb_fiches: number | null
-          nb_indicateurs: number | null
-          nb_indicateurs_cae: number | null
-          nb_indicateurs_eci: number | null
-          nb_indicateurs_personnalises: number | null
-          nb_lecture: number | null
-          nb_plans: number | null
-          nb_users_actifs: number | null
-          nb_valeurs_indicateurs: number | null
-          niveau_label_cae: number | null
-          niveau_label_eci: number | null
-          nom: string | null
-          population_totale: number | null
-          programme_courant_cae: number | null
-          programme_courant_eci: number | null
-          programme_label_cae: number | null
-          programme_label_eci: number | null
-          realise_courant_cae: number | null
-          realise_courant_eci: number | null
-          realise_label_cae: number | null
-          realise_label_eci: number | null
-          region_code: string | null
-          region_name: string | null
+            | null;
+          admin_nom_1: string | null;
+          admin_nom_10: string | null;
+          admin_nom_2: string | null;
+          admin_nom_3: string | null;
+          admin_nom_4: string | null;
+          admin_nom_5: string | null;
+          admin_nom_6: string | null;
+          admin_nom_7: string | null;
+          admin_nom_8: string | null;
+          admin_nom_9: string | null;
+          admin_prenom_1: string | null;
+          admin_prenom_10: string | null;
+          admin_prenom_2: string | null;
+          admin_prenom_3: string | null;
+          admin_prenom_4: string | null;
+          admin_prenom_5: string | null;
+          admin_prenom_6: string | null;
+          admin_prenom_7: string | null;
+          admin_prenom_8: string | null;
+          admin_prenom_9: string | null;
+          admin_telephone_1: string | null;
+          admin_telephone_10: string | null;
+          admin_telephone_2: string | null;
+          admin_telephone_3: string | null;
+          admin_telephone_4: string | null;
+          admin_telephone_5: string | null;
+          admin_telephone_6: string | null;
+          admin_telephone_7: string | null;
+          admin_telephone_8: string | null;
+          admin_telephone_9: string | null;
+          code_siren_insee: string | null;
+          collectivite_id: number | null;
+          completude_cae: number | null;
+          completude_eci: number | null;
+          cot: boolean | null;
+          date_activation: string | null;
+          departement_code: string | null;
+          departement_name: string | null;
+          nature_collectivite: Database["public"]["Enums"]["nature"] | null;
+          nb_admin: number | null;
+          nb_ecriture: number | null;
+          nb_fiches: number | null;
+          nb_indicateurs: number | null;
+          nb_indicateurs_cae: number | null;
+          nb_indicateurs_eci: number | null;
+          nb_indicateurs_personnalises: number | null;
+          nb_lecture: number | null;
+          nb_plans: number | null;
+          nb_users_actifs: number | null;
+          nb_valeurs_indicateurs: number | null;
+          niveau_label_cae: number | null;
+          niveau_label_eci: number | null;
+          nom: string | null;
+          population_totale: number | null;
+          programme_courant_cae: number | null;
+          programme_courant_eci: number | null;
+          programme_label_cae: number | null;
+          programme_label_eci: number | null;
+          realise_courant_cae: number | null;
+          realise_courant_eci: number | null;
+          realise_label_cae: number | null;
+          realise_label_eci: number | null;
+          region_code: string | null;
+          region_name: string | null;
           type_collectivite:
             | Database["public"]["Enums"]["filterable_type_collectivite"]
-            | null
-        }
-      }
+            | null;
+        };
+      };
       retool_user_collectivites_list: {
         Row: {
-          collectivites: string[] | null
-          creation: string | null
-          derniere_connexion: string | null
-          email: string | null
-          nb_collectivite: number | null
-          nom: string | null
-          prenom: string | null
-        }
-      }
+          collectivites: string[] | null;
+          creation: string | null;
+          derniere_connexion: string | null;
+          email: string | null;
+          nb_collectivite: number | null;
+          nom: string | null;
+          prenom: string | null;
+        };
+      };
       retool_user_list: {
         Row: {
-          active: boolean | null
+          active: boolean | null;
           champ_intervention:
             | Database["public"]["Enums"]["referentiel"][]
-            | null
-          collectivite: string | null
-          collectivite_id: number | null
-          details_fonction: string | null
-          droit_id: number | null
-          email: string | null
-          fonction: Database["public"]["Enums"]["membre_fonction"] | null
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null
-          nom: string | null
-          prenom: string | null
-          telephone: string | null
-          user_id: string | null
-        }
-      }
+            | null;
+          collectivite: string | null;
+          collectivite_id: number | null;
+          details_fonction: string | null;
+          droit_id: number | null;
+          email: string | null;
+          fonction: Database["public"]["Enums"]["membre_fonction"] | null;
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"] | null;
+          nom: string | null;
+          prenom: string | null;
+          telephone: string | null;
+          user_id: string | null;
+        };
+      };
       stats_active_real_collectivites: {
         Row: {
-          collectivite_id: number | null
-          nom: string | null
-        }
-      }
+          collectivite_id: number | null;
+          nom: string | null;
+        };
+      };
       stats_carte_collectivite_active: {
         Row: {
-          code_siren_insee: string | null
-          collectivite_id: number | null
-          departement_code: string | null
-          departement_name: string | null
-          geojson: Json | null
-          nature_collectivite: string | null
-          nom: string | null
-          population_totale: number | null
-          region_code: string | null
-          region_name: string | null
+          code_siren_insee: string | null;
+          collectivite_id: number | null;
+          departement_code: string | null;
+          departement_name: string | null;
+          geojson: Json | null;
+          nature_collectivite: string | null;
+          nom: string | null;
+          population_totale: number | null;
+          region_code: string | null;
+          region_name: string | null;
           type_collectivite:
             | Database["public"]["Enums"]["type_collectivite"]
-            | null
-        }
-      }
+            | null;
+        };
+      };
       stats_carte_epci_par_departement: {
         Row: {
-          actives: number | null
-          geojson: Json | null
-          insee: string | null
-          libelle: string | null
-          total: number | null
-        }
-      }
+          actives: number | null;
+          geojson: Json | null;
+          insee: string | null;
+          libelle: string | null;
+          total: number | null;
+        };
+      };
       stats_collectivite_actives_et_total_par_type: {
         Row: {
-          actives: number | null
-          total: number | null
-          type_collectivite: string | null
-        }
-      }
+          actives: number | null;
+          total: number | null;
+          type_collectivite: string | null;
+        };
+      };
       stats_evolution_collectivite_avec_minimum_fiches: {
         Row: {
-          collectivites: number | null
-          mois: string | null
-        }
-      }
+          collectivites: number | null;
+          mois: string | null;
+        };
+      };
       stats_evolution_indicateur_referentiel: {
         Row: {
-          indicateurs: number | null
-          mois: string | null
-        }
-      }
+          indicateurs: number | null;
+          mois: string | null;
+        };
+      };
       stats_evolution_nombre_fiches: {
         Row: {
-          fiches: number | null
-          mois: string | null
-        }
-      }
+          fiches: number | null;
+          mois: string | null;
+        };
+      };
       stats_evolution_nombre_utilisateur_par_collectivite: {
         Row: {
-          maximum: number | null
-          median: number | null
-          mois: string | null
-          moyen: number | null
-        }
-      }
+          maximum: number | null;
+          median: number | null;
+          mois: string | null;
+          moyen: number | null;
+        };
+      };
       stats_evolution_resultat_indicateur_personnalise: {
         Row: {
-          mois: string | null
-          resultats: number | null
-        }
-      }
+          mois: string | null;
+          resultats: number | null;
+        };
+      };
       stats_evolution_resultat_indicateur_referentiel: {
         Row: {
-          mois: string | null
-          resultats: number | null
-        }
-      }
+          mois: string | null;
+          resultats: number | null;
+        };
+      };
       stats_evolution_total_activation_par_type: {
         Row: {
-          mois: string | null
-          total: number | null
-          total_commune: number | null
-          total_epci: number | null
-          total_syndicat: number | null
-        }
-      }
+          mois: string | null;
+          total: number | null;
+          total_commune: number | null;
+          total_epci: number | null;
+          total_syndicat: number | null;
+        };
+      };
       stats_evolution_utilisateur: {
         Row: {
-          mois: string | null
-          total_utilisateurs: number | null
-          utilisateurs: number | null
-        }
-      }
+          mois: string | null;
+          total_utilisateurs: number | null;
+          utilisateurs: number | null;
+        };
+      };
       stats_labellisation_par_niveau: {
         Row: {
-          etoiles: number | null
-          labellisations: number | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-        }
-      }
+          etoiles: number | null;
+          labellisations: number | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+        };
+      };
       stats_locales_collectivite_actives_et_total_par_type: {
         Row: {
-          actives: number | null
-          code_departement: string | null
-          code_region: string | null
-          total: number | null
-          typologie: string | null
-        }
-      }
+          actives: number | null;
+          code_departement: string | null;
+          code_region: string | null;
+          total: number | null;
+          typologie: string | null;
+        };
+      };
       stats_locales_engagement_collectivite: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          collectivite_id: number | null
-          cot: boolean | null
-          etoiles_cae: number | null
-          etoiles_eci: number | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          collectivite_id: number | null;
+          cot: boolean | null;
+          etoiles_cae: number | null;
+          etoiles_eci: number | null;
+        };
+      };
       stats_locales_evolution_collectivite_avec_indicateur: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          collectivites: number | null
-          mois: string | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          collectivites: number | null;
+          mois: string | null;
+        };
+      };
       stats_locales_evolution_collectivite_avec_minimum_fiches: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          collectivites: number | null
-          mois: string | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          collectivites: number | null;
+          mois: string | null;
+        };
+      };
       stats_locales_evolution_indicateur_referentiel: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          indicateurs: number | null
-          mois: string | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          indicateurs: number | null;
+          mois: string | null;
+        };
+      };
       stats_locales_evolution_nombre_fiches: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          fiches: number | null
-          mois: string | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          fiches: number | null;
+          mois: string | null;
+        };
+      };
       stats_locales_evolution_nombre_utilisateur_par_collectivite: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          maximum: number | null
-          median: number | null
-          mois: string | null
-          moyen: number | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          maximum: number | null;
+          median: number | null;
+          mois: string | null;
+          moyen: number | null;
+        };
+      };
       stats_locales_evolution_resultat_indicateur_personnalise: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          indicateurs: number | null
-          mois: string | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          indicateurs: number | null;
+          mois: string | null;
+        };
+      };
       stats_locales_evolution_resultat_indicateur_referentiel: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          indicateurs: number | null
-          mois: string | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          indicateurs: number | null;
+          mois: string | null;
+        };
+      };
       stats_locales_evolution_total_activation: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          mois: string | null
-          total: number | null
-          total_commune: number | null
-          total_epci: number | null
-          total_syndicat: number | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          mois: string | null;
+          total: number | null;
+          total_commune: number | null;
+          total_epci: number | null;
+          total_syndicat: number | null;
+        };
+      };
       stats_locales_evolution_utilisateur: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          mois: string | null
-          total_utilisateurs: number | null
-          utilisateurs: number | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          mois: string | null;
+          total_utilisateurs: number | null;
+          utilisateurs: number | null;
+        };
+      };
       stats_locales_labellisation_par_niveau: {
         Row: {
-          code_departement: string | null
-          code_region: string | null
-          etoiles: number | null
-          labellisations: number | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-        }
-      }
+          code_departement: string | null;
+          code_region: string | null;
+          etoiles: number | null;
+          labellisations: number | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+        };
+      };
       stats_locales_tranche_completude: {
         Row: {
-          cae: number | null
-          code_departement: string | null
-          code_region: string | null
-          eci: number | null
-          lower_bound: number | null
-          upper_bound: number | null
-        }
-      }
+          cae: number | null;
+          code_departement: string | null;
+          code_region: string | null;
+          eci: number | null;
+          lower_bound: number | null;
+          upper_bound: number | null;
+        };
+      };
       suivi_audit: {
         Row: {
-          action_id: string | null
-          avis: string | null
-          collectivite_id: number | null
-          have_children: boolean | null
-          ordre_du_jour: boolean | null
-          ordres_du_jour: boolean[] | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          statut: Database["public"]["Enums"]["audit_statut"] | null
-          statuts: Database["public"]["Enums"]["audit_statut"][] | null
-          type: Database["public"]["Enums"]["action_type"] | null
-        }
-      }
+          action_id: string | null;
+          avis: string | null;
+          collectivite_id: number | null;
+          have_children: boolean | null;
+          ordre_du_jour: boolean | null;
+          ordres_du_jour: boolean[] | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          statut: Database["public"]["Enums"]["audit_statut"] | null;
+          statuts: Database["public"]["Enums"]["audit_statut"][] | null;
+          type: Database["public"]["Enums"]["action_type"] | null;
+        };
+      };
       tap_funky: {
         Row: {
-          args: string | null
-          is_definer: boolean | null
-          is_strict: boolean | null
-          is_visible: boolean | null
-          kind: unknown | null
-          langoid: unknown | null
-          name: unknown | null
-          oid: unknown | null
-          owner: unknown | null
-          returns: string | null
-          returns_set: boolean | null
-          schema: unknown | null
-          volatility: string | null
-        }
-      }
-    }
+          args: string | null;
+          is_definer: boolean | null;
+          is_strict: boolean | null;
+          is_visible: boolean | null;
+          kind: unknown | null;
+          langoid: unknown | null;
+          name: unknown | null;
+          oid: unknown | null;
+          owner: unknown | null;
+          returns: string | null;
+          returns_set: boolean | null;
+          schema: unknown | null;
+          volatility: string | null;
+        };
+      };
+    };
     Functions: {
       _cleanup: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
       _contract_on: {
         Args: {
-          "": string
-        }
-        Returns: unknown
-      }
+          "": string;
+        };
+        Returns: unknown;
+      };
       _currtest: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       _db_privs: {
-        Args: Record<PropertyKey, never>
-        Returns: unknown[]
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: unknown[];
+      };
       _definer: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _dexists: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _expand_context: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       _expand_on: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       _expand_vol: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       _ext_exists: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _extensions:
         | {
             Args: {
-              "": unknown
-            }
-            Returns: unknown[]
+              "": unknown;
+            };
+            Returns: unknown[];
           }
         | {
-            Args: Record<PropertyKey, never>
-            Returns: unknown[]
-          }
+            Args: Record<PropertyKey, never>;
+            Returns: unknown[];
+          };
       _funkargs: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       _get: {
         Args: {
-          "": string
-        }
-        Returns: number
-      }
+          "": string;
+        };
+        Returns: number;
+      };
       _get_db_owner: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       _get_dtype: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       _get_language_owner: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       _get_latest: {
         Args: {
-          "": string
-        }
-        Returns: number[]
-      }
+          "": string;
+        };
+        Returns: number[];
+      };
       _get_note:
         | {
             Args: {
-              "": string
-            }
-            Returns: string
+              "": string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              "": number
-            }
-            Returns: string
-          }
+              "": number;
+            };
+            Returns: string;
+          };
       _get_opclass_owner: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       _get_rel_owner: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       _get_schema_owner: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       _get_tablespace_owner: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       _get_type_owner: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       _got_func: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _grolist: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown[]
-      }
+          "": unknown;
+        };
+        Returns: unknown[];
+      };
       _has_group: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _has_role: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _has_user: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _inherited: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _is_schema: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _is_super: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _is_trusted: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _is_verbose: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
       _lang: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       _opc_exists: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _parts: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown[]
-      }
+          "": unknown;
+        };
+        Returns: unknown[];
+      };
       _pg_sv_type_array: {
         Args: {
-          "": unknown[]
-        }
-        Returns: unknown[]
-      }
+          "": unknown[];
+        };
+        Returns: unknown[];
+      };
       _prokind: {
         Args: {
-          p_oid: unknown
-        }
-        Returns: unknown
-      }
+          p_oid: unknown;
+        };
+        Returns: unknown;
+      };
       _query: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       _refine_vol: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       _relexists: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _returns: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       _strict: {
         Args: {
-          "": unknown
-        }
-        Returns: boolean
-      }
+          "": unknown;
+        };
+        Returns: boolean;
+      };
       _table_privs: {
-        Args: Record<PropertyKey, never>
-        Returns: unknown[]
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: unknown[];
+      };
       _temptypes: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       _todo: {
-        Args: Record<PropertyKey, never>
-        Returns: string
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: string;
+      };
       _vol: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       accepter_cgu: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          cgu_acceptees_le: string | null
-          created_at: string
-          deleted: boolean
-          email: string
-          limited: boolean
-          modified_at: string
-          nom: string
-          prenom: string
-          telephone: string | null
-          user_id: string
-        }
-      }
+          cgu_acceptees_le: string | null;
+          created_at: string;
+          deleted: boolean;
+          email: string;
+          limited: boolean;
+          modified_at: string;
+          nom: string;
+          prenom: string;
+          telephone: string | null;
+          user_id: string;
+        };
+      };
       action_contexte: {
         Args: {
-          id: unknown
-        }
-        Returns: Record<string, unknown>
-      }
+          id: unknown;
+        };
+        Returns: Record<string, unknown>;
+      };
       action_down_to_tache: {
         Args: {
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          identifiant: string
-        }
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          identifiant: string;
+        };
         Returns: {
-          children: unknown[] | null
-          depth: number | null
-          description: string | null
-          have_contexte: boolean | null
-          have_exemples: boolean | null
-          have_perimetre_evaluation: boolean | null
-          have_preuve: boolean | null
-          have_questions: boolean | null
-          have_reduction_potentiel: boolean | null
-          have_ressources: boolean | null
-          id: string | null
-          identifiant: string | null
-          nom: string | null
-          phase: Database["public"]["Enums"]["action_categorie"] | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          type: Database["public"]["Enums"]["action_type"] | null
-        }[]
-      }
+          children: unknown[] | null;
+          depth: number | null;
+          description: string | null;
+          have_contexte: boolean | null;
+          have_exemples: boolean | null;
+          have_perimetre_evaluation: boolean | null;
+          have_preuve: boolean | null;
+          have_questions: boolean | null;
+          have_reduction_potentiel: boolean | null;
+          have_ressources: boolean | null;
+          id: string | null;
+          identifiant: string | null;
+          nom: string | null;
+          phase: Database["public"]["Enums"]["action_categorie"] | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          type: Database["public"]["Enums"]["action_type"] | null;
+        }[];
+      };
       action_exemples: {
         Args: {
-          id: unknown
-        }
-        Returns: Record<string, unknown>
-      }
+          id: unknown;
+        };
+        Returns: Record<string, unknown>;
+      };
       action_perimetre_evaluation: {
         Args: {
-          id: unknown
-        }
-        Returns: Record<string, unknown>
-      }
+          id: unknown;
+        };
+        Returns: Record<string, unknown>;
+      };
       action_preuve: {
         Args: {
-          id: unknown
-        }
-        Returns: Record<string, unknown>
-      }
+          id: unknown;
+        };
+        Returns: Record<string, unknown>;
+      };
       action_reduction_potentiel: {
         Args: {
-          id: unknown
-        }
-        Returns: Record<string, unknown>
-      }
+          id: unknown;
+        };
+        Returns: Record<string, unknown>;
+      };
       action_ressources: {
         Args: {
-          id: unknown
-        }
-        Returns: Record<string, unknown>
-      }
+          id: unknown;
+        };
+        Returns: Record<string, unknown>;
+      };
       add_bibliotheque_fichier: {
         Args: {
-          collectivite_id: number
-          hash: string
-          filename: string
-        }
+          collectivite_id: number;
+          hash: string;
+          filename: string;
+        };
         Returns: {
-          bucket_id: string | null
-          collectivite_id: number | null
-          file_id: string | null
-          filename: string | null
-          filesize: number | null
-          hash: string | null
-          id: number | null
-        }
-      }
+          bucket_id: string | null;
+          collectivite_id: number | null;
+          file_id: string | null;
+          filename: string | null;
+          filesize: number | null;
+          hash: string | null;
+          id: number | null;
+        };
+      };
       add_compression_policy: {
         Args: {
-          hypertable: unknown
-          compress_after: unknown
-          if_not_exists?: boolean
-          schedule_interval?: unknown
-          initial_start?: string
-          timezone?: string
-        }
-        Returns: number
-      }
+          hypertable: unknown;
+          compress_after: unknown;
+          if_not_exists?: boolean;
+          schedule_interval?: unknown;
+          initial_start?: string;
+          timezone?: string;
+        };
+        Returns: number;
+      };
       add_continuous_aggregate_policy: {
         Args: {
-          continuous_aggregate: unknown
-          start_offset: unknown
-          end_offset: unknown
-          schedule_interval: unknown
-          if_not_exists?: boolean
-          initial_start?: string
-          timezone?: string
-        }
-        Returns: number
-      }
+          continuous_aggregate: unknown;
+          start_offset: unknown;
+          end_offset: unknown;
+          schedule_interval: unknown;
+          if_not_exists?: boolean;
+          initial_start?: string;
+          timezone?: string;
+        };
+        Returns: number;
+      };
       add_data_node: {
         Args: {
-          node_name: unknown
-          host: string
-          database?: unknown
-          port?: number
-          if_not_exists?: boolean
-          bootstrap?: boolean
-          password?: string
-        }
+          node_name: unknown;
+          host: string;
+          database?: unknown;
+          port?: number;
+          if_not_exists?: boolean;
+          bootstrap?: boolean;
+          password?: string;
+        };
         Returns: {
-          node_name: unknown
-          host: string
-          port: number
-          database: unknown
-          node_created: boolean
-          database_created: boolean
-          extension_created: boolean
-        }[]
-      }
+          node_name: unknown;
+          host: string;
+          port: number;
+          database: unknown;
+          node_created: boolean;
+          database_created: boolean;
+          extension_created: boolean;
+        }[];
+      };
       add_dimension: {
         Args: {
-          hypertable: unknown
-          column_name: unknown
-          number_partitions?: number
-          chunk_time_interval?: unknown
-          partitioning_func?: unknown
-          if_not_exists?: boolean
-        }
+          hypertable: unknown;
+          column_name: unknown;
+          number_partitions?: number;
+          chunk_time_interval?: unknown;
+          partitioning_func?: unknown;
+          if_not_exists?: boolean;
+        };
         Returns: {
-          dimension_id: number
-          schema_name: unknown
-          table_name: unknown
-          column_name: unknown
-          created: boolean
-        }[]
-      }
+          dimension_id: number;
+          schema_name: unknown;
+          table_name: unknown;
+          column_name: unknown;
+          created: boolean;
+        }[];
+      };
       add_job: {
         Args: {
-          proc: unknown
-          schedule_interval: unknown
-          config?: Json
-          initial_start?: string
-          scheduled?: boolean
-          check_config?: unknown
-          fixed_schedule?: boolean
-          timezone?: string
-        }
-        Returns: number
-      }
+          proc: unknown;
+          schedule_interval: unknown;
+          config?: Json;
+          initial_start?: string;
+          scheduled?: boolean;
+          check_config?: unknown;
+          fixed_schedule?: boolean;
+          timezone?: string;
+        };
+        Returns: number;
+      };
       add_reorder_policy: {
         Args: {
-          hypertable: unknown
-          index_name: unknown
-          if_not_exists?: boolean
-          initial_start?: string
-          timezone?: string
-        }
-        Returns: number
-      }
+          hypertable: unknown;
+          index_name: unknown;
+          if_not_exists?: boolean;
+          initial_start?: string;
+          timezone?: string;
+        };
+        Returns: number;
+      };
       add_retention_policy: {
         Args: {
-          relation: unknown
-          drop_after: unknown
-          if_not_exists?: boolean
-          schedule_interval?: unknown
-          initial_start?: string
-          timezone?: string
-        }
-        Returns: number
-      }
+          relation: unknown;
+          drop_after: unknown;
+          if_not_exists?: boolean;
+          schedule_interval?: unknown;
+          initial_start?: string;
+          timezone?: string;
+        };
+        Returns: number;
+      };
       add_user: {
         Args: {
-          collectivite_id: number
-          email: string
-          niveau: Database["public"]["Enums"]["niveau_acces"]
-        }
-        Returns: Json
-      }
+          collectivite_id: number;
+          email: string;
+          niveau: Database["public"]["Enums"]["niveau_acces"];
+        };
+        Returns: Json;
+      };
       ajouter_action: {
         Args: {
-          fiche_id: number
-          action_id: unknown
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          action_id: unknown;
+        };
+        Returns: undefined;
+      };
       ajouter_fiche_action_dans_un_axe: {
         Args: {
-          fiche_id: number
-          axe_id: number
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          axe_id: number;
+        };
+        Returns: undefined;
+      };
       ajouter_financeur: {
         Args: {
-          fiche_id: number
-          financeur: Database["public"]["CompositeTypes"]["financeur_montant"]
-        }
-        Returns: Database["public"]["CompositeTypes"]["financeur_montant"]
-      }
+          fiche_id: number;
+          financeur: Database["public"]["CompositeTypes"]["financeur_montant"];
+        };
+        Returns: Database["public"]["CompositeTypes"]["financeur_montant"];
+      };
       ajouter_indicateur: {
         Args: {
-          fiche_id: number
-          indicateur: Database["public"]["CompositeTypes"]["indicateur_generique"]
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          indicateur: Database["public"]["CompositeTypes"]["indicateur_generique"];
+        };
+        Returns: undefined;
+      };
       ajouter_partenaire: {
         Args: {
-          fiche_id: number
-          partenaire: unknown
-        }
+          fiche_id: number;
+          partenaire: unknown;
+        };
         Returns: {
-          collectivite_id: number
-          id: number
-          nom: string
-        }
-      }
+          collectivite_id: number;
+          id: number;
+          nom: string;
+        };
+      };
       ajouter_pilote: {
         Args: {
-          fiche_id: number
-          pilote: Database["public"]["CompositeTypes"]["personne"]
-        }
-        Returns: Database["public"]["CompositeTypes"]["personne"]
-      }
+          fiche_id: number;
+          pilote: Database["public"]["CompositeTypes"]["personne"];
+        };
+        Returns: Database["public"]["CompositeTypes"]["personne"];
+      };
       ajouter_referent: {
         Args: {
-          fiche_id: number
-          referent: Database["public"]["CompositeTypes"]["personne"]
-        }
-        Returns: Database["public"]["CompositeTypes"]["personne"]
-      }
+          fiche_id: number;
+          referent: Database["public"]["CompositeTypes"]["personne"];
+        };
+        Returns: Database["public"]["CompositeTypes"]["personne"];
+      };
       ajouter_service: {
         Args: {
-          fiche_id: number
-          service: unknown
-        }
+          fiche_id: number;
+          service: unknown;
+        };
         Returns: {
-          collectivite_id: number
-          id: number
-          nom: string
-        }
-      }
+          collectivite_id: number;
+          id: number;
+          nom: string;
+        };
+      };
       ajouter_sous_thematique: {
         Args: {
-          fiche_id: number
-          thematique_id: number
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          thematique_id: number;
+        };
+        Returns: undefined;
+      };
       ajouter_structure: {
         Args: {
-          fiche_id: number
-          structure: unknown
-        }
+          fiche_id: number;
+          structure: unknown;
+        };
         Returns: {
-          collectivite_id: number
-          id: number
-          nom: string
-        }
-      }
+          collectivite_id: number;
+          id: number;
+          nom: string;
+        };
+      };
       ajouter_thematique: {
         Args: {
-          fiche_id: number
-          thematique: string
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          thematique: string;
+        };
+        Returns: undefined;
+      };
       alter_data_node: {
         Args: {
-          node_name: unknown
-          host?: string
-          database?: unknown
-          port?: number
-          available?: boolean
-        }
+          node_name: unknown;
+          host?: string;
+          database?: unknown;
+          port?: number;
+          available?: boolean;
+        };
         Returns: {
-          node_name: unknown
-          host: string
-          port: number
-          database: unknown
-          available: boolean
-        }[]
-      }
+          node_name: unknown;
+          host: string;
+          port: number;
+          database: unknown;
+          available: boolean;
+        }[];
+      };
       alter_job: {
         Args: {
-          job_id: number
-          schedule_interval?: unknown
-          max_runtime?: unknown
-          max_retries?: number
-          retry_period?: unknown
-          scheduled?: boolean
-          config?: Json
-          next_start?: string
-          if_exists?: boolean
-          check_config?: unknown
-        }
+          job_id: number;
+          schedule_interval?: unknown;
+          max_runtime?: unknown;
+          max_retries?: number;
+          retry_period?: unknown;
+          scheduled?: boolean;
+          config?: Json;
+          next_start?: string;
+          if_exists?: boolean;
+          check_config?: unknown;
+        };
         Returns: {
-          job_id: number
-          schedule_interval: unknown
-          max_runtime: unknown
-          max_retries: number
-          retry_period: unknown
-          scheduled: boolean
-          config: Json
-          next_start: string
-          check_config: string
-        }[]
-      }
+          job_id: number;
+          schedule_interval: unknown;
+          max_runtime: unknown;
+          max_retries: number;
+          retry_period: unknown;
+          scheduled: boolean;
+          config: Json;
+          next_start: string;
+          check_config: string;
+        }[];
+      };
       approximate_row_count: {
         Args: {
-          relation: unknown
-        }
-        Returns: number
-      }
+          relation: unknown;
+        };
+        Returns: number;
+      };
       attach_data_node: {
         Args: {
-          node_name: unknown
-          hypertable: unknown
-          if_not_attached?: boolean
-          repartition?: boolean
-        }
+          node_name: unknown;
+          hypertable: unknown;
+          if_not_attached?: boolean;
+          repartition?: boolean;
+        };
         Returns: {
-          hypertable_id: number
-          node_hypertable_id: number
-          node_name: unknown
-        }[]
-      }
+          hypertable_id: number;
+          node_hypertable_id: number;
+          node_name: unknown;
+        }[];
+      };
       attach_tablespace: {
         Args: {
-          tablespace: unknown
-          hypertable: unknown
-          if_not_attached?: boolean
-        }
-        Returns: undefined
-      }
+          tablespace: unknown;
+          hypertable: unknown;
+          if_not_attached?: boolean;
+        };
+        Returns: undefined;
+      };
       business_insert_actions: {
         Args: {
-          relations: unknown[]
-          definitions: unknown[]
-          computed_points: unknown[]
-        }
-        Returns: undefined
-      }
+          relations: unknown[];
+          definitions: unknown[];
+          computed_points: unknown[];
+        };
+        Returns: undefined;
+      };
       business_update_actions: {
         Args: {
-          definitions: unknown[]
-          computed_points: unknown[]
-        }
-        Returns: undefined
-      }
+          definitions: unknown[];
+          computed_points: unknown[];
+        };
+        Returns: undefined;
+      };
       business_upsert_indicateurs: {
         Args: {
-          indicateur_definitions: unknown[]
-          indicateur_actions: unknown[]
-        }
-        Returns: undefined
-      }
+          indicateur_definitions: unknown[];
+          indicateur_actions: unknown[];
+        };
+        Returns: undefined;
+      };
       can: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       can_read_acces_restreint: {
         Args: {
-          collectivite_id: number
-        }
-        Returns: boolean
-      }
+          collectivite_id: number;
+        };
+        Returns: boolean;
+      };
       casts_are: {
         Args: {
-          "": string[]
-        }
-        Returns: string
-      }
+          "": string[];
+        };
+        Returns: string;
+      };
       chunk_compression_stats: {
         Args: {
-          hypertable: unknown
-        }
+          hypertable: unknown;
+        };
         Returns: {
-          chunk_schema: unknown
-          chunk_name: unknown
-          compression_status: string
-          before_compression_table_bytes: number
-          before_compression_index_bytes: number
-          before_compression_toast_bytes: number
-          before_compression_total_bytes: number
-          after_compression_table_bytes: number
-          after_compression_index_bytes: number
-          after_compression_toast_bytes: number
-          after_compression_total_bytes: number
-          node_name: unknown
-        }[]
-      }
+          chunk_schema: unknown;
+          chunk_name: unknown;
+          compression_status: string;
+          before_compression_table_bytes: number;
+          before_compression_index_bytes: number;
+          before_compression_toast_bytes: number;
+          before_compression_total_bytes: number;
+          after_compression_table_bytes: number;
+          after_compression_index_bytes: number;
+          after_compression_toast_bytes: number;
+          after_compression_total_bytes: number;
+          node_name: unknown;
+        }[];
+      };
       chunks_detailed_size: {
         Args: {
-          hypertable: unknown
-        }
+          hypertable: unknown;
+        };
         Returns: {
-          chunk_schema: unknown
-          chunk_name: unknown
-          table_bytes: number
-          index_bytes: number
-          toast_bytes: number
-          total_bytes: number
-          node_name: unknown
-        }[]
-      }
+          chunk_schema: unknown;
+          chunk_name: unknown;
+          table_bytes: number;
+          index_bytes: number;
+          toast_bytes: number;
+          total_bytes: number;
+          node_name: unknown;
+        }[];
+      };
       claim_collectivite: {
         Args: {
-          id: number
-        }
-        Returns: Json
-      }
+          id: number;
+        };
+        Returns: Json;
+      };
       col_is_null:
         | {
             Args: {
-              schema_name: unknown
-              table_name: unknown
-              column_name: unknown
-              description?: string
-            }
-            Returns: string
+              schema_name: unknown;
+              table_name: unknown;
+              column_name: unknown;
+              description?: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              table_name: unknown
-              column_name: unknown
-              description?: string
-            }
-            Returns: string
-          }
+              table_name: unknown;
+              column_name: unknown;
+              description?: string;
+            };
+            Returns: string;
+          };
       col_not_null:
         | {
             Args: {
-              schema_name: unknown
-              table_name: unknown
-              column_name: unknown
-              description?: string
-            }
-            Returns: string
+              schema_name: unknown;
+              table_name: unknown;
+              column_name: unknown;
+              description?: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              table_name: unknown
-              column_name: unknown
-              description?: string
-            }
-            Returns: string
-          }
+              table_name: unknown;
+              column_name: unknown;
+              description?: string;
+            };
+            Returns: string;
+          };
       collect_tap:
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string
+            Args: Record<PropertyKey, never>;
+            Returns: string;
           }
         | {
             Args: {
-              "": string[]
-            }
-            Returns: string
-          }
+              "": string[];
+            };
+            Returns: string;
+          };
       collectivite_membres: {
         Args: {
-          id: number
-        }
+          id: number;
+        };
         Returns: {
-          user_id: string
-          prenom: string
-          nom: string
-          email: string
-          telephone: string
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"]
-          fonction: Database["public"]["Enums"]["membre_fonction"]
-          details_fonction: string
-          champ_intervention: Database["public"]["Enums"]["referentiel"][]
-        }[]
-      }
+          user_id: string;
+          prenom: string;
+          nom: string;
+          email: string;
+          telephone: string;
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"];
+          fonction: Database["public"]["Enums"]["membre_fonction"];
+          details_fonction: string;
+          champ_intervention: Database["public"]["Enums"]["referentiel"][];
+        }[];
+      };
       compress_chunk: {
         Args: {
-          uncompressed_chunk: unknown
-          if_not_compressed?: boolean
-        }
-        Returns: unknown
-      }
+          uncompressed_chunk: unknown;
+          if_not_compressed?: boolean;
+        };
+        Returns: unknown;
+      };
       consume_invitation: {
         Args: {
-          id: string
-        }
-        Returns: undefined
-      }
+          id: string;
+        };
+        Returns: undefined;
+      };
       create_distributed_hypertable: {
         Args: {
-          relation: unknown
-          time_column_name: unknown
-          partitioning_column?: unknown
-          number_partitions?: number
-          associated_schema_name?: unknown
-          associated_table_prefix?: unknown
-          chunk_time_interval?: unknown
-          create_default_indexes?: boolean
-          if_not_exists?: boolean
-          partitioning_func?: unknown
-          migrate_data?: boolean
-          chunk_target_size?: string
-          chunk_sizing_func?: unknown
-          time_partitioning_func?: unknown
-          replication_factor?: number
-          data_nodes?: unknown[]
-        }
+          relation: unknown;
+          time_column_name: unknown;
+          partitioning_column?: unknown;
+          number_partitions?: number;
+          associated_schema_name?: unknown;
+          associated_table_prefix?: unknown;
+          chunk_time_interval?: unknown;
+          create_default_indexes?: boolean;
+          if_not_exists?: boolean;
+          partitioning_func?: unknown;
+          migrate_data?: boolean;
+          chunk_target_size?: string;
+          chunk_sizing_func?: unknown;
+          time_partitioning_func?: unknown;
+          replication_factor?: number;
+          data_nodes?: unknown[];
+        };
         Returns: {
-          hypertable_id: number
-          schema_name: unknown
-          table_name: unknown
-          created: boolean
-        }[]
-      }
+          hypertable_id: number;
+          schema_name: unknown;
+          table_name: unknown;
+          created: boolean;
+        }[];
+      };
       create_distributed_restore_point: {
         Args: {
-          name: string
-        }
+          name: string;
+        };
         Returns: {
-          node_name: unknown
-          node_type: string
-          restore_point: unknown
-        }[]
-      }
+          node_name: unknown;
+          node_type: string;
+          restore_point: unknown;
+        }[];
+      };
       create_hypertable: {
         Args: {
-          relation: unknown
-          time_column_name: unknown
-          partitioning_column?: unknown
-          number_partitions?: number
-          associated_schema_name?: unknown
-          associated_table_prefix?: unknown
-          chunk_time_interval?: unknown
-          create_default_indexes?: boolean
-          if_not_exists?: boolean
-          partitioning_func?: unknown
-          migrate_data?: boolean
-          chunk_target_size?: string
-          chunk_sizing_func?: unknown
-          time_partitioning_func?: unknown
-          replication_factor?: number
-          data_nodes?: unknown[]
-          distributed?: boolean
-        }
+          relation: unknown;
+          time_column_name: unknown;
+          partitioning_column?: unknown;
+          number_partitions?: number;
+          associated_schema_name?: unknown;
+          associated_table_prefix?: unknown;
+          chunk_time_interval?: unknown;
+          create_default_indexes?: boolean;
+          if_not_exists?: boolean;
+          partitioning_func?: unknown;
+          migrate_data?: boolean;
+          chunk_target_size?: string;
+          chunk_sizing_func?: unknown;
+          time_partitioning_func?: unknown;
+          replication_factor?: number;
+          data_nodes?: unknown[];
+          distributed?: boolean;
+        };
         Returns: {
-          hypertable_id: number
-          schema_name: unknown
-          table_name: unknown
-          created: boolean
-        }[]
-      }
+          hypertable_id: number;
+          schema_name: unknown;
+          table_name: unknown;
+          created: boolean;
+        }[];
+      };
       decompress_chunk: {
         Args: {
-          uncompressed_chunk: unknown
-          if_compressed?: boolean
-        }
-        Returns: unknown
-      }
+          uncompressed_chunk: unknown;
+          if_compressed?: boolean;
+        };
+        Returns: unknown;
+      };
       delete_axe_all: {
         Args: {
-          axe_id: number
-        }
-        Returns: undefined
-      }
+          axe_id: number;
+        };
+        Returns: undefined;
+      };
       delete_data_node: {
         Args: {
-          node_name: unknown
-          if_exists?: boolean
-          force?: boolean
-          repartition?: boolean
-          drop_database?: boolean
-        }
-        Returns: boolean
-      }
+          node_name: unknown;
+          if_exists?: boolean;
+          force?: boolean;
+          repartition?: boolean;
+          drop_database?: boolean;
+        };
+        Returns: boolean;
+      };
       delete_job: {
         Args: {
-          job_id: number
-        }
-        Returns: undefined
-      }
+          job_id: number;
+        };
+        Returns: undefined;
+      };
       detach_data_node: {
         Args: {
-          node_name: unknown
-          hypertable?: unknown
-          if_attached?: boolean
-          force?: boolean
-          repartition?: boolean
-          drop_remote_data?: boolean
-        }
-        Returns: number
-      }
+          node_name: unknown;
+          hypertable?: unknown;
+          if_attached?: boolean;
+          force?: boolean;
+          repartition?: boolean;
+          drop_remote_data?: boolean;
+        };
+        Returns: number;
+      };
       detach_tablespace: {
         Args: {
-          tablespace: unknown
-          hypertable?: unknown
-          if_attached?: boolean
-        }
-        Returns: number
-      }
+          tablespace: unknown;
+          hypertable?: unknown;
+          if_attached?: boolean;
+        };
+        Returns: number;
+      };
       detach_tablespaces: {
         Args: {
-          hypertable: unknown
-        }
-        Returns: number
-      }
+          hypertable: unknown;
+        };
+        Returns: number;
+      };
       diag:
         | {
             Args: {
-              msg: string
-            }
-            Returns: string
+              msg: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              msg: unknown
-            }
-            Returns: string
+              msg: unknown;
+            };
+            Returns: string;
           }
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string
+            Args: Record<PropertyKey, never>;
+            Returns: string;
           }
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string
-          }
+            Args: Record<PropertyKey, never>;
+            Returns: string;
+          };
       diag_test_name: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       do_tap:
         | {
             Args: {
-              "": unknown
-            }
-            Returns: string[]
+              "": unknown;
+            };
+            Returns: string[];
           }
         | {
             Args: {
-              "": string
-            }
-            Returns: string[]
+              "": string;
+            };
+            Returns: string[];
           }
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string[]
-          }
+            Args: Record<PropertyKey, never>;
+            Returns: string[];
+          };
       domains_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       drop_chunks: {
         Args: {
-          relation: unknown
-          older_than?: unknown
-          newer_than?: unknown
-          verbose?: boolean
-        }
-        Returns: string[]
-      }
+          relation: unknown;
+          older_than?: unknown;
+          newer_than?: unknown;
+          verbose?: boolean;
+        };
+        Returns: string[];
+      };
       enlever_action: {
         Args: {
-          fiche_id: number
-          action_id: unknown
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          action_id: unknown;
+        };
+        Returns: undefined;
+      };
       enlever_fiche_action_d_un_axe: {
         Args: {
-          fiche_id: number
-          axe_id: number
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          axe_id: number;
+        };
+        Returns: undefined;
+      };
       enlever_indicateur: {
         Args: {
-          fiche_id: number
-          indicateur: Database["public"]["CompositeTypes"]["indicateur_generique"]
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          indicateur: Database["public"]["CompositeTypes"]["indicateur_generique"];
+        };
+        Returns: undefined;
+      };
       enlever_partenaire: {
         Args: {
-          fiche_id: number
-          partenaire: unknown
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          partenaire: unknown;
+        };
+        Returns: undefined;
+      };
       enlever_pilote: {
         Args: {
-          fiche_id: number
-          pilote: Database["public"]["CompositeTypes"]["personne"]
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          pilote: Database["public"]["CompositeTypes"]["personne"];
+        };
+        Returns: undefined;
+      };
       enlever_referent: {
         Args: {
-          fiche_id: number
-          referent: Database["public"]["CompositeTypes"]["personne"]
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          referent: Database["public"]["CompositeTypes"]["personne"];
+        };
+        Returns: undefined;
+      };
       enlever_service: {
         Args: {
-          fiche_id: number
-          service: unknown
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          service: unknown;
+        };
+        Returns: undefined;
+      };
       enlever_sous_thematique: {
         Args: {
-          fiche_id: number
-          thematique_id: number
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          thematique_id: number;
+        };
+        Returns: undefined;
+      };
       enlever_structure: {
         Args: {
-          fiche_id: number
-          structure: unknown
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          structure: unknown;
+        };
+        Returns: undefined;
+      };
       enlever_thematique: {
         Args: {
-          fiche_id: number
-          thematique: string
-        }
-        Returns: undefined
-      }
+          fiche_id: number;
+          thematique: string;
+        };
+        Returns: undefined;
+      };
       enums_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       est_auditeur: {
         Args: {
-          collectivite: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
-        Returns: boolean
-      }
+          collectivite: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
+        Returns: boolean;
+      };
       extensions_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       fail:
         | {
             Args: {
-              "": string
-            }
-            Returns: string
+              "": string;
+            };
+            Returns: string;
           }
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string
-          }
+            Args: Record<PropertyKey, never>;
+            Returns: string;
+          };
       fiche_resume: {
         Args: {
-          "": unknown
-        }
+          "": unknown;
+        };
         Returns: {
-          collectivite_id: number | null
-          id: number | null
-          modified_at: string | null
-          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
-          plans: unknown[] | null
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          titre: string | null
-        }[]
-      }
+          collectivite_id: number | null;
+          id: number | null;
+          modified_at: string | null;
+          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null;
+          plans: unknown[] | null;
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
+          titre: string | null;
+        }[];
+      };
       filter_fiches_action: {
         Args: {
-          collectivite_id: number
-          sans_plan?: boolean
-          axes_id?: number[]
-          sans_pilote?: boolean
-          pilotes?: Database["public"]["CompositeTypes"]["personne"][]
-          sans_referent?: boolean
-          referents?: Database["public"]["CompositeTypes"]["personne"][]
-          niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][]
-          statuts?: Database["public"]["Enums"]["fiche_action_statuts"][]
-          thematiques?: unknown[]
-          sous_thematiques?: unknown[]
-          budget_min?: number
-          budget_max?: number
-          date_debut?: string
-          date_fin?: string
-          echeance?: Database["public"]["Enums"]["fiche_action_echeances"]
-          limit?: number
-        }
+          collectivite_id: number;
+          sans_plan?: boolean;
+          axes_id?: number[];
+          sans_pilote?: boolean;
+          pilotes?: Database["public"]["CompositeTypes"]["personne"][];
+          sans_referent?: boolean;
+          referents?: Database["public"]["CompositeTypes"]["personne"][];
+          niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][];
+          statuts?: Database["public"]["Enums"]["fiche_action_statuts"][];
+          thematiques?: unknown[];
+          sous_thematiques?: unknown[];
+          budget_min?: number;
+          budget_max?: number;
+          date_debut?: string;
+          date_fin?: string;
+          echeance?: Database["public"]["Enums"]["fiche_action_echeances"];
+          limit?: number;
+        };
         Returns: {
-          collectivite_id: number | null
-          id: number | null
-          modified_at: string | null
-          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
-          plans: unknown[] | null
-          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          titre: string | null
-        }[]
-      }
+          collectivite_id: number | null;
+          id: number | null;
+          modified_at: string | null;
+          pilotes: Database["public"]["CompositeTypes"]["personne"][] | null;
+          plans: unknown[] | null;
+          statut: Database["public"]["Enums"]["fiche_action_statuts"] | null;
+          titre: string | null;
+        }[];
+      };
       findfuncs: {
         Args: {
-          "": string
-        }
-        Returns: string[]
-      }
+          "": string;
+        };
+        Returns: string[];
+      };
       finish: {
         Args: {
-          exception_on_failure?: boolean
-        }
-        Returns: string[]
-      }
+          exception_on_failure?: boolean;
+        };
+        Returns: string[];
+      };
       flat_axes: {
         Args: {
-          axe_id: number
-          max_depth?: number
-        }
-        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-      }
+          axe_id: number;
+          max_depth?: number;
+        };
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][];
+      };
       foreign_tables_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       functions_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       gbt_bit_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_bool_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_bool_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_bpchar_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_bytea_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_cash_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_cash_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_date_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_date_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_decompress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_enum_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_enum_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_float4_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_float4_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_float8_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_float8_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_inet_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_int2_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_int2_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_int4_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_int4_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_int8_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_int8_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_intv_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_intv_decompress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_intv_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_macad_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_macad_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_macad8_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_macad8_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_numeric_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_oid_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_oid_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_text_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_time_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_time_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_timetz_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_ts_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_ts_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_tstz_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_uuid_compress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_uuid_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_var_decompress: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbt_var_fetch: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey_var_in: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey_var_out: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey16_in: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey16_out: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey2_in: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey2_out: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey32_in: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey32_out: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey4_in: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey4_out: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey8_in: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       gbtreekey8_out: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       get_telemetry_report: {
-        Args: Record<PropertyKey, never>
-        Returns: Json
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: Json;
+      };
       groups_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       has_check: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_composite: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_domain: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_enum: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_extension: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_fk: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_foreign_table: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_function: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_group: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_inherited_tables: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_language: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_materialized_view: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_opclass: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_pk: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_relation: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_role: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_schema: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_sequence: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_table: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_tablespace: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_type: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_unique: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       has_user: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       has_view: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_composite: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_domain: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_enum: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_extension: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_fk: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_foreign_table: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_function: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_group: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_inherited_tables: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_language: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_materialized_view: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_opclass: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_pk: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_relation: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_role: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_schema: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_sequence: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_table: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_tablespace: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_type: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_user: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       hasnt_view: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       have_admin_acces: {
         Args: {
-          id: number
-        }
-        Returns: boolean
-      }
+          id: number;
+        };
+        Returns: boolean;
+      };
       have_discussion_edition_acces: {
         Args: {
-          id: number
-        }
-        Returns: boolean
-      }
+          id: number;
+        };
+        Returns: boolean;
+      };
       have_discussion_lecture_acces: {
         Args: {
-          id: number
-        }
-        Returns: boolean
-      }
+          id: number;
+        };
+        Returns: boolean;
+      };
       have_edition_acces: {
         Args: {
-          id: number
-        }
-        Returns: boolean
-      }
+          id: number;
+        };
+        Returns: boolean;
+      };
       have_lecture_acces: {
         Args: {
-          id: number
-        }
-        Returns: boolean
-      }
+          id: number;
+        };
+        Returns: boolean;
+      };
       have_one_of_niveaux_acces: {
         Args: {
-          niveaux: Database["public"]["Enums"]["niveau_acces"][]
-          id: number
-        }
-        Returns: boolean
-      }
+          niveaux: Database["public"]["Enums"]["niveau_acces"][];
+          id: number;
+        };
+        Returns: boolean;
+      };
       hypertable_compression_stats: {
         Args: {
-          hypertable: unknown
-        }
+          hypertable: unknown;
+        };
         Returns: {
-          total_chunks: number
-          number_compressed_chunks: number
-          before_compression_table_bytes: number
-          before_compression_index_bytes: number
-          before_compression_toast_bytes: number
-          before_compression_total_bytes: number
-          after_compression_table_bytes: number
-          after_compression_index_bytes: number
-          after_compression_toast_bytes: number
-          after_compression_total_bytes: number
-          node_name: unknown
-        }[]
-      }
+          total_chunks: number;
+          number_compressed_chunks: number;
+          before_compression_table_bytes: number;
+          before_compression_index_bytes: number;
+          before_compression_toast_bytes: number;
+          before_compression_total_bytes: number;
+          after_compression_table_bytes: number;
+          after_compression_index_bytes: number;
+          after_compression_toast_bytes: number;
+          after_compression_total_bytes: number;
+          node_name: unknown;
+        }[];
+      };
       hypertable_detailed_size: {
         Args: {
-          hypertable: unknown
-        }
+          hypertable: unknown;
+        };
         Returns: {
-          table_bytes: number
-          index_bytes: number
-          toast_bytes: number
-          total_bytes: number
-          node_name: unknown
-        }[]
-      }
+          table_bytes: number;
+          index_bytes: number;
+          toast_bytes: number;
+          total_bytes: number;
+          node_name: unknown;
+        }[];
+      };
       hypertable_index_size: {
         Args: {
-          index_name: unknown
-        }
-        Returns: number
-      }
+          index_name: unknown;
+        };
+        Returns: number;
+      };
       hypertable_size: {
         Args: {
-          hypertable: unknown
-        }
-        Returns: number
-      }
+          hypertable: unknown;
+        };
+        Returns: number;
+      };
       in_todo: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
       index_is_primary: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       index_is_unique: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       interpolate:
         | {
             Args: {
-              value: number
-              prev?: Record<string, unknown>
-              next?: Record<string, unknown>
-            }
-            Returns: number
+              value: number;
+              prev?: Record<string, unknown>;
+              next?: Record<string, unknown>;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              value: number
-              prev?: Record<string, unknown>
-              next?: Record<string, unknown>
-            }
-            Returns: number
+              value: number;
+              prev?: Record<string, unknown>;
+              next?: Record<string, unknown>;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              value: number
-              prev?: Record<string, unknown>
-              next?: Record<string, unknown>
-            }
-            Returns: number
+              value: number;
+              prev?: Record<string, unknown>;
+              next?: Record<string, unknown>;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              value: number
-              prev?: Record<string, unknown>
-              next?: Record<string, unknown>
-            }
-            Returns: number
+              value: number;
+              prev?: Record<string, unknown>;
+              next?: Record<string, unknown>;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              value: number
-              prev?: Record<string, unknown>
-              next?: Record<string, unknown>
-            }
-            Returns: number
-          }
+              value: number;
+              prev?: Record<string, unknown>;
+              next?: Record<string, unknown>;
+            };
+            Returns: number;
+          };
       is_agent_of: {
         Args: {
-          id: number
-        }
-        Returns: boolean
-      }
+          id: number;
+        };
+        Returns: boolean;
+      };
       is_aggregate: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       is_any_role_on: {
         Args: {
-          id: number
-        }
-        Returns: boolean
-      }
+          id: number;
+        };
+        Returns: boolean;
+      };
       is_authenticated: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
       is_bucket_writer: {
         Args: {
-          id: string
-        }
-        Returns: boolean
-      }
+          id: string;
+        };
+        Returns: boolean;
+      };
       is_clustered: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       is_definer: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       is_empty: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       is_normal_function: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       is_partitioned: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       is_procedure: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       is_referent_of: {
         Args: {
-          id: number
-        }
-        Returns: boolean
-      }
+          id: number;
+        };
+        Returns: boolean;
+      };
       is_service_role: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
       is_strict: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       is_superuser: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       is_window: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       isnt_aggregate: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       isnt_definer: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       isnt_empty: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       isnt_normal_function: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       isnt_partitioned: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       isnt_procedure: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       isnt_strict: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       isnt_superuser: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       isnt_window: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       json_matches_schema: {
         Args: {
-          schema: Json
-          instance: Json
-        }
-        Returns: boolean
-      }
+          schema: Json;
+          instance: Json;
+        };
+        Returns: boolean;
+      };
       jsonb_matches_schema: {
         Args: {
-          schema: Json
-          instance: Json
-        }
-        Returns: boolean
-      }
+          schema: Json;
+          instance: Json;
+        };
+        Returns: boolean;
+      };
       labellisation_cloturer_audit: {
         Args: {
-          audit_id: number
-          date_fin?: string
-        }
+          audit_id: number;
+          date_fin?: string;
+        };
         Returns: {
-          collectivite_id: number
-          date_debut: string | null
-          date_fin: string | null
-          demande_id: number | null
-          id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          valide: boolean
-        }
-      }
+          collectivite_id: number;
+          date_debut: string | null;
+          date_fin: string | null;
+          demande_id: number | null;
+          id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          valide: boolean;
+        };
+      };
       labellisation_commencer_audit: {
         Args: {
-          audit_id: number
-          date_debut?: string
-        }
+          audit_id: number;
+          date_debut?: string;
+        };
         Returns: {
-          collectivite_id: number
-          date_debut: string | null
-          date_fin: string | null
-          demande_id: number | null
-          id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          valide: boolean
-        }
-      }
+          collectivite_id: number;
+          date_debut: string | null;
+          date_fin: string | null;
+          demande_id: number | null;
+          id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          valide: boolean;
+        };
+      };
       labellisation_demande: {
         Args: {
-          collectivite_id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          collectivite_id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Returns: {
-          collectivite_id: number
-          date: string
-          demandeur: string | null
-          en_cours: boolean
-          envoyee_le: string | null
-          etoiles: Database["labellisation"]["Enums"]["etoile"] | null
-          id: number
-          modified_at: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"]
-        }
-      }
+          collectivite_id: number;
+          date: string;
+          demandeur: string | null;
+          en_cours: boolean;
+          envoyee_le: string | null;
+          etoiles: Database["labellisation"]["Enums"]["etoile"] | null;
+          id: number;
+          modified_at: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"];
+        };
+      };
       labellisation_parcours: {
         Args: {
-          collectivite_id: number
-        }
+          collectivite_id: number;
+        };
         Returns: {
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          etoiles: Database["labellisation"]["Enums"]["etoile"]
-          completude_ok: boolean
-          critere_score: Json
-          criteres_action: Json
-          rempli: boolean
-          calendrier: string
-          demande: Json
-          labellisation: Json
-          audit: Json
-        }[]
-      }
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          etoiles: Database["labellisation"]["Enums"]["etoile"];
+          completude_ok: boolean;
+          critere_score: Json;
+          criteres_action: Json;
+          rempli: boolean;
+          calendrier: string;
+          demande: Json;
+          labellisation: Json;
+          audit: Json;
+        }[];
+      };
       labellisation_peut_commencer_audit: {
         Args: {
-          collectivite_id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
-        Returns: boolean
-      }
+          collectivite_id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
+        Returns: boolean;
+      };
       labellisation_submit_demande: {
         Args: {
-          collectivite_id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"]
-          etoiles?: Database["labellisation"]["Enums"]["etoile"]
-        }
+          collectivite_id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"];
+          etoiles?: Database["labellisation"]["Enums"]["etoile"];
+        };
         Returns: {
-          collectivite_id: number
-          date: string
-          demandeur: string | null
-          en_cours: boolean
-          envoyee_le: string | null
-          etoiles: Database["labellisation"]["Enums"]["etoile"] | null
-          id: number
-          modified_at: string | null
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          sujet: Database["labellisation"]["Enums"]["sujet_demande"]
-        }
-      }
+          collectivite_id: number;
+          date: string;
+          demandeur: string | null;
+          en_cours: boolean;
+          envoyee_le: string | null;
+          etoiles: Database["labellisation"]["Enums"]["etoile"] | null;
+          id: number;
+          modified_at: string | null;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          sujet: Database["labellisation"]["Enums"]["sujet_demande"];
+        };
+      };
       language_is_trusted: {
         Args: {
-          "": unknown
-        }
-        Returns: string
-      }
+          "": unknown;
+        };
+        Returns: string;
+      };
       languages_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       lives_ok: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       locf: {
         Args: {
-          value: unknown
-          prev?: unknown
-          treat_null_as_missing?: boolean
-        }
-        Returns: unknown
-      }
+          value: unknown;
+          prev?: unknown;
+          treat_null_as_missing?: boolean;
+        };
+        Returns: unknown;
+      };
       materialized_views_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       move_chunk: {
         Args: {
-          chunk: unknown
-          destination_tablespace: unknown
-          index_destination_tablespace?: unknown
-          reorder_index?: unknown
-          verbose?: boolean
-        }
-        Returns: undefined
-      }
+          chunk: unknown;
+          destination_tablespace: unknown;
+          index_destination_tablespace?: unknown;
+          reorder_index?: unknown;
+          verbose?: boolean;
+        };
+        Returns: undefined;
+      };
       naturalsort: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       navigation_plans: {
         Args: {
-          collectivite_id: number
-        }
-        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][]
-      }
+          collectivite_id: number;
+        };
+        Returns: Database["public"]["CompositeTypes"]["flat_axe_node"][];
+      };
       no_plan: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean[]
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean[];
+      };
       num_failed: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       ok: {
         Args: {
-          "": boolean
-        }
-        Returns: string
-      }
+          "": boolean;
+        };
+        Returns: string;
+      };
       opclasses_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       operators_are: {
         Args: {
-          "": string[]
-        }
-        Returns: string
-      }
+          "": string[];
+        };
+        Returns: string;
+      };
       os_name: {
-        Args: Record<PropertyKey, never>
-        Returns: string
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: string;
+      };
       pass:
         | {
             Args: {
-              "": string
-            }
-            Returns: string
+              "": string;
+            };
+            Returns: string;
           }
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string
-          }
+            Args: Record<PropertyKey, never>;
+            Returns: string;
+          };
       personnes_collectivite: {
         Args: {
-          collectivite_id: number
-        }
-        Returns: Database["public"]["CompositeTypes"]["personne"][]
-      }
+          collectivite_id: number;
+        };
+        Returns: Database["public"]["CompositeTypes"]["personne"][];
+      };
       peut_lire_la_fiche: {
         Args: {
-          fiche_id: number
-        }
-        Returns: boolean
-      }
+          fiche_id: number;
+        };
+        Returns: boolean;
+      };
       peut_modifier_la_fiche: {
         Args: {
-          fiche_id: number
-        }
-        Returns: boolean
-      }
+          fiche_id: number;
+        };
+        Returns: boolean;
+      };
       pg_version: {
-        Args: Record<PropertyKey, never>
-        Returns: string
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: string;
+      };
       pg_version_num: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       pgtap_version: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
       plan: {
         Args: {
-          "": number
-        }
-        Returns: string
-      }
+          "": number;
+        };
+        Returns: string;
+      };
       plan_action: {
         Args: {
-          id: number
-        }
-        Returns: Json
-      }
+          id: number;
+        };
+        Returns: Json;
+      };
       plan_action_export: {
         Args: {
-          id: number
-        }
-        Returns: Database["public"]["CompositeTypes"]["fiche_action_export"][]
-      }
+          id: number;
+        };
+        Returns: Database["public"]["CompositeTypes"]["fiche_action_export"][];
+      };
       plan_action_profondeur: {
         Args: {
-          id: number
-          profondeur: number
-        }
-        Returns: Json
-      }
+          id: number;
+          profondeur: number;
+        };
+        Returns: Json;
+      };
       plan_action_tableau_de_bord: {
         Args: {
-          collectivite_id: number
-          plan_id?: number
-          sans_plan?: boolean
-        }
-        Returns: Database["public"]["CompositeTypes"]["plan_action_tableau_de_bord"]
-      }
+          collectivite_id: number;
+          plan_id?: number;
+          sans_plan?: boolean;
+        };
+        Returns: Database["public"]["CompositeTypes"]["plan_action_tableau_de_bord"];
+      };
       plans_action_collectivite: {
         Args: {
-          collectivite_id: number
-        }
+          collectivite_id: number;
+        };
         Returns: {
-          collectivite_id: number
-          created_at: string
-          id: number
-          modified_at: string
-          modified_by: string | null
-          nom: string | null
-          parent: number | null
-        }[]
-      }
+          collectivite_id: number;
+          created_at: string;
+          id: number;
+          modified_at: string;
+          modified_by: string | null;
+          nom: string | null;
+          parent: number | null;
+        }[];
+      };
       preuve_count: {
         Args: {
-          collectivite_id: number
-          action_id: unknown
-        }
-        Returns: number
-      }
+          collectivite_id: number;
+          action_id: unknown;
+        };
+        Returns: number;
+      };
       quit_collectivite: {
         Args: {
-          id: number
-        }
-        Returns: Json
-      }
+          id: number;
+        };
+        Returns: Json;
+      };
       referent_contact: {
         Args: {
-          id: number
-        }
-        Returns: Json
-      }
+          id: number;
+        };
+        Returns: Json;
+      };
       referent_contacts: {
         Args: {
-          id: number
-        }
+          id: number;
+        };
         Returns: {
-          prenom: string
-          nom: string
-          email: string
-        }[]
-      }
+          prenom: string;
+          nom: string;
+          email: string;
+        }[];
+      };
       referentiel_down_to_action: {
         Args: {
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
         Returns: {
-          children: unknown[] | null
-          depth: number | null
-          description: string | null
-          have_contexte: boolean | null
-          have_exemples: boolean | null
-          have_perimetre_evaluation: boolean | null
-          have_preuve: boolean | null
-          have_questions: boolean | null
-          have_reduction_potentiel: boolean | null
-          have_ressources: boolean | null
-          id: string | null
-          identifiant: string | null
-          nom: string | null
-          phase: Database["public"]["Enums"]["action_categorie"] | null
-          referentiel: Database["public"]["Enums"]["referentiel"] | null
-          type: Database["public"]["Enums"]["action_type"] | null
-        }[]
-      }
+          children: unknown[] | null;
+          depth: number | null;
+          description: string | null;
+          have_contexte: boolean | null;
+          have_exemples: boolean | null;
+          have_perimetre_evaluation: boolean | null;
+          have_preuve: boolean | null;
+          have_questions: boolean | null;
+          have_reduction_potentiel: boolean | null;
+          have_ressources: boolean | null;
+          id: string | null;
+          identifiant: string | null;
+          nom: string | null;
+          phase: Database["public"]["Enums"]["action_categorie"] | null;
+          referentiel: Database["public"]["Enums"]["referentiel"] | null;
+          type: Database["public"]["Enums"]["action_type"] | null;
+        }[];
+      };
       remove_compression_policy: {
         Args: {
-          hypertable: unknown
-          if_exists?: boolean
-        }
-        Returns: boolean
-      }
+          hypertable: unknown;
+          if_exists?: boolean;
+        };
+        Returns: boolean;
+      };
       remove_continuous_aggregate_policy: {
         Args: {
-          continuous_aggregate: unknown
-          if_not_exists?: boolean
-          if_exists?: boolean
-        }
-        Returns: undefined
-      }
+          continuous_aggregate: unknown;
+          if_not_exists?: boolean;
+          if_exists?: boolean;
+        };
+        Returns: undefined;
+      };
       remove_membre_from_collectivite: {
         Args: {
-          collectivite_id: number
-          email: string
-        }
-        Returns: Json
-      }
+          collectivite_id: number;
+          email: string;
+        };
+        Returns: Json;
+      };
       remove_reorder_policy: {
         Args: {
-          hypertable: unknown
-          if_exists?: boolean
-        }
-        Returns: undefined
-      }
+          hypertable: unknown;
+          if_exists?: boolean;
+        };
+        Returns: undefined;
+      };
       remove_retention_policy: {
         Args: {
-          relation: unknown
-          if_exists?: boolean
-        }
-        Returns: undefined
-      }
+          relation: unknown;
+          if_exists?: boolean;
+        };
+        Returns: undefined;
+      };
       reorder_chunk: {
         Args: {
-          chunk: unknown
-          index?: unknown
-          verbose?: boolean
-        }
-        Returns: undefined
-      }
+          chunk: unknown;
+          index?: unknown;
+          verbose?: boolean;
+        };
+        Returns: undefined;
+      };
       retool_user_list: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          droit_id: number
-          nom: string
-          prenom: string
-          email: string
-          collectivite: string
-        }[]
-      }
+          droit_id: number;
+          nom: string;
+          prenom: string;
+          email: string;
+          collectivite: string;
+        }[];
+      };
       roles_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       runtests:
         | {
             Args: {
-              "": unknown
-            }
-            Returns: string[]
+              "": unknown;
+            };
+            Returns: string[];
           }
         | {
             Args: {
-              "": string
-            }
-            Returns: string[]
+              "": string;
+            };
+            Returns: string[];
           }
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string[]
-          }
+            Args: Record<PropertyKey, never>;
+            Returns: string[];
+          };
       save_reponse: {
         Args: {
-          "": Json
-        }
-        Returns: undefined
-      }
+          "": Json;
+        };
+        Returns: undefined;
+      };
       schemas_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       sequences_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       set_adaptive_chunking: {
         Args: {
-          hypertable: unknown
-          chunk_target_size: string
-        }
-        Returns: Record<string, unknown>
-      }
+          hypertable: unknown;
+          chunk_target_size: string;
+        };
+        Returns: Record<string, unknown>;
+      };
       set_chunk_time_interval: {
         Args: {
-          hypertable: unknown
-          chunk_time_interval: unknown
-          dimension_name?: unknown
-        }
-        Returns: undefined
-      }
+          hypertable: unknown;
+          chunk_time_interval: unknown;
+          dimension_name?: unknown;
+        };
+        Returns: undefined;
+      };
       set_integer_now_func: {
         Args: {
-          hypertable: unknown
-          integer_now_func: unknown
-          replace_if_exists?: boolean
-        }
-        Returns: undefined
-      }
+          hypertable: unknown;
+          integer_now_func: unknown;
+          replace_if_exists?: boolean;
+        };
+        Returns: undefined;
+      };
       set_number_partitions: {
         Args: {
-          hypertable: unknown
-          number_partitions: number
-          dimension_name?: unknown
-        }
-        Returns: undefined
-      }
+          hypertable: unknown;
+          number_partitions: number;
+          dimension_name?: unknown;
+        };
+        Returns: undefined;
+      };
       set_replication_factor: {
         Args: {
-          hypertable: unknown
-          replication_factor: number
-        }
-        Returns: undefined
-      }
+          hypertable: unknown;
+          replication_factor: number;
+        };
+        Returns: undefined;
+      };
       show_chunks: {
         Args: {
-          relation: unknown
-          older_than?: unknown
-          newer_than?: unknown
-        }
-        Returns: unknown[]
-      }
+          relation: unknown;
+          older_than?: unknown;
+          newer_than?: unknown;
+        };
+        Returns: unknown[];
+      };
       show_tablespaces: {
         Args: {
-          hypertable: unknown
-        }
-        Returns: unknown[]
-      }
+          hypertable: unknown;
+        };
+        Returns: unknown[];
+      };
       skip:
         | {
             Args: {
-              why: string
-              how_many: number
-            }
-            Returns: string
+              why: string;
+              how_many: number;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              "": string
-            }
-            Returns: string
+              "": string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              "": number
-            }
-            Returns: string
-          }
+              "": number;
+            };
+            Returns: string;
+          };
       tables_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       tablespaces_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       teapot: {
-        Args: Record<PropertyKey, never>
-        Returns: Json
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: Json;
+      };
       test_add_random_user: {
         Args: {
-          collectivite_id: number
-          niveau: Database["public"]["Enums"]["niveau_acces"]
-          cgu_acceptees?: boolean
-        }
-        Returns: Record<string, unknown>
-      }
+          collectivite_id: number;
+          niveau: Database["public"]["Enums"]["niveau_acces"];
+          cgu_acceptees?: boolean;
+        };
+        Returns: Record<string, unknown>;
+      };
       test_attach_user: {
         Args: {
-          user_id: string
-          collectivite_id: number
-          niveau: Database["public"]["Enums"]["niveau_acces"]
-        }
-        Returns: undefined
-      }
+          user_id: string;
+          collectivite_id: number;
+          niveau: Database["public"]["Enums"]["niveau_acces"];
+        };
+        Returns: undefined;
+      };
       test_changer_acces_restreint_collectivite: {
         Args: {
-          collectivite_id: number
-          access_restreint: boolean
-        }
-        Returns: undefined
-      }
+          collectivite_id: number;
+          access_restreint: boolean;
+        };
+        Returns: undefined;
+      };
       test_clear_history: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_create_collectivite: {
         Args: {
-          nom: string
-        }
+          nom: string;
+        };
         Returns: {
-          collectivite_id: number | null
-          id: number
-          nom: string
-        }
-      }
+          collectivite_id: number | null;
+          id: number;
+          nom: string;
+        };
+      };
       test_create_user: {
         Args: {
-          user_id: string
-          prenom: string
-          nom: string
-          email: string
-        }
-        Returns: undefined
-      }
+          user_id: string;
+          prenom: string;
+          nom: string;
+          email: string;
+        };
+        Returns: undefined;
+      };
       test_disable_fake_score_generation: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_enable_fake_score_generation: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_fulfill: {
         Args: {
-          collectivite_id: number
-          etoile: Database["labellisation"]["Enums"]["etoile"]
-        }
-        Returns: undefined
-      }
+          collectivite_id: number;
+          etoile: Database["labellisation"]["Enums"]["etoile"];
+        };
+        Returns: undefined;
+      };
       test_generate_fake_scores: {
         Args: {
-          collectivite_id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-          statuts: unknown[]
-        }
-        Returns: Json
-      }
+          collectivite_id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+          statuts: unknown[];
+        };
+        Returns: Json;
+      };
       test_max_fulfill: {
         Args: {
-          collectivite_id: number
-          referentiel: Database["public"]["Enums"]["referentiel"]
-        }
-        Returns: undefined
-      }
+          collectivite_id: number;
+          referentiel: Database["public"]["Enums"]["referentiel"];
+        };
+        Returns: undefined;
+      };
       test_remove_user: {
         Args: {
-          email: string
-        }
-        Returns: undefined
-      }
+          email: string;
+        };
+        Returns: undefined;
+      };
       test_reset: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_action_statut_and_desc: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_audit: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_discussion_et_commentaires: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_droits: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_membres: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_plan_action: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_preuves: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_reponse: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_reset_users: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       test_set_auditeur: {
         Args: {
-          demande_id: number
-          user_id: string
-          audit_en_cours?: boolean
-        }
+          demande_id: number;
+          user_id: string;
+          audit_en_cours?: boolean;
+        };
         Returns: {
-          audit_id: number
-          auditeur: string
-          created_at: string | null
-        }
-      }
+          audit_id: number;
+          auditeur: string;
+          created_at: string | null;
+        };
+      };
       test_set_cot: {
         Args: {
-          collectivite_id: number
-          actif: boolean
-        }
+          collectivite_id: number;
+          actif: boolean;
+        };
         Returns: {
-          actif: boolean
-          collectivite_id: number
-          signataire: number | null
-        }
-      }
+          actif: boolean;
+          collectivite_id: number;
+          signataire: number | null;
+        };
+      };
       test_write_scores: {
         Args: {
-          collectivite_id: number
-          scores?: unknown[]
-        }
-        Returns: undefined
-      }
+          collectivite_id: number;
+          scores?: unknown[];
+        };
+        Returns: undefined;
+      };
       throws_ok: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       time_bucket:
         | {
             Args: {
+<<<<<<< HEAD
               bucket_width: unknown
               ts: string
             }
@@ -6522,228 +6529,251 @@ export interface Database {
 =======
             }
             Returns: string
+=======
+              bucket_width: unknown;
+              ts: string;
+              offset: unknown;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+            };
+            Returns: string;
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+              origin: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+              origin: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
+              bucket_width: unknown;
+              ts: string;
+              origin: string;
+            };
+            Returns: string;
+          }
+        | {
+            Args: {
+<<<<<<< HEAD
               bucket_width: unknown
               ts: string
 >>>>>>> bd0b6d67b (MAJ database.types.ts)
               offset: unknown
             }
             Returns: string
+=======
+              bucket_width: unknown;
+              ts: string;
+              offset: unknown;
+            };
+            Returns: string;
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              offset: unknown
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+              offset: unknown;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              timezone: string
-              origin?: string
-              offset?: unknown
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+              timezone: string;
+              origin?: string;
+              offset?: unknown;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
+              bucket_width: number;
+              ts: number;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
+              bucket_width: number;
+              ts: number;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
+              bucket_width: number;
+              ts: number;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
+              bucket_width: number;
+              ts: number;
+              offset: number;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
+              bucket_width: number;
+              ts: number;
+              offset: number;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
+              bucket_width: number;
+              ts: number;
+              offset: number;
+            };
+            Returns: number;
+          };
       time_bucket_gapfill:
         | {
             Args: {
-              bucket_width: number
-              ts: number
-              start?: number
-              finish?: number
-            }
-            Returns: number
+              bucket_width: number;
+              ts: number;
+              start?: number;
+              finish?: number;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              bucket_width: number
-              ts: number
-              start?: number
-              finish?: number
-            }
-            Returns: number
+              bucket_width: number;
+              ts: number;
+              start?: number;
+              finish?: number;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              bucket_width: number
-              ts: number
-              start?: number
-              finish?: number
-            }
-            Returns: number
+              bucket_width: number;
+              ts: number;
+              start?: number;
+              finish?: number;
+            };
+            Returns: number;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              start?: string
-              finish?: string
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+              start?: string;
+              finish?: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              start?: string
-              finish?: string
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+              start?: string;
+              finish?: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              start?: string
-              finish?: string
-            }
-            Returns: string
+              bucket_width: unknown;
+              ts: string;
+              start?: string;
+              finish?: string;
+            };
+            Returns: string;
           }
         | {
             Args: {
-              bucket_width: unknown
-              ts: string
-              timezone: string
-              start?: string
-              finish?: string
-            }
-            Returns: string
-          }
+              bucket_width: unknown;
+              ts: string;
+              timezone: string;
+              start?: string;
+              finish?: string;
+            };
+            Returns: string;
+          };
       timescaledb_fdw_handler: {
-        Args: Record<PropertyKey, never>
-        Returns: unknown
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: unknown;
+      };
       timescaledb_post_restore: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
       timescaledb_pre_restore: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
       todo:
         | {
             Args: {
-              why: string
-              how_many: number
-            }
-            Returns: boolean[]
+              why: string;
+              how_many: number;
+            };
+            Returns: boolean[];
           }
         | {
             Args: {
-              how_many: number
-              why: string
-            }
-            Returns: boolean[]
+              how_many: number;
+              why: string;
+            };
+            Returns: boolean[];
           }
         | {
             Args: {
-              why: string
-            }
-            Returns: boolean[]
+              why: string;
+            };
+            Returns: boolean[];
           }
         | {
             Args: {
-              how_many: number
-            }
-            Returns: boolean[]
-          }
+              how_many: number;
+            };
+            Returns: boolean[];
+          };
       todo_end: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean[]
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: boolean[];
+      };
       todo_start:
         | {
             Args: {
+<<<<<<< HEAD
               "": string
             }
             Returns: boolean[]
@@ -6752,103 +6782,113 @@ export interface Database {
             Args: Record<PropertyKey, never>
             Returns: boolean[]
           }
+=======
+              "": string;
+            };
+            Returns: boolean[];
+          }
+        | {
+            Args: Record<PropertyKey, never>;
+            Returns: boolean[];
+          };
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
       types_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       unaccent: {
         Args: {
-          "": string
-        }
-        Returns: string
-      }
+          "": string;
+        };
+        Returns: string;
+      };
       unaccent_init: {
         Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
+          "": unknown;
+        };
+        Returns: unknown;
+      };
       update_bibliotheque_fichier_filename: {
         Args: {
-          collectivite_id: number
-          hash: string
-          filename: string
-        }
-        Returns: undefined
-      }
+          collectivite_id: number;
+          hash: string;
+          filename: string;
+        };
+        Returns: undefined;
+      };
       update_collectivite_membre_champ_intervention: {
         Args: {
-          collectivite_id: number
-          membre_id: string
-          champ_intervention: Database["public"]["Enums"]["referentiel"][]
-        }
-        Returns: Json
-      }
+          collectivite_id: number;
+          membre_id: string;
+          champ_intervention: Database["public"]["Enums"]["referentiel"][];
+        };
+        Returns: Json;
+      };
       update_collectivite_membre_details_fonction: {
         Args: {
-          collectivite_id: number
-          membre_id: string
-          details_fonction: string
-        }
-        Returns: Json
-      }
+          collectivite_id: number;
+          membre_id: string;
+          details_fonction: string;
+        };
+        Returns: Json;
+      };
       update_collectivite_membre_fonction: {
         Args: {
-          collectivite_id: number
-          membre_id: string
-          fonction: Database["public"]["Enums"]["membre_fonction"]
-        }
-        Returns: Json
-      }
+          collectivite_id: number;
+          membre_id: string;
+          fonction: Database["public"]["Enums"]["membre_fonction"];
+        };
+        Returns: Json;
+      };
       update_collectivite_membre_niveau_acces: {
         Args: {
-          collectivite_id: number
-          membre_id: string
-          niveau_acces: Database["public"]["Enums"]["niveau_acces"]
-        }
-        Returns: Json
-      }
+          collectivite_id: number;
+          membre_id: string;
+          niveau_acces: Database["public"]["Enums"]["niveau_acces"];
+        };
+        Returns: Json;
+      };
       upsert_axe: {
         Args: {
-          nom: string
-          collectivite_id: number
-          parent: number
-        }
-        Returns: number
-      }
+          nom: string;
+          collectivite_id: number;
+          parent: number;
+        };
+        Returns: number;
+      };
       users_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
+          "": unknown[];
+        };
+        Returns: string;
+      };
       views_are: {
         Args: {
-          "": unknown[]
-        }
-        Returns: string
-      }
-    }
+          "": unknown[];
+        };
+        Returns: string;
+      };
+    };
     Enums: {
-      action_categorie: "bases" | "mise en œuvre" | "effets"
-      action_discussion_statut: "ouvert" | "ferme"
+      action_categorie: "bases" | "mise en œuvre" | "effets";
+      action_discussion_statut: "ouvert" | "ferme";
       action_type:
         | "referentiel"
         | "axe"
         | "sous-axe"
         | "action"
         | "sous-action"
-        | "tache"
-      audit_statut: "non_audite" | "en_cours" | "audite"
+        | "tache";
+      audit_statut: "non_audite" | "en_cours" | "audite";
       avancement:
         | "fait"
         | "pas_fait"
         | "programme"
         | "non_renseigne"
-        | "detaille"
-      collectivite_filtre_type: "population" | "score" | "remplissage"
+        | "detaille";
+      collectivite_filtre_type: "population" | "score" | "remplissage";
       fiche_action_cibles:
         | "Grand public et associations"
         | "Public Scolaire"
@@ -6860,15 +6900,15 @@ export interface Database {
         | "Partenaires"
         | "Collectivité elle-même"
         | "Elus locaux"
-        | "Agents"
+        | "Agents";
       fiche_action_echeances:
         | "Action en amélioration continue"
         | "Sans échéance"
         | "Échéance dépassée"
         | "Échéance dans moins de trois mois"
         | "Échéance entre trois mois et 1 an"
-        | "Échéance dans plus d’un an"
-      fiche_action_niveaux_priorite: "Élevé" | "Moyen" | "Bas"
+        | "Échéance dans plus d’un an";
+      fiche_action_niveaux_priorite: "Élevé" | "Moyen" | "Bas";
       fiche_action_piliers_eci:
         | "Approvisionnement durable"
         | "Écoconception"
@@ -6876,7 +6916,7 @@ export interface Database {
         | "Économie de la fonctionnalité"
         | "Consommation responsable"
         | "Allongement de la durée d’usage"
-        | "Recyclage"
+        | "Recyclage";
       fiche_action_resultats_attendus:
         | "Adaptation au changement climatique"
         | "Allongement de la durée d’usage"
@@ -6888,13 +6928,13 @@ export interface Database {
         | "Réduction des déchets"
         | "Réduction des émissions de gaz à effet de serre"
         | "Réduction des polluants atmosphériques"
-        | "Sobriété énergétique"
+        | "Sobriété énergétique";
       fiche_action_statuts:
         | "À venir"
         | "En cours"
         | "Réalisé"
         | "En pause"
-        | "Abandonné"
+        | "Abandonné";
       filterable_type_collectivite:
         | "commune"
         | "syndicat"
@@ -6904,14 +6944,14 @@ export interface Database {
         | "METRO"
         | "CA"
         | "EPT"
-        | "PETR"
-      indicateur_group: "cae" | "crte" | "eci"
+        | "PETR";
+      indicateur_group: "cae" | "crte" | "eci";
       membre_fonction:
         | "referent"
         | "conseiller"
         | "technique"
         | "politique"
-        | "partenaire"
+        | "partenaire";
       nature:
         | "SMF"
         | "CU"
@@ -6923,13 +6963,14 @@ export interface Database {
         | "CA"
         | "EPT"
         | "SIVU"
-        | "PETR"
-      niveau_acces: "admin" | "edition" | "lecture"
+        | "PETR";
+      niveau_acces: "admin" | "edition" | "lecture";
       preuve_type:
         | "complementaire"
         | "reglementaire"
         | "labellisation"
         | "audit"
+<<<<<<< HEAD
         | "rapport"
       question_type: "choix" | "binaire" | "proportion"
       referentiel: "eci" | "cae"
@@ -6944,6 +6985,16 @@ export interface Database {
         | "saisie"
         | "selection"
         | "agrandissement"
+=======
+        | "rapport";
+      question_type: "choix" | "binaire" | "proportion";
+      referentiel: "eci" | "cae";
+      regle_type: "score" | "desactivation" | "reduction";
+      role_name: "agent" | "referent" | "conseiller" | "auditeur" | "aucun";
+      thematique_completude: "complete" | "a_completer";
+      type_collectivite: "EPCI" | "commune" | "syndicat";
+      usage_action: "clic" | "vue" | "telechargement" | "saisie" | "selection";
+>>>>>>> d1c38935a (MAJ database.types.ts)
       usage_fonction:
         | "aide"
         | "preuve"
@@ -6965,11 +7016,15 @@ export interface Database {
         | "modele_import"
         | "cta_plan"
         | "cta_indicateur"
+<<<<<<< HEAD
         | "cta_labellisation"
         | "cta_plan_creation"
         | "cta_plan_maj"
         | "cta_edl_commencer"
         | "cta_edl_personnaliser"
+=======
+        | "cta_labellisation";
+>>>>>>> d1c38935a (MAJ database.types.ts)
       visite_onglet:
         | "progression"
         | "priorisation"
@@ -6981,7 +7036,7 @@ export interface Database {
         | "comparaison"
         | "critere"
         | "informations"
-        | "commentaires"
+        | "commentaires";
       visite_page:
         | "autre"
         | "signin"
@@ -7009,7 +7064,15 @@ export interface Database {
         | "nouveau_plan"
         | "nouveau_plan_import"
         | "nouveau_plan_creation"
+<<<<<<< HEAD
         | "indicateurs"
+<<<<<<< HEAD
+=======
+        | "synthese"
+=======
+        | "indicateurs";
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
+>>>>>>> 5eb3065f1 (MAJ database.types.ts)
       visite_tag:
         | "cae"
         | "eci"
@@ -7018,6 +7081,7 @@ export interface Database {
         | "thematique"
         | "personnalise"
         | "clef"
+<<<<<<< HEAD
         | "tous"
         | "statuts"
         | "pilotes"
@@ -7025,70 +7089,73 @@ export interface Database {
         | "priorites"
         | "echeances"
     }
+=======
+        | "tous";
+    };
+>>>>>>> 55e9bca97 (MAJ database.types.ts)
     CompositeTypes: {
       fiche_action_export: {
-        axe_id: number
-        axe_nom: string
-        axe_path: unknown
-        fiche: Json
-      }
+        axe_id: number;
+        axe_nom: string;
+        axe_path: unknown;
+        fiche: Json;
+      };
       financeur_montant: {
-        financeur_tag: unknown
-        montant_ttc: number
-        id: number
-      }
+        financeur_tag: unknown;
+        montant_ttc: number;
+        id: number;
+      };
       flat_axe_node: {
-        id: number
-        nom: string
-        fiches: unknown
-        ancestors: unknown
-        depth: number
-        sort_path: string
-      }
+        id: number;
+        nom: string;
+        fiches: unknown;
+        ancestors: unknown;
+        depth: number;
+        sort_path: string;
+      };
       graphique_tranche: {
-        id: string
-        value: number
-      }
+        id: string;
+        value: number;
+      };
       indicateur_generique: {
-        indicateur_id: unknown
-        indicateur_personnalise_id: number
-        nom: string
-        description: string
-        unite: string
-      }
+        indicateur_id: unknown;
+        indicateur_personnalise_id: number;
+        nom: string;
+        description: string;
+        unite: string;
+      };
       personne: {
-        nom: string
-        collectivite_id: number
-        tag_id: number
-        user_id: string
-      }
+        nom: string;
+        collectivite_id: number;
+        tag_id: number;
+        user_id: string;
+      };
       plan_action_tableau_de_bord: {
-        collectivite_id: number
-        plan_id: number
-        statuts: unknown
-        pilotes: unknown
-        referents: unknown
-        priorites: unknown
-        echeances: unknown
-      }
+        collectivite_id: number;
+        plan_id: number;
+        statuts: unknown;
+        pilotes: unknown;
+        referents: unknown;
+        priorites: unknown;
+        echeances: unknown;
+      };
       tabular_score: {
-        referentiel: Database["public"]["Enums"]["referentiel"]
-        action_id: unknown
-        score_realise: number
-        score_programme: number
-        score_realise_plus_programme: number
-        score_pas_fait: number
-        score_non_renseigne: number
-        points_restants: number
-        points_realises: number
-        points_programmes: number
-        points_max_personnalises: number
-        points_max_referentiel: number
-        avancement: Database["public"]["Enums"]["avancement"]
-        concerne: boolean
-        desactive: boolean
-      }
-    }
-  }
+        referentiel: Database["public"]["Enums"]["referentiel"];
+        action_id: unknown;
+        score_realise: number;
+        score_programme: number;
+        score_realise_plus_programme: number;
+        score_pas_fait: number;
+        score_non_renseigne: number;
+        points_restants: number;
+        points_realises: number;
+        points_programmes: number;
+        points_max_personnalises: number;
+        points_max_referentiel: number;
+        avancement: Database["public"]["Enums"]["avancement"];
+        concerne: boolean;
+        desactive: boolean;
+      };
+    };
+  };
 }
-

--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -4827,57 +4827,30 @@ export interface Database {
       filter_fiches_action: {
         Args: {
           collectivite_id: number
+          sans_plan?: boolean
           axes_id?: number[]
+          sans_pilote?: boolean
           pilotes?: Database["public"]["CompositeTypes"]["personne"][]
+          sans_referent?: boolean
+          referents?: Database["public"]["CompositeTypes"]["personne"][]
           niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][]
           statuts?: Database["public"]["Enums"]["fiche_action_statuts"][]
-          referents?: Database["public"]["CompositeTypes"]["personne"][]
+          thematiques?: unknown[]
+          sous_thematiques?: unknown[]
+          budget_min?: number
+          budget_max?: number
+          date_debut?: string
+          date_fin?: string
+          echeance?: Database["public"]["Enums"]["fiche_action_echeances"]
           limit?: number
         }
         Returns: {
-          actions: unknown[] | null
-          amelioration_continue: boolean | null
-          axes: unknown[] | null
-          budget_previsionnel: number | null
-          calendrier: string | null
-          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null
           collectivite_id: number | null
-          created_at: string | null
-          date_debut: string | null
-          date_fin_provisoire: string | null
-          description: string | null
-          fiches_liees: unknown[] | null
-          financements: string | null
-          financeurs:
-            | Database["public"]["CompositeTypes"]["financeur_montant"][]
-            | null
           id: number | null
-          indicateurs:
-            | Database["public"]["CompositeTypes"]["indicateur_generique"][]
-            | null
-          maj_termine: boolean | null
           modified_at: string | null
-          modified_by: string | null
-          niveau_priorite:
-            | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null
-          notes_complementaires: string | null
-          objectifs: string | null
-          partenaires: unknown[] | null
-          piliers_eci:
-            | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null
           pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
-          referents: Database["public"]["CompositeTypes"]["personne"][] | null
-          ressources: string | null
-          resultats_attendus:
-            | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null
-          services: unknown[] | null
-          sous_thematiques: unknown[] | null
+          plans: unknown[] | null
           statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          structures: unknown[] | null
-          thematiques: unknown[] | null
           titre: string | null
         }[]
       }
@@ -6545,6 +6518,54 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
+<<<<<<< HEAD
+=======
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+>>>>>>> bd0b6d67b (MAJ database.types.ts)
               offset: unknown
             }
             Returns: string
@@ -6840,6 +6861,13 @@ export interface Database {
         | "Collectivité elle-même"
         | "Elus locaux"
         | "Agents"
+      fiche_action_echeances:
+        | "Action en amélioration continue"
+        | "Sans échéance"
+        | "Échéance dépassée"
+        | "Échéance dans moins de trois mois"
+        | "Échéance entre trois mois et 1 an"
+        | "Échéance dans plus d’un an"
       fiche_action_niveaux_priorite: "Élevé" | "Moyen" | "Bas"
       fiche_action_piliers_eci:
         | "Approvisionnement durable"

--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -7090,6 +7090,36 @@ export interface Database {
       time_bucket:
         | {
             Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -7171,36 +7201,6 @@ export interface Database {
             Args: {
               bucket_width: number
               ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
             }
             Returns: number
           }
@@ -7615,22 +7615,6 @@ export interface Database {
         | "nouveau_plan_import"
         | "nouveau_plan_creation"
         | "indicateurs"
-<<<<<<< HEAD
-=======
-        | "synthese"
-<<<<<<< HEAD
-=======
-        | "indicateurs";
->>>>>>> 55e9bca97 (MAJ database.types.ts)
-<<<<<<< HEAD
->>>>>>> 5eb3065f1 (MAJ database.types.ts)
-=======
-=======
-        | "indicateurs"
->>>>>>> d8b0e10a9 (update types)
->>>>>>> 75edc2a5d (update types)
-=======
->>>>>>> dedef088a (Mise à jours des types)
       visite_tag:
         | "cae"
         | "eci"

--- a/api_tests/tests/plan_action/filtres.test.ts
+++ b/api_tests/tests/plan_action/filtres.test.ts
@@ -62,11 +62,15 @@ Deno.test("Fiches par echeance", async () => {
   await testReset();
   await signIn("yolododo");
 
-  await supabase.from('fiche_action').update({"amelioration_continue" : true}).eq("id", 1).select();
+  await supabase
+    .from("fiche_action")
+    .update({ amelioration_continue: true })
+    .eq("id", 1)
+    .select();
 
   const filterResponse = await supabase.rpc("filter_fiches_action", {
     collectivite_id: 1,
-    echeance: 'Action en amélioration continue'
+    echeance: "Action en amélioration continue",
   });
   assertExists(filterResponse.data);
   assertEquals(filterResponse.data.length, 1);
@@ -76,18 +80,22 @@ Deno.test("Fiches par echeance", async () => {
   await testReset();
   await signIn("yolododo");
 
-  await supabase.from('fiche_action').update({"date_fin_provisoire" : new Date().toISOString()}).eq("id", 1).select();
+  await supabase
+    .from("fiche_action")
+    .update({ date_fin_provisoire: new Date().toISOString() })
+    .eq("id", 1)
+    .select();
 
   const filterResponse2 = await supabase.rpc("filter_fiches_action", {
     collectivite_id: 1,
-    echeance: 'Échéance dépassée'
+    echeance: "Échéance dépassée",
   });
   assertExists(filterResponse2.data);
   assertEquals(filterResponse2.data.length, 1);
 
   const filterResponse3 = await supabase.rpc("filter_fiches_action", {
     collectivite_id: 1,
-    echeance: 'Échéance dans plus d’un an'
+    echeance: "Échéance dans plus d’un an",
   });
   assertExists(filterResponse3.data);
   assertEquals(filterResponse3.data.length, 0);
@@ -99,11 +107,15 @@ Deno.test("Fiches par budget", async () => {
   await testReset();
   await signIn("yolododo");
 
-  await supabase.from('fiche_action').update({"budget_previsionnel" : 10}).eq("id", 1).select();
+  await supabase
+    .from("fiche_action")
+    .update({ budget_previsionnel: 10 })
+    .eq("id", 1)
+    .select();
 
   const filterResponse = await supabase.rpc("filter_fiches_action", {
     collectivite_id: 1,
-    budget_min: 8
+    budget_min: 8,
   });
   assertExists(filterResponse.data);
   assertEquals(filterResponse.data.length, 1);
@@ -111,7 +123,7 @@ Deno.test("Fiches par budget", async () => {
   const filterResponse2 = await supabase.rpc("filter_fiches_action", {
     collectivite_id: 1,
     budget_min: 8,
-    budget_max : 9
+    budget_max: 9,
   });
   assertExists(filterResponse2.data);
   assertEquals(filterResponse2.data.length, 0);
@@ -125,21 +137,27 @@ Deno.test("Fiches par thematique", async () => {
 
   const filterResponse = await supabase.rpc("filter_fiches_action", {
     collectivite_id: 1,
-    thematiques: [{"thematique" : 'Activités économiques'}]
+    thematiques: [{ thematique: "Activités économiques" }],
   });
   assertExists(filterResponse.data);
   assertEquals(filterResponse.data.length, 10);
 
   const filterResponse2 = await supabase.rpc("filter_fiches_action", {
     collectivite_id: 1,
-    thematiques: [{"thematique" : 'Énergie et climat'}]
+    thematiques: [{ thematique: "Énergie et climat" }],
   });
   assertExists(filterResponse2.data);
   assertEquals(filterResponse2.data.length, 0);
 
   const filterResponse3 = await supabase.rpc("filter_fiches_action", {
     collectivite_id: 1,
-    sous_thematiques: [{"id" : 1, "thematique" : "Activités économiques", "sous_thematique":"Agriculture et alimentation"}]
+    sous_thematiques: [
+      {
+        id: 1,
+        thematique: "Activités économiques",
+        sous_thematique: "Agriculture et alimentation",
+      },
+    ],
   });
   assertExists(filterResponse3.data);
   assertEquals(filterResponse3.data.length, 10);
@@ -160,5 +178,3 @@ Deno.test("Fiches sans plan", async () => {
 
   await signOut();
 });
-
-

--- a/api_tests/tests/plan_action/filtres.test.ts
+++ b/api_tests/tests/plan_action/filtres.test.ts
@@ -1,6 +1,6 @@
-import { supabase } from "/lib/supabase.ts";
-import { signIn, signOut } from "/lib/auth.ts";
-import { testReset } from "/lib/rpcs/testReset.ts";
+import { supabase } from "../../lib/supabase.ts";
+import { signIn, signOut } from "../../lib/auth.ts";
+import { testReset } from "../../lib/rpcs/testReset.ts";
 import {
   assertEquals,
   assertExists,
@@ -16,7 +16,7 @@ Deno.test("Fiches par axe", async () => {
     axes_id: [16],
   });
   assertExists(filterResponse.data);
-  assertEquals(filterResponse.data.length, 6);
+  assertEquals(filterResponse.data.length, 3);
 
   await signOut();
 });
@@ -57,3 +57,108 @@ Deno.test("Fiches par pilote", async () => {
 
   await signOut();
 });
+
+Deno.test("Fiches par echeance", async () => {
+  await testReset();
+  await signIn("yolododo");
+
+  await supabase.from('fiche_action').update({"amelioration_continue" : true}).eq("id", 1).select();
+
+  const filterResponse = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    echeance: 'Action en amélioration continue'
+  });
+  assertExists(filterResponse.data);
+  assertEquals(filterResponse.data.length, 1);
+
+  await signOut();
+
+  await testReset();
+  await signIn("yolododo");
+
+  await supabase.from('fiche_action').update({"date_fin_provisoire" : new Date().toISOString()}).eq("id", 1).select();
+
+  const filterResponse2 = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    echeance: 'Échéance dépassée'
+  });
+  assertExists(filterResponse2.data);
+  assertEquals(filterResponse2.data.length, 1);
+
+  const filterResponse3 = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    echeance: 'Échéance dans plus d’un an'
+  });
+  assertExists(filterResponse3.data);
+  assertEquals(filterResponse3.data.length, 0);
+
+  await signOut();
+});
+
+Deno.test("Fiches par budget", async () => {
+  await testReset();
+  await signIn("yolododo");
+
+  await supabase.from('fiche_action').update({"budget_previsionnel" : 10}).eq("id", 1).select();
+
+  const filterResponse = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    budget_min: 8
+  });
+  assertExists(filterResponse.data);
+  assertEquals(filterResponse.data.length, 1);
+
+  const filterResponse2 = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    budget_min: 8,
+    budget_max : 9
+  });
+  assertExists(filterResponse2.data);
+  assertEquals(filterResponse2.data.length, 0);
+
+  await signOut();
+});
+
+Deno.test("Fiches par thematique", async () => {
+  await testReset();
+  await signIn("yolododo");
+
+  const filterResponse = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    thematiques: [{"thematique" : 'Activités économiques'}]
+  });
+  assertExists(filterResponse.data);
+  assertEquals(filterResponse.data.length, 10);
+
+  const filterResponse2 = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    thematiques: [{"thematique" : 'Énergie et climat'}]
+  });
+  assertExists(filterResponse2.data);
+  assertEquals(filterResponse2.data.length, 0);
+
+  const filterResponse3 = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    sous_thematiques: [{"id" : 1, "thematique" : "Activités économiques", "sous_thematique":"Agriculture et alimentation"}]
+  });
+  assertExists(filterResponse3.data);
+  assertEquals(filterResponse3.data.length, 10);
+
+  await signOut();
+});
+
+Deno.test("Fiches sans plan", async () => {
+  await testReset();
+  await signIn("yolododo");
+
+  const filterResponse = await supabase.rpc("filter_fiches_action", {
+    collectivite_id: 1,
+    sans_plan: true,
+  });
+  assertExists(filterResponse.data);
+  assertEquals(filterResponse.data.length, 1);
+
+  await signOut();
+});
+
+

--- a/app.territoiresentransitions.react/src/app/Layout/Header/__snapshots__/Header.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/__snapshots__/Header.stories.storyshot
@@ -271,7 +271,7 @@ exports[`Storyshots app/Layout/Header Connected 1`] = `
             <a
               aria-controls="modal-header__menu"
               className="fr-nav__link"
-              href="/collectivite/1/plans"
+              href="/collectivite/1/plans/synthese"
               onClick={[Function]}
               target="_self"
             >

--- a/app.territoiresentransitions.react/src/app/Layout/Header/makeNavItems.ts
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/makeNavItems.ts
@@ -7,7 +7,7 @@ import {
   makeCollectiviteLabellisationRootUrl,
   makeCollectiviteLabellisationUrl,
   makeCollectivitePersoRefUrl,
-  makeCollectivitePlansActionsBaseUrl,
+  makeCollectivitePlansActionsSyntheseUrl,
   makeCollectiviteReferentielUrl,
   makeCollectiviteUsersUrl,
 } from 'app/paths';
@@ -94,7 +94,7 @@ const makeNavItemsBase = (collectivite: CurrentCollectivite): TNavItemsList => {
     {
       acces_restreint,
       label: "Plans d'action",
-      to: makeCollectivitePlansActionsBaseUrl({
+      to: makeCollectivitePlansActionsSyntheseUrl({
         collectiviteId,
       }),
     },

--- a/app.territoiresentransitions.react/src/app/Layout/__snapshots__/Layout.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/Layout/__snapshots__/Layout.stories.storyshot
@@ -260,7 +260,7 @@ exports[`Storyshots app/Layout Exemple 1`] = `
                 <a
                   aria-controls="modal-header__menu"
                   className="fr-nav__link"
-                  href="/collectivite/1/plans"
+                  href="/collectivite/1/plans/synthese"
                   onClick={[Function]}
                   target="_self"
                 >

--- a/app.territoiresentransitions.react/src/app/pages/ToutesLesCollectivites/components/Filtres.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/ToutesLesCollectivites/components/Filtres.tsx
@@ -102,7 +102,7 @@ export const RegionFiltre = (props: {
   <fieldset>
     <label className="font-semibold mb-2 ml-0">Région</label>
     <MultiSelectDropdown
-      buttonClassName={DSFRbuttonClassname}
+      dsfrButton
       options={props.regions.map(({code, libelle}) => ({
         value: code,
         label: libelle,
@@ -123,7 +123,7 @@ export const DepartementFiltre = (props: {
     <fieldset>
       <label className="font-semibold mb-2 ml-0">Département</label>
       <MultiSelectDropdown
-        buttonClassName={DSFRbuttonClassname}
+        dsfrButton
         placeholderText="Sélectionnez un ou plusieurs départements"
         options={props.departements
           .filter(

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionCard.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionCard.tsx
@@ -1,46 +1,39 @@
 import ActionCard from '../components/ActionCard';
-import {FicheAction, FicheResume} from './data/types';
+import {FicheResume} from './data/types';
 import {formatNomPilotes, generateTitle} from './data/utils';
 import FicheActionBadgeStatut from './FicheActionForm/FicheActionBadgeStatut';
 
-function isFicheResumeFromAxe(
-  fiche: FicheAction | FicheResume
-): fiche is FicheResume {
-  return (fiche as FicheResume).plans !== undefined;
-}
-
-const generateDetails = (fiche: FicheAction | FicheResume) => {
+const generateDetails = (fiche: FicheResume, displayAxe: boolean) => {
+  const {plans, pilotes} = fiche;
   let details = '';
-  if (isFicheResumeFromAxe(fiche)) {
-    if (!fiche.plans) {
-      details = details + 'Fiche non classée';
-      // on affiche la barre uniquement si "Fiche non classée" est présent
-      if (fiche.pilotes) {
-        details = details + ' | ';
-      }
-    }
-  } else {
-    if (!fiche.axes) {
-      details = details + 'Fiche non classée';
-      // on affiche la barre uniquement si "Fiche non classée" est présent
-      if (fiche.pilotes) {
-        details = details + ' | ';
-      }
-    }
+
+  const plan = plans?.[0];
+
+  if (displayAxe) {
+    details = plan?.nom || 'Fiches non classées';
   }
-  if (fiche.pilotes) {
-    details += formatNomPilotes(fiche.pilotes);
+  if (displayAxe && pilotes) {
+    details += ' | ';
+  }
+  if (pilotes) {
+    details += `${formatNomPilotes(pilotes)}`;
   }
   return details;
 };
 
 type Props = {
   link: string;
-  ficheAction: FicheAction | FicheResume;
+  ficheAction: FicheResume;
+  displayAxe?: boolean;
   openInNewTab?: boolean;
 };
 
-const FicheActionCard = ({openInNewTab, ficheAction, link}: Props) => {
+const FicheActionCard = ({
+  openInNewTab,
+  ficheAction,
+  displayAxe = false,
+  link,
+}: Props) => {
   return (
     <ActionCard
       openInNewTab={openInNewTab}
@@ -50,7 +43,7 @@ const FicheActionCard = ({openInNewTab, ficheAction, link}: Props) => {
           <FicheActionBadgeStatut statut={ficheAction.statut} small />
         )
       }
-      details={generateDetails(ficheAction)}
+      details={generateDetails(ficheAction, displayAxe)}
       title={generateTitle(ficheAction.titre)}
     />
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionForm/ActionsLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionForm/ActionsLiees.tsx
@@ -54,6 +54,7 @@ const ActionsLiees = ({actions, onSelect, isReadonly}: Props) => {
     <>
       <FormField label="Actions des référentiels liées">
         <AutocompleteInputSelect
+          dsfrButton
           containerWidthMatchButton
           values={actions?.map((action: TActionRelationInsert) => action.id)}
           options={formatOptions(actionListe)}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionForm/FichesLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionForm/FichesLiees.tsx
@@ -104,6 +104,7 @@ const FichesLiees = ({
     <>
       <FormField label="Fiches des plans liées">
         <AutocompleteInputSelect
+          dsfrButton
           containerWidthMatchButton
           values={fiches?.map((fiche: FicheResume) => fiche.id!.toString())}
           options={formatOptions(ficheListeSansFicheCourante)}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionForm/FichesLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionForm/FichesLiees.tsx
@@ -1,5 +1,4 @@
 import FormField from 'ui/shared/form/FormField';
-import ActionCard from '../../components/ActionCard';
 import AutocompleteInputSelect from 'ui/shared/select/AutocompleteInputSelect';
 import {TOptionSection} from 'ui/shared/select/commons';
 import {useCollectiviteId} from 'core-logic/hooks/params';
@@ -8,10 +7,10 @@ import {
   makeCollectiviteFicheNonClasseeUrl,
   makeCollectivitePlanActionFicheUrl,
 } from 'app/paths';
-import FicheActionBadgeStatut from './FicheActionBadgeStatut';
 import {FicheResume} from '../data/types';
 import {TAxeInsert} from 'types/alias';
-import {generateTitle, formatNomPilotes} from '../data/utils';
+import {generateTitle} from '../data/utils';
+import FicheActionCard from '../FicheActionCard';
 
 type Props = {
   ficheCouranteId: number | null;
@@ -101,17 +100,6 @@ const FichesLiees = ({
     return selectedFiches;
   };
 
-  const generateCardDetails = (fiche: FicheResume) => {
-    const {plans, pilotes} = fiche;
-    const plan = plans?.[0];
-
-    let details = plan?.nom || 'Fiches non classées';
-    if (pilotes) {
-      details += ` | ${formatNomPilotes(pilotes)}`;
-    }
-    return details;
-  };
-
   return (
     <>
       <FormField label="Fiches des plans liées">
@@ -127,9 +115,11 @@ const FichesLiees = ({
       {fiches && fiches.length > 0 && (
         <div className="grid grid-cols-2 gap-6">
           {fiches.map(fiche => (
-            <ActionCard
-              openInNewTab
+            <FicheActionCard
               key={fiche.id}
+              openInNewTab
+              displayAxe
+              ficheAction={fiche}
               link={
                 fiche.plans && fiche.plans[0] && fiche.plans[0].id
                   ? makeCollectivitePlanActionFicheUrl({
@@ -142,13 +132,6 @@ const FichesLiees = ({
                       ficheUid: fiche.id!.toString(),
                     })
               }
-              statutBadge={
-                fiche.statut && (
-                  <FicheActionBadgeStatut statut={fiche.statut} small />
-                )
-              }
-              details={generateCardDetails(fiche)}
-              title={generateTitle(fiche.titre)}
             />
           ))}
         </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionForm/IndicateursDropdown.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionForm/IndicateursDropdown.tsx
@@ -33,6 +33,7 @@ const IndicateursDropdown = ({indicateurs, onSelect, isReadonly}: Props) => {
 
   return (
     <AutocompleteInputSelect
+      dsfrButton
       containerWidthMatchButton
       values={indicateurs?.map((indicateur: Indicateur) =>
         indicateur.indicateur_personnalise_id

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
@@ -25,6 +25,8 @@ export type TFilters = {
   page?: number;
 };
 
+export type FiltersKeys = keyof TFilters;
+
 export type TSetFilters = (newFilter: TFilters) => void;
 
 export type TFiltreProps = {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
@@ -11,10 +11,16 @@ export type TFilters = {
   collectivite_id: number;
   /** par id plan d'action ou axe */
   axes?: number[];
+  /** par fiches non classées */
+  sans_plan?: number;
   /** par personnes pilote */
   pilotes?: string[];
+  /** sans pilote */
+  sans_pilote?: number;
   /** par référents */
   referents?: string[];
+  /** sans référent */
+  sans_referent?: number;
   /** par statuts */
   statuts?: TFicheActionStatuts[];
   /** par priorites */
@@ -36,8 +42,11 @@ export type TFiltreProps = {
 
 export const nameToShortNames = {
   axes: 'axes',
+  sans_plan: 'nc', // fiches non classées
   pilotes: 'pilotes',
+  sans_pilote: 'sp',
   referents: 'ref',
+  sans_referent: 'sr',
   statuts: 's',
   priorites: 'prio',
   echeance: 'e',

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
@@ -4,8 +4,6 @@ import {
   TFicheActionStatuts,
 } from 'types/alias';
 
-export const NB_ITEMS_PER_PAGE = 20;
-
 export type TFilters = {
   /** filtre par collectivite */
   collectivite_id: number;
@@ -60,6 +58,8 @@ export const nameToShortNames = {
 };
 
 // Constantes
+export const NB_FICHES_PER_PAGE = 20;
+
 export const SANS_PILOTE = 'sans_pilote';
 export const SANS_REFERENT = 'sans_referent';
 export const SANS_STATUT = 'sans_statut';

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
@@ -60,5 +60,7 @@ export const nameToShortNames = {
 };
 
 // Constantes
+export const SANS_PILOTE = 'sans_pilote';
+export const SANS_REFERENT = 'sans_referent';
 export const SANS_STATUT = 'sans_statut';
 export const SANS_PRIORITE = 'sans_priorite';

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
@@ -23,8 +23,12 @@ export type TFilters = {
   sans_referent?: number;
   /** par statuts */
   statuts?: TFicheActionStatuts[];
+  /** sans statut */
+  sans_statut?: number;
   /** par priorites */
   priorites?: TFicheActionNiveauxPriorite[];
+  /** sans niveau de priorité */
+  sans_niveau?: number;
   /** par échéance */
   echeance?: TFicheActionEcheances;
   /** index de la page voulue */
@@ -48,7 +52,13 @@ export const nameToShortNames = {
   referents: 'ref',
   sans_referent: 'sr',
   statuts: 's',
+  sans_statut: 'ss',
+  sans_niveau: 'snp',
   priorites: 'prio',
   echeance: 'e',
   page: 'p',
 };
+
+// Constantes
+export const SANS_STATUT = 'sans_statut';
+export const SANS_PRIORITE = 'sans_priorite';

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/filters.ts
@@ -1,12 +1,16 @@
-import {TFicheActionNiveauxPriorite, TFicheActionStatuts} from 'types/alias';
+import {
+  TFicheActionEcheances,
+  TFicheActionNiveauxPriorite,
+  TFicheActionStatuts,
+} from 'types/alias';
 
 export const NB_ITEMS_PER_PAGE = 20;
 
 export type TFilters = {
   /** filtre par collectivite */
   collectivite_id: number;
-  /** par plan d'action ou axe */
-  axes_id: number[];
+  /** par id plan d'action ou axe */
+  axes?: number[];
   /** par personnes pilote */
   pilotes?: string[];
   /** par référents */
@@ -15,6 +19,8 @@ export type TFilters = {
   statuts?: TFicheActionStatuts[];
   /** par priorites */
   priorites?: TFicheActionNiveauxPriorite[];
+  /** par échéance */
+  echeance?: TFicheActionEcheances;
   /** index de la page voulue */
   page?: number;
 };
@@ -27,9 +33,11 @@ export type TFiltreProps = {
 };
 
 export const nameToShortNames = {
+  axes: 'axes',
   pilotes: 'pilotes',
   referents: 'ref',
   statuts: 's',
   priorites: 'prio',
+  echeance: 'e',
   page: 'p',
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/options/listesStatiques.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/options/listesStatiques.ts
@@ -1,109 +1,128 @@
 import {
-    TFicheActionCibles,
-    TFicheActionNiveauxPriorite,
-    TFicheActionResultatsAttendus,
-    TFicheActionStatuts,
+  TFicheActionCibles,
+  TFicheActionEcheances,
+  TFicheActionNiveauxPriorite,
+  TFicheActionResultatsAttendus,
+  TFicheActionStatuts,
 } from 'types/alias';
 
 type Options<T extends string> = {value: T; label: T}[];
 
 export const ficheActionResultatsAttendusOptions: Options<TFicheActionResultatsAttendus> =
-    [
-        {
-            value: 'Adaptation au changement climatique',
-            label: 'Adaptation au changement climatique',
-        },
-        {
-            value: 'Allongement de la durée d’usage',
-            label: 'Allongement de la durée d’usage',
-        },
-        {
-            value: 'Amélioration de la qualité de vie',
-            label: 'Amélioration de la qualité de vie',
-        },
-        {
-            value: 'Développement des énergies renouvelables',
-            label: 'Développement des énergies renouvelables',
-        },
-        {value: 'Efficacité énergétique', label: 'Efficacité énergétique'},
-        {
-            value: 'Préservation de la biodiversité',
-            label: 'Préservation de la biodiversité',
-        },
-        {
-            value: 'Réduction des consommations énergétiques',
-            label: 'Réduction des consommations énergétiques',
-        },
-        {value: 'Réduction des déchets', label: 'Réduction des déchets'},
-        {
-            value: 'Réduction des polluants atmosphériques',
-            label: 'Réduction des polluants atmosphériques',
-        },
-        {
-            value: 'Réduction des émissions de gaz à effet de serre',
-            label: 'Réduction des émissions de gaz à effet de serre',
-        },
-        {value: 'Sobriété énergétique', label: 'Sobriété énergétique'},
-    ];
+  [
+    {
+      value: 'Adaptation au changement climatique',
+      label: 'Adaptation au changement climatique',
+    },
+    {
+      value: 'Allongement de la durée d’usage',
+      label: 'Allongement de la durée d’usage',
+    },
+    {
+      value: 'Amélioration de la qualité de vie',
+      label: 'Amélioration de la qualité de vie',
+    },
+    {
+      value: 'Développement des énergies renouvelables',
+      label: 'Développement des énergies renouvelables',
+    },
+    {value: 'Efficacité énergétique', label: 'Efficacité énergétique'},
+    {
+      value: 'Préservation de la biodiversité',
+      label: 'Préservation de la biodiversité',
+    },
+    {
+      value: 'Réduction des consommations énergétiques',
+      label: 'Réduction des consommations énergétiques',
+    },
+    {value: 'Réduction des déchets', label: 'Réduction des déchets'},
+    {
+      value: 'Réduction des polluants atmosphériques',
+      label: 'Réduction des polluants atmosphériques',
+    },
+    {
+      value: 'Réduction des émissions de gaz à effet de serre',
+      label: 'Réduction des émissions de gaz à effet de serre',
+    },
+    {value: 'Sobriété énergétique', label: 'Sobriété énergétique'},
+  ];
 
 export const ficheActionCiblesOptions: Options<TFicheActionCibles> = [
-    {
-        value: 'Grand public et associations',
-        label: 'Grand public et associations'
-    },
-    {
-        value: 'Public Scolaire',
-        label: 'Public Scolaire'
-    },
-    {
-        value: 'Acteurs économiques',
-        label: 'Acteurs économiques'
-    },
-    {
-        value: 'Acteurs économiques du secteur primaire',
-        label: 'Acteurs économiques du secteur primaire'
-    },
-    {
-        value: 'Acteurs économiques du secteur secondaire',
-        label: 'Acteurs économiques du secteur secondaire'
-    },
-    {
-        value: 'Acteurs économiques du secteur tertiaire',
-        label: 'Acteurs économiques du secteur tertiaire'
-    },
-    {
-        value: 'Partenaires',
-        label: 'Partenaires'
-    },
-    {
-        value: 'Autres collectivités du territoire',
-        label: 'Autres collectivités du territoire'
-    },
-    {
-        value: 'Collectivité elle-même',
-        label: 'Collectivité elle-même'
-    },
-    {
-        value: 'Elus locaux',
-        label: 'Elus locaux'
-    },
-    {
-        value: 'Agents',
-        label: 'Agents'
-    }
+  {
+    value: 'Grand public et associations',
+    label: 'Grand public et associations',
+  },
+  {
+    value: 'Public Scolaire',
+    label: 'Public Scolaire',
+  },
+  {
+    value: 'Acteurs économiques',
+    label: 'Acteurs économiques',
+  },
+  {
+    value: 'Acteurs économiques du secteur primaire',
+    label: 'Acteurs économiques du secteur primaire',
+  },
+  {
+    value: 'Acteurs économiques du secteur secondaire',
+    label: 'Acteurs économiques du secteur secondaire',
+  },
+  {
+    value: 'Acteurs économiques du secteur tertiaire',
+    label: 'Acteurs économiques du secteur tertiaire',
+  },
+  {
+    value: 'Partenaires',
+    label: 'Partenaires',
+  },
+  {
+    value: 'Autres collectivités du territoire',
+    label: 'Autres collectivités du territoire',
+  },
+  {
+    value: 'Collectivité elle-même',
+    label: 'Collectivité elle-même',
+  },
+  {
+    value: 'Elus locaux',
+    label: 'Elus locaux',
+  },
+  {
+    value: 'Agents',
+    label: 'Agents',
+  },
 ];
 
 export const ficheActionStatutOptions: Options<TFicheActionStatuts> = [
-    {value: 'À venir', label: 'À venir'},
-    {value: 'En cours', label: 'En cours'},
-    {value: 'Réalisé', label: 'Réalisé'},
-    {value: 'En pause', label: 'En pause'},
-    {value: 'Abandonné', label: 'Abandonné'},
+  {value: 'À venir', label: 'À venir'},
+  {value: 'En cours', label: 'En cours'},
+  {value: 'Réalisé', label: 'Réalisé'},
+  {value: 'En pause', label: 'En pause'},
+  {value: 'Abandonné', label: 'Abandonné'},
 ];
 
 export const ficheActionNiveauPrioriteOptions: Options<TFicheActionNiveauxPriorite> =
-    [
-        {value: 'Élevé', label: 'Élevé'},
-        {value: 'Moyen', label: 'Moyen'},
-        {value: 'Bas', label: 'Bas'},
-    ];
+  [
+    {value: 'Élevé', label: 'Élevé'},
+    {value: 'Moyen', label: 'Moyen'},
+    {value: 'Bas', label: 'Bas'},
+  ];
+
+export const ficheActionEcheanceOptions: Options<TFicheActionEcheances> = [
+  {
+    value: 'Action en amélioration continue',
+    label: 'Action en amélioration continue',
+  },
+  {value: 'Sans échéance', label: 'Sans échéance'},
+  {value: 'Échéance dépassée', label: 'Échéance dépassée'},
+  {
+    value: 'Échéance dans moins de trois mois',
+    label: 'Échéance dans moins de trois mois',
+  },
+  {
+    value: 'Échéance entre trois mois et 1 an',
+    label: 'Échéance entre trois mois et 1 an',
+  },
+  {value: 'Échéance dans plus d’un an', label: 'Échéance dans plus d’un an'},
+];

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useDeleteFicheAction.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useDeleteFicheAction.ts
@@ -5,7 +5,7 @@ import {useCollectiviteId} from 'core-logic/hooks/params';
 import {useHistory, useParams} from 'react-router-dom';
 import {
   makeCollectivitePlanActionUrl,
-  makeCollectivitePlansActionsBaseUrl,
+  makeCollectivitePlansActionsSyntheseUrl,
 } from 'app/paths';
 
 /** Supprime une fiche action d'une collectivité */
@@ -44,7 +44,7 @@ export const useDeleteFicheAction = () => {
         );
       } else {
         history.push(
-          makeCollectivitePlansActionsBaseUrl({
+          makeCollectivitePlansActionsSyntheseUrl({
             collectiviteId: collectivite_id!,
           })
         );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
@@ -2,7 +2,7 @@ import {useQuery} from 'react-query';
 
 import {supabaseClient} from 'core-logic/api/supabase';
 import {useSearchParams} from 'core-logic/hooks/query';
-import {nameToShortNames, TFilters} from './filters';
+import {nameToShortNames, NB_FICHES_PER_PAGE, TFilters} from './filters';
 import {useCollectiviteId} from 'core-logic/hooks/params';
 import {FicheResume} from './types';
 import {TPersonne} from 'types/alias';
@@ -77,7 +77,7 @@ export const fetchFichesActionFiltresListe = async (
       niveaux_priorite: priorites,
       sans_niveau: sansPriorite,
       echeance: echeanceSansTableau,
-      limit: 20,
+      limit: NB_FICHES_PER_PAGE,
     },
     {count: 'exact'}
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
@@ -4,7 +4,7 @@ import {supabaseClient} from 'core-logic/api/supabase';
 import {useSearchParams} from 'core-logic/hooks/query';
 import {nameToShortNames, TFilters} from './filters';
 import {useCollectiviteId} from 'core-logic/hooks/params';
-import {FicheAction} from './types';
+import {FicheResume} from './types';
 import {TPersonne} from 'types/alias';
 
 /**
@@ -22,7 +22,7 @@ export const makePersonnesWithIds = (personnes?: string[]) => {
 };
 
 export type TFichesActionsListe = {
-  items: FicheAction[];
+  items: FicheResume[];
   total: number;
   initialFilters: TFilters;
   filters: TFilters;
@@ -30,7 +30,7 @@ export type TFichesActionsListe = {
   setFilters: (filters: TFilters) => void;
 };
 
-type TFetchedData = {items: FicheAction[]; total: number};
+type TFetchedData = {items: FicheResume[]; total: number};
 
 export const fetchFichesActionFiltresListe = async (
   filters: TFilters
@@ -67,7 +67,7 @@ export const fetchFichesActionFiltresListe = async (
     throw new Error(error.message);
   }
 
-  return {items: (data as unknown as FicheAction[]) || [], total: count || 0};
+  return {items: (data as unknown as FicheResume[]) || [], total: count || 0};
 };
 
 type Args = {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
@@ -42,37 +42,40 @@ export const fetchFichesActionFiltresListe = async (
     pilotes,
     sans_pilote,
     statuts,
+    sans_statut,
     referents,
     sans_referent,
     priorites,
+    sans_niveau,
     echeance,
   } = filters;
 
   // Quand les valeurs viennent de l'URL, elle sont données sous forme de tableau de string
   const echeanceSansTableau = Array.isArray(echeance) ? echeance[0] : echeance;
-  const sansPlanSansTableau = Array.isArray(sans_plan)
-    ? sans_plan[0] === '1'
-    : sans_plan === 1;
-  const sansPiloteSansTableau = Array.isArray(sans_pilote)
-    ? sans_pilote[0] === '1'
-    : sans_pilote === 1;
-  const sansReferentSansTableau = Array.isArray(sans_referent)
-    ? sans_referent[0] === '1'
-    : sans_referent === 1;
+  /** Transforme le filtre en booléen  */
+  const getBooleanFromNumber = (v: number | string[] | undefined) =>
+    Array.isArray(v) ? v[0] === '1' : v === 1;
+  const sansPlan = getBooleanFromNumber(sans_plan);
+  const sansPilote = getBooleanFromNumber(sans_pilote);
+  const sansReferent = getBooleanFromNumber(sans_referent);
+  const sansStatut = getBooleanFromNumber(sans_statut);
+  const sansPriorite = getBooleanFromNumber(sans_niveau);
 
   const {error, data, count} = await supabaseClient.rpc(
     'filter_fiches_action',
     {
       collectivite_id: collectivite_id!,
       axes_id: axes,
-      sans_plan: sansPlanSansTableau || undefined,
+      sans_plan: sansPlan || undefined,
       // sans_plan: sans_plan === 1 || sans_plan[0] === '1',
       pilotes: makePersonnesWithIds(pilotes),
-      sans_pilote: sansPiloteSansTableau || undefined,
+      sans_pilote: sansPilote || undefined,
       referents: makePersonnesWithIds(referents),
-      sans_referent: sansReferentSansTableau || undefined,
+      sans_referent: sansReferent || undefined,
       statuts,
+      sans_statut: sansStatut,
       niveaux_priorite: priorites,
+      sans_niveau: sansPriorite,
       echeance: echeanceSansTableau,
       limit: 20,
     },

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
@@ -6,7 +6,6 @@ import {nameToShortNames, TFilters} from './filters';
 import {useCollectiviteId} from 'core-logic/hooks/params';
 import {FicheAction} from './types';
 import {TPersonne} from 'types/alias';
-import {PlanNode} from '../../PlanAction/data/types';
 
 /**
  * Renvoie un tableau de Personne.
@@ -59,6 +58,7 @@ export const fetchFichesActionFiltresListe = async (
       statuts,
       niveaux_priorite: priorites,
       echeance: echeanceSansTableau,
+      limit: 20,
     },
     {count: 'exact'}
   );
@@ -71,35 +71,28 @@ export const fetchFichesActionFiltresListe = async (
 };
 
 type Args = {
-  plan: PlanNode;
-  axe?: PlanNode;
+  /** URL à matcher pour récupérer les paramètres */
+  url: string;
+  initialFilters: TFilters;
 };
 /**
  * Liste de fiches actions au sein d'un axe
  */
 export const useFichesActionFiltresListe = ({
-  plan,
-  axe,
+  url,
+  initialFilters,
 }: Args): TFichesActionsListe => {
   const collectivite_id = useCollectiviteId();
 
-  const initialFilters: TFilters = {
-    collectivite_id: collectivite_id!,
-    axes_id: [axe ? axe.id : plan.id],
-  };
-
   const [filters, setFilters, filtersCount] = useSearchParams<TFilters>(
-    axe
-      ? `/collectivite/${collectivite_id}/plans/plan/${plan.id}/${axe.id}`
-      : `/collectivite/${collectivite_id}/plans/plan/${plan.id}`,
+    url,
     initialFilters,
     nameToShortNames
   );
 
   // charge les données
-  const {data} = useQuery(
-    ['fiches_Actions', collectivite_id, axe ? axe.id : plan.id, filters],
-    () => fetchFichesActionFiltresListe(filters)
+  const {data} = useQuery(['fiches_Actions', collectivite_id, filters], () =>
+    fetchFichesActionFiltresListe(filters)
   );
 
   return {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
@@ -36,18 +36,29 @@ type TFetchedData = {items: FicheAction[]; total: number};
 export const fetchFichesActionFiltresListe = async (
   filters: TFilters
 ): Promise<TFetchedData> => {
-  const {collectivite_id, axes_id, pilotes, statuts, referents, priorites} =
-    filters;
+  const {
+    collectivite_id,
+    axes,
+    pilotes,
+    statuts,
+    referents,
+    priorites,
+    echeance,
+  } = filters;
+
+  // Quand l'écheance vient de l'URL, elle est donnée dans un tableau
+  const echeanceSansTableau = Array.isArray(echeance) ? echeance[0] : echeance;
 
   const {error, data, count} = await supabaseClient.rpc(
     'filter_fiches_action',
     {
       collectivite_id: collectivite_id!,
-      axes_id: axes_id,
+      axes_id: axes,
       pilotes: makePersonnesWithIds(pilotes),
       referents: makePersonnesWithIds(referents),
-      statuts: statuts,
+      statuts,
       niveaux_priorite: priorites,
+      echeance: echeanceSansTableau,
     },
     {count: 'exact'}
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
@@ -67,7 +67,6 @@ export const fetchFichesActionFiltresListe = async (
       collectivite_id: collectivite_id!,
       axes_id: axes,
       sans_plan: sansPlan || undefined,
-      // sans_plan: sans_plan === 1 || sans_plan[0] === '1',
       pilotes: makePersonnesWithIds(pilotes),
       sans_pilote: sansPilote || undefined,
       referents: makePersonnesWithIds(referents),

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useFichesActionFiltresListe.ts
@@ -38,23 +38,39 @@ export const fetchFichesActionFiltresListe = async (
   const {
     collectivite_id,
     axes,
+    sans_plan,
     pilotes,
+    sans_pilote,
     statuts,
     referents,
+    sans_referent,
     priorites,
     echeance,
   } = filters;
 
-  // Quand l'écheance vient de l'URL, elle est donnée dans un tableau
+  // Quand les valeurs viennent de l'URL, elle sont données sous forme de tableau de string
   const echeanceSansTableau = Array.isArray(echeance) ? echeance[0] : echeance;
+  const sansPlanSansTableau = Array.isArray(sans_plan)
+    ? sans_plan[0] === '1'
+    : sans_plan === 1;
+  const sansPiloteSansTableau = Array.isArray(sans_pilote)
+    ? sans_pilote[0] === '1'
+    : sans_pilote === 1;
+  const sansReferentSansTableau = Array.isArray(sans_referent)
+    ? sans_referent[0] === '1'
+    : sans_referent === 1;
 
   const {error, data, count} = await supabaseClient.rpc(
     'filter_fiches_action',
     {
       collectivite_id: collectivite_id!,
       axes_id: axes,
+      sans_plan: sansPlanSansTableau || undefined,
+      // sans_plan: sans_plan === 1 || sans_plan[0] === '1',
       pilotes: makePersonnesWithIds(pilotes),
+      sans_pilote: sansPiloteSansTableau || undefined,
       referents: makePersonnesWithIds(referents),
+      sans_referent: sansReferentSansTableau || undefined,
       statuts,
       niveaux_priorite: priorites,
       echeance: echeanceSansTableau,

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanAction.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanAction.tsx
@@ -32,7 +32,17 @@ export const PlanAction = ({plan, axe}: PlanActionProps) => {
   return (
     <div data-test={isAxePage ? 'PageAxe' : 'PlanAction'} className="w-full">
       <HeaderTitle
-        type={isAxePage ? 'axe' : 'plan'}
+        customClass={
+          isAxePage
+            ? {
+                container: 'bg-indigo-300',
+                text: 'text-[1.75rem] text-gray-800 placeholder:text-gray-800 focus:placeholder:text-gray-500 disabled:text-gray-800',
+              }
+            : {
+                container: 'bg-indigo-700',
+                text: 'text-[2rem]',
+              }
+        }
         titre={isAxePage ? axe.nom : plan.nom}
         onUpdate={nom => updateAxe({id: isAxePage ? axe.id : plan.id, nom})}
         isReadonly={isReadonly}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltreEcheance.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltreEcheance.tsx
@@ -1,0 +1,42 @@
+import FilterField from 'ui/shared/filters/FilterField';
+import {TOption} from 'ui/shared/select/commons';
+import {TFiltreProps} from '../../FicheAction/data/filters';
+import {getIsAllSelected, ITEM_ALL} from 'ui/shared/filters/commons';
+import {ficheActionEcheanceOptions} from '../../FicheAction/data/options/listesStatiques';
+import SelectDropdown from 'ui/shared/select/SelectDropdown';
+import {TFicheActionEcheances} from 'types/alias';
+
+const FiltreEcheance = ({filters, setFilters}: TFiltreProps) => {
+  const {echeance} = filters;
+
+  // Initialisation du tableau d'options pour le multi-select
+  const options: TOption[] = [
+    {value: ITEM_ALL, label: 'Tous'},
+    ...ficheActionEcheanceOptions,
+  ];
+
+  return (
+    <FilterField title="Échéance">
+      <SelectDropdown
+        data-test="filtre-echeance"
+        value={Array.isArray(echeance) ? echeance[0] : echeance}
+        options={options}
+        onSelect={(value: TFicheActionEcheances) => {
+          // onClick "tous" ou toggle option
+          if (getIsAllSelected([value]) || !value) {
+            const newFilters = filters;
+            delete newFilters.echeance;
+            setFilters({...newFilters});
+            // d'une option à l'autre
+          } else {
+            setFilters({...filters, echeance: value});
+          }
+        }}
+        placeholderText="Sélectionner des options"
+        disabled={options.length === 0}
+      />
+    </FilterField>
+  );
+};
+
+export default FiltreEcheance;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePersonnes.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePersonnes.tsx
@@ -1,6 +1,5 @@
 import FilterField from 'ui/shared/filters/FilterField';
 import {TOption} from 'ui/shared/select/commons';
-import {MultiSelectFilter} from 'ui/shared/select/MultiSelectFilter';
 import {
   SANS_PILOTE,
   SANS_REFERENT,
@@ -10,6 +9,7 @@ import {
 import {getIsAllSelected, ITEM_ALL} from 'ui/shared/filters/commons';
 import {getPersonneId} from '../../FicheAction/data/utils';
 import {usePersonneListe} from '../../FicheAction/data/options/usePersonneListe';
+import AutocompleteInputSelect from 'ui/shared/select/AutocompleteInputSelect';
 
 type Props = TFiltreProps & {
   label: string;
@@ -134,12 +134,13 @@ const FiltrePersonnes = ({
 
   return (
     <FilterField title={label}>
-      <MultiSelectFilter
-        data-test={dataTest}
+      <AutocompleteInputSelect
+        containerWidthMatchButton
+        dsfrButton={false}
         values={values()}
         options={options}
         onSelect={newValues => setFilters(onSelect(newValues))}
-        placeholderText="Sélectionner des options"
+        placeholderText="Rechercher ou sélectionner des options"
         disabled={options.length === 0}
       />
     </FilterField>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePersonnes.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePersonnes.tsx
@@ -1,7 +1,12 @@
 import FilterField from 'ui/shared/filters/FilterField';
 import {TOption} from 'ui/shared/select/commons';
 import {MultiSelectFilter} from 'ui/shared/select/MultiSelectFilter';
-import {TFilters, TFiltreProps} from '../../FicheAction/data/filters';
+import {
+  SANS_PILOTE,
+  SANS_REFERENT,
+  TFilters,
+  TFiltreProps,
+} from '../../FicheAction/data/filters';
 import {getIsAllSelected, ITEM_ALL} from 'ui/shared/filters/commons';
 import {getPersonneId} from '../../FicheAction/data/utils';
 import {usePersonneListe} from '../../FicheAction/data/options/usePersonneListe';
@@ -31,14 +36,14 @@ const FiltrePersonnes = ({
 
   if (filterKey === 'pilotes') {
     options.push({
-      value: 'sans_pilote',
+      value: SANS_PILOTE,
       label: 'Sans pilote',
     });
   }
 
   if (filterKey === 'referents') {
     options.push({
-      value: 'sans_referent',
+      value: SANS_REFERENT,
       label: 'Sans élu·e référent·e',
     });
   }
@@ -56,14 +61,14 @@ const FiltrePersonnes = ({
   const values = (): string[] => {
     if (filterKey === 'pilotes') {
       if (filters.sans_pilote && filters.sans_pilote === 1) {
-        return ['sans_pilote'];
+        return [SANS_PILOTE];
       } else {
         return filters.pilotes || [];
       }
     }
     if (filterKey === 'referents') {
       if (filters.sans_referent && filters.sans_referent === 1) {
-        return ['sans_referent'];
+        return [SANS_REFERENT];
       } else {
         return filters.referents || [];
       }
@@ -92,7 +97,7 @@ const FiltrePersonnes = ({
       return {...newFilters};
     } else {
       if (filterKey === 'pilotes') {
-        if (newValues.includes('sans_pilote')) {
+        if (newValues.includes(SANS_PILOTE)) {
           if (filters.sans_pilote === 1) {
             delete newFilters.sans_pilote;
             return {...newFilters, [filterKey]: newPersonnes};
@@ -108,7 +113,7 @@ const FiltrePersonnes = ({
         }
       }
       if (filterKey === 'referents') {
-        if (newValues.includes('sans_referent')) {
+        if (newValues.includes(SANS_REFERENT)) {
           if (filters.sans_referent === 1) {
             delete newFilters.sans_referent;
             return {...newFilters, [filterKey]: newPersonnes};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePersonnes.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePersonnes.tsx
@@ -135,6 +135,7 @@ const FiltrePersonnes = ({
   return (
     <FilterField title={label}>
       <AutocompleteInputSelect
+        data-test={dataTest}
         containerWidthMatchButton
         dsfrButton={false}
         values={values()}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePriorites.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePriorites.tsx
@@ -1,34 +1,57 @@
 import FilterField from 'ui/shared/filters/FilterField';
 import {TOption} from 'ui/shared/select/commons';
 import {MultiSelectFilter} from 'ui/shared/select/MultiSelectFilter';
-import {TFiltreProps} from '../../FicheAction/data/filters';
+import {SANS_PRIORITE, TFiltreProps} from '../../FicheAction/data/filters';
 import {getIsAllSelected, ITEM_ALL} from 'ui/shared/filters/commons';
 import {ficheActionNiveauPrioriteOptions} from '../../FicheAction/data/options/listesStatiques';
+import {TFicheActionNiveauxPriorite} from 'types/alias';
 
 const FiltrePriorites = ({filters, setFilters}: TFiltreProps) => {
   // Initialisation du tableau d'options pour le multi-select
   const options: TOption[] = [
     {value: ITEM_ALL, label: 'Tous'},
+    {value: SANS_PRIORITE, label: 'Sans priorité'},
     ...ficheActionNiveauPrioriteOptions,
   ];
+
+  const selectPriorite = (newPriorites: string[]) => {
+    const newFilters = filters;
+    const priorites = newPriorites.filter(p => p !== SANS_PRIORITE);
+
+    if (getIsAllSelected(newPriorites)) {
+      delete newFilters.sans_niveau;
+      delete newFilters.priorites;
+      return {...newFilters};
+    } else if (newPriorites.includes(SANS_PRIORITE)) {
+      if (filters.sans_niveau === 1) {
+        delete newFilters.sans_niveau;
+        return {
+          ...newFilters,
+          priorites: priorites as TFicheActionNiveauxPriorite[],
+        };
+      } else {
+        delete newFilters.priorites;
+        return {...newFilters, sans_niveau: 1};
+      }
+    } else {
+      return {
+        ...newFilters,
+        priorites: priorites as TFicheActionNiveauxPriorite[],
+      };
+    }
+  };
 
   return (
     <FilterField title="Niveau de priorité">
       <MultiSelectFilter
         data-test="filtre-priorite"
-        values={filters.priorites}
+        values={
+          filters.sans_niveau && filters.sans_niveau === 1
+            ? [SANS_PRIORITE]
+            : filters.priorites
+        }
         options={options}
-        onSelect={newValues => {
-          // onClick "tous" ou toggle option
-          if (getIsAllSelected(newValues)) {
-            const newFilters = filters;
-            delete newFilters.priorites;
-            setFilters({...newFilters});
-            // d'une option à l'autre
-          } else {
-            setFilters({...filters, priorites: newValues});
-          }
-        }}
+        onSelect={newValues => setFilters(selectPriorite(newValues))}
         placeholderText="Sélectionner des options"
         disabled={options.length === 0}
       />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePriorites.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/FiltrePriorites.tsx
@@ -10,7 +10,7 @@ const FiltrePriorites = ({filters, setFilters}: TFiltreProps) => {
   // Initialisation du tableau d'options pour le multi-select
   const options: TOption[] = [
     {value: ITEM_ALL, label: 'Tous'},
-    {value: SANS_PRIORITE, label: 'Sans priorité'},
+    {value: SANS_PRIORITE, label: 'Non priorisé'},
     ...ficheActionNiveauPrioriteOptions,
   ];
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/PlanActionFiltres.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/PlanActionFiltres.tsx
@@ -6,6 +6,8 @@ import PlanActionFiltresResultats from './PlanActionFiltresResultats';
 import {useFichesActionFiltresListe} from '../../FicheAction/data/useFichesActionFiltresListe';
 import {PlanNode} from '../data/types';
 import {useEffect, useState} from 'react';
+import {TFilters} from '../../FicheAction/data/filters';
+import {useCollectiviteId} from 'core-logic/hooks/params';
 
 type Props = {
   plan: PlanNode;
@@ -14,8 +16,21 @@ type Props = {
 };
 
 const PlanActionFiltres = ({plan, axe, setIsFiltered}: Props) => {
+  const collectivite_id = useCollectiviteId();
+
   const [filtered, setFiltered] = useState(false);
-  const filters = useFichesActionFiltresListe({plan, axe});
+
+  const initialFilters: TFilters = {
+    collectivite_id: collectivite_id!,
+    axes: [axe ? axe.id : plan.id],
+  };
+
+  const filters = useFichesActionFiltresListe({
+    url: axe
+      ? `/collectivite/${collectivite_id}/plans/plan/${plan.id}/${axe.id}`
+      : `/collectivite/${collectivite_id}/plans/plan/${plan.id}`,
+    initialFilters,
+  });
 
   // On prend à partir de 2 éléments car les filtres "collectivite_id" et "plan/axe id" sont des constantes
   // Et on le passe au parent pour afficher le plan ou les filtres

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/PlanActionFiltresAccordeon.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/PlanActionFiltresAccordeon.tsx
@@ -23,7 +23,7 @@ const PlanActionFiltresAccordeon = ({plan, axe, setIsFiltered}: Props) => {
     axe
       ? `/collectivite/${collectivite_id}/plans/plan/${plan.id}/${axe.id}`
       : `/collectivite/${collectivite_id}/plans/plan/${plan.id}`,
-    {collectivite_id: collectivite_id!, axes_id: [axe ? axe.id : plan.id]},
+    {collectivite_id: collectivite_id!, axes: [axe ? axe.id : plan.id]},
     nameToShortNames
   );
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/PlanActionFiltresAccordeon.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/PlanActionFiltres/PlanActionFiltresAccordeon.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 
 import {AccordionControlled} from 'ui/Accordion';
 import PlanActionFiltres from './PlanActionFiltres';
@@ -17,10 +17,6 @@ type Props = {
 const PlanActionFiltresAccordeon = ({plan, axe, setIsFiltered}: Props) => {
   const collectivite_id = useCollectiviteId();
 
-  // Stock l'état d'ouverture de l'accordéon afin d'afficher ou non la liste les filtres
-  // et donc prévenir l'appel à la base s'il n'est pas ouvert
-  const [isOpen, setIsOpen] = useState(false);
-
   // on utilise les params pour savoir si l'URL contient des filtres et
   // ainsi afficher l'accordéon ouvert ou non au montage de la page
   const [filters] = useSearchParams<TFilters>(
@@ -33,7 +29,9 @@ const PlanActionFiltresAccordeon = ({plan, axe, setIsFiltered}: Props) => {
 
   const isFiltered = filters && Object.keys(filters).length > 2;
 
-  useEffect(() => setIsOpen(isFiltered), []);
+  // Stock l'état d'ouverture de l'accordéon afin d'afficher ou non la liste les filtres
+  // et donc prévenir l'appel à la base s'il n'est pas ouvert
+  const [isOpen, setIsOpen] = useState(isFiltered);
 
   return (
     <AccordionControlled

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlansActionsRoutes.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlansActionsRoutes.tsx
@@ -14,11 +14,13 @@ import {
   collectivitePlansActionsImporterPath,
   collectivitePlansActionsNouveauPath,
   collectivitePlansActionsSynthesePath,
+  collectivitePlansActionsSyntheseVuePath,
 } from 'app/paths';
 import {SynthesePage} from './Synthese/SynthesePage';
 import {SelectionPage} from './ParcoursCreationPlan/SelectionPage';
 import {ImporterPlanPage} from './ParcoursCreationPlan/ImporterPlanPage';
 import {CreerPlanPage} from './ParcoursCreationPlan/CreerPlanPage';
+import {SyntheseVuePage} from './Synthese/SyntheseVue/SyntheseVuePage';
 
 type Props = {
   collectivite_id: number;
@@ -43,6 +45,9 @@ export const PlansActionsRoutes = ({collectivite_id}: Props) => {
       {/* Synthèse */}
       <Route exact path={[collectivitePlansActionsSynthesePath]}>
         <SynthesePage collectiviteId={collectivite_id} />
+      </Route>
+      <Route exact path={[collectivitePlansActionsSyntheseVuePath]}>
+        <SyntheseVuePage />
       </Route>
       {/* <FichesNonClassees /> */}
       <Route exact path={[collectiviteFichesNonClasseesPath]}>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlansActionsRoutes.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlansActionsRoutes.tsx
@@ -1,4 +1,4 @@
-import {Redirect, Route} from 'react-router-dom';
+import {Route} from 'react-router-dom';
 
 import {FicheActionPage} from 'app/pages/collectivite/PlansActions/FicheAction/FicheActionPage';
 import {PlanActionPage} from './PlanAction/PlanActionPage';
@@ -10,12 +10,10 @@ import {
   collectivitePlanActionAxePath,
   collectivitePlanActionFichePath,
   collectivitePlanActionPath,
-  collectivitePlansActionsBasePath,
   collectivitePlansActionsCreerPath,
   collectivitePlansActionsImporterPath,
   collectivitePlansActionsNouveauPath,
   collectivitePlansActionsSynthesePath,
-  makeCollectivitePlansActionsSyntheseUrl,
 } from 'app/paths';
 import {SynthesePage} from './Synthese/SynthesePage';
 import {SelectionPage} from './ParcoursCreationPlan/SelectionPage';
@@ -32,14 +30,6 @@ type Props = {
 export const PlansActionsRoutes = ({collectivite_id}: Props) => {
   return (
     <>
-      <Route exact path={[collectivitePlansActionsBasePath]}>
-        {/* Redirection vers la page de synthèse */}
-        <Redirect
-          to={makeCollectivitePlansActionsSyntheseUrl({
-            collectiviteId: collectivite_id,
-          })}
-        />
-      </Route>
       {/* Création */}
       <Route exact path={collectivitePlansActionsNouveauPath}>
         <SelectionPage />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/FiltersPlanAction.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/FiltersPlanAction.tsx
@@ -3,6 +3,7 @@ import {useFichesNonClasseesListe} from '../FicheAction/data/useFichesNonClassee
 import {usePlansActionsListe} from '../PlanAction/data/usePlansActionsListe';
 import {generateTitle} from '../FicheAction/data/utils';
 import {ITEM_ALL} from 'ui/shared/filters/commons';
+import {useEffect} from 'react';
 
 export type PlanActionFilter = {id: number | 'nc' | 'tous'; name: string};
 export const filtreToutesLesFiches: PlanActionFilter = {
@@ -25,12 +26,14 @@ export const filtreFichesNonClassees: PlanActionFilter = {
 type FiltersPlanActionProps = {
   collectiviteId: number;
   initialPlan?: string;
+  getInitialPlan?: (plan: PlanActionFilter) => void;
   onChangePlan: ({id, name}: PlanActionFilter) => void;
 };
 
 const FiltersPlanAction = ({
   collectiviteId,
   initialPlan,
+  getInitialPlan,
   onChangePlan,
 }: FiltersPlanActionProps): JSX.Element => {
   const plansActions = usePlansActionsListe(collectiviteId);
@@ -60,22 +63,25 @@ const FiltersPlanAction = ({
     });
   }
 
-  // Mise à jour des filtres sélectionnés
-  const handleChangeFilter = (value: string) => {
+  const generatePlan = (value: string): PlanActionFilter => {
     // Toutes les fiches
     if (value === ITEM_ALL) {
-      onChangePlan(filtreToutesLesFiches);
+      return filtreToutesLesFiches;
       // Fiches non classées
     } else if (value === 'nc') {
-      onChangePlan(filtreFichesNonClassees);
+      return filtreFichesNonClassees;
       // Les plans d'action
     } else {
-      onChangePlan({
+      return {
         id: parseInt(value),
-        name: filters.filter(f => f.value === value)[0].label,
-      });
+        name: filters.filter(f => f.value === value)[0]?.label ?? '',
+      };
     }
   };
+
+  useEffect(() => {
+    initialPlan && getInitialPlan && getInitialPlan(generatePlan(initialPlan));
+  }, []);
 
   return (
     // Filtres affichés si plus d'un plan d'action défini
@@ -84,7 +90,7 @@ const FiltersPlanAction = ({
         defaultOption={initialPlan}
         name="plans_actions"
         options={filters}
-        onChange={handleChangeFilter}
+        onChange={value => onChangePlan(generatePlan(value))}
       />
     ) : (
       <></>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/FiltersPlanAction.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/FiltersPlanAction.tsx
@@ -2,6 +2,17 @@ import TagFilters from 'ui/shared/filters/TagFilters';
 import {useFichesNonClasseesListe} from '../FicheAction/data/useFichesNonClasseesListe';
 import {usePlansActionsListe} from '../PlanAction/data/usePlansActionsListe';
 import {generateTitle} from '../FicheAction/data/utils';
+import {ITEM_ALL} from 'ui/shared/filters/commons';
+
+export type PlanActionFilter = {id: number | 'nc' | 'tous'; name: string};
+export const filtreToutesLesFiches: PlanActionFilter = {
+  id: ITEM_ALL,
+  name: 'Toutes les fiches',
+};
+export const filtreFichesNonClassees: PlanActionFilter = {
+  id: 'nc',
+  name: 'Fiches non classées',
+};
 
 /**
  * Filtres tags par plan d'action
@@ -13,20 +24,25 @@ import {generateTitle} from '../FicheAction/data/utils';
 
 type FiltersPlanActionProps = {
   collectiviteId: number;
-  onChangePlan: ({id, name}: {id: number | null; name: string}) => void;
-  onChangeWithoutPlan: (value: boolean | null) => void;
+  initialPlan?: string;
+  onChangePlan: ({id, name}: PlanActionFilter) => void;
 };
 
 const FiltersPlanAction = ({
   collectiviteId,
+  initialPlan,
   onChangePlan,
-  onChangeWithoutPlan,
 }: FiltersPlanActionProps): JSX.Element => {
   const plansActions = usePlansActionsListe(collectiviteId);
   const fichesNonClassees = useFichesNonClasseesListe(collectiviteId);
 
   // Construction de la liste de filtres par plan d'action
-  const filters = [{value: 'default', label: 'Toutes les fiches'}];
+  const filters = [
+    {
+      value: filtreToutesLesFiches.id?.toString(),
+      label: filtreToutesLesFiches.name,
+    },
+  ];
 
   if (plansActions?.plans && plansActions.plans.length) {
     filters.push(
@@ -39,25 +55,25 @@ const FiltersPlanAction = ({
 
   if (fichesNonClassees?.fiches && fichesNonClassees.fiches.length > 0) {
     filters.push({
-      value: 'nc',
-      label: 'Fiches non classées',
+      value: filtreFichesNonClassees.id.toString(),
+      label: filtreFichesNonClassees.name,
     });
   }
 
   // Mise à jour des filtres sélectionnés
   const handleChangeFilter = (id: string) => {
-    if (id === 'default') {
-      onChangePlan({id: null, name: 'Toutes les fiches'});
-      onChangeWithoutPlan(null);
+    // Toutes les fiches
+    if (id === ITEM_ALL) {
+      onChangePlan(filtreToutesLesFiches);
+      // Fiches non classées
     } else if (id === 'nc') {
-      onChangePlan({id: null, name: 'Fiches non classées'});
-      onChangeWithoutPlan(true);
+      onChangePlan(filtreFichesNonClassees);
+      // Les plans d'action
     } else {
       onChangePlan({
         id: parseInt(id),
         name: filters.filter(f => f.value === id)[0].label,
       });
-      onChangeWithoutPlan(false);
     }
   };
 
@@ -65,9 +81,9 @@ const FiltersPlanAction = ({
     // Filtres affichés si plus d'un plan d'action défini
     filters.length > 2 ? (
       <TagFilters
+        defaultOption={initialPlan}
         name="plans_actions"
         options={filters}
-        className="pb-10"
         onChange={handleChangeFilter}
       />
     ) : (

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/FiltersPlanAction.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/FiltersPlanAction.tsx
@@ -61,18 +61,18 @@ const FiltersPlanAction = ({
   }
 
   // Mise à jour des filtres sélectionnés
-  const handleChangeFilter = (id: string) => {
+  const handleChangeFilter = (value: string) => {
     // Toutes les fiches
-    if (id === ITEM_ALL) {
+    if (value === ITEM_ALL) {
       onChangePlan(filtreToutesLesFiches);
       // Fiches non classées
-    } else if (id === 'nc') {
+    } else if (value === 'nc') {
       onChangePlan(filtreFichesNonClassees);
       // Les plans d'action
     } else {
       onChangePlan({
-        id: parseInt(id),
-        name: filters.filter(f => f.value === id)[0].label,
+        id: parseInt(value),
+        name: filters.filter(f => f.value === value)[0].label,
       });
     }
   };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/Synthese.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/Synthese.tsx
@@ -26,7 +26,10 @@ const Synthese = ({collectiviteId}: SyntheseProps): JSX.Element => {
   return (
     <div className="w-full">
       <HeaderTitle
-        type="plan"
+        customClass={{
+          container: 'bg-indigo-200',
+          text: 'text-[2rem] text-gray-800 placeholder:text-gray-800 focus:placeholder:text-gray-500 disabled:text-gray-800',
+        }}
         titre="Synthèse des fiches action"
         isReadonly={true}
       />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/Synthese.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/Synthese.tsx
@@ -1,6 +1,9 @@
 import {useState} from 'react';
 import HeaderTitle from '../components/HeaderTitle';
-import FiltersPlanAction from './FiltersPlanAction';
+import FiltersPlanAction, {
+  PlanActionFilter,
+  filtreToutesLesFiches,
+} from './FiltersPlanAction';
 import SyntheseGraphsList from './SyntheseGraphsList';
 import {useCurrentCollectivite} from 'core-logic/hooks/useCurrentCollectivite';
 
@@ -17,11 +20,9 @@ type SyntheseProps = {
 const Synthese = ({collectiviteId}: SyntheseProps): JSX.Element => {
   const collectivite = useCurrentCollectivite();
 
-  const [selectedPlan, setSelectedPlan] = useState<{
-    id: number | null;
-    name: string;
-  }>({id: null, name: 'Toutes les fiches'});
-  const [withoutPlan, setWithoutPlan] = useState<boolean | null>(null);
+  const [selectedPlan, setSelectedPlan] = useState<PlanActionFilter>(
+    filtreToutesLesFiches
+  );
 
   return (
     <div className="w-full">
@@ -34,18 +35,19 @@ const Synthese = ({collectiviteId}: SyntheseProps): JSX.Element => {
         isReadonly={true}
       />
       <div className="max-w-4xl mx-auto p-10">
-        {/* Filtres par plan d'actions */}
-        <FiltersPlanAction
-          collectiviteId={collectiviteId}
-          onChangePlan={setSelectedPlan}
-          onChangeWithoutPlan={setWithoutPlan}
-        />
+        <div className="mb-6">
+          {/* Filtres par plan d'actions */}
+          <FiltersPlanAction
+            collectiviteId={collectiviteId}
+            onChangePlan={setSelectedPlan}
+          />
+        </div>
 
         {/* Graphes répartition des fiches */}
         <SyntheseGraphsList
           collectiviteId={collectiviteId}
           selectedPlan={selectedPlan}
-          withoutPlan={withoutPlan}
+          withoutPlan={selectedPlan.id === 'nc'}
           isReadonly={collectivite?.readonly ?? true}
         />
       </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
@@ -50,6 +50,7 @@ const SyntheseGraphsList = ({
           !!graph.data.length && (
             <div key={graph.title} className="fr-col-sm-12 fr-col-xl-6">
               <Link
+                data-test={`lien-graph-${graph.id}`}
                 className="group fr-col-sm-12 fr-col-xl-6 hover:bg-gray-100"
                 to={`${makeCollectivitePlansActionsSyntheseVueUrl({
                   collectiviteId,

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
@@ -8,7 +8,7 @@ import {
   makeCollectivitePlansActionsSyntheseVueUrl,
 } from 'app/paths';
 import {PlanActionFilter} from './FiltersPlanAction';
-import {generateGraphData} from './utils';
+import {generateSyntheseGraphData} from './utils';
 
 const getLegendColor = (
   data: {id: string; value: number; color?: any},
@@ -93,7 +93,7 @@ const SyntheseGraphsList = ({
 
   return data ? (
     <div className="fr-grid-row fr-grid-row--gutters">
-      {generateGraphData(data).map(
+      {generateSyntheseGraphData(data).map(
         graph =>
           !!graph.data.length && (
             <div key={graph.title} className="fr-col-sm-12 fr-col-xl-6">

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
@@ -7,7 +7,7 @@ import {
   makeCollectivitePlansActionsSyntheseVueUrl,
 } from 'app/paths';
 import {PlanActionFilter} from './FiltersPlanAction';
-import {generateSyntheseGraphData, getCustomLegend} from './utils';
+import {generateSyntheseGraphData} from './utils';
 
 type SyntheseGraphsListProps = {
   collectiviteId: number;
@@ -49,22 +49,9 @@ const SyntheseGraphsList = ({
         graph =>
           !!graph.data.length && (
             <div key={graph.title} className="fr-col-sm-12 fr-col-xl-6">
-              <ChartCard
-                chartType="donut"
-                chartProps={{
-                  data: graph.data,
-                  label: graph.id === 'statuts' || graph.id === 'priorites',
-                }}
-                chartInfo={{
-                  title: graph.title,
-                  extendedTitle: `${selectedPlan.name} - ${graph.title}`,
-                  legend: getCustomLegend(graph.data),
-                  expandable: true,
-                  downloadedFileName: `repartition-${
-                    graph.id
-                  }-${selectedPlan.name.toLowerCase().split(' ').join('-')}`,
-                }}
-                link={`${makeCollectivitePlansActionsSyntheseVueUrl({
+              <Link
+                className="group fr-col-sm-12 fr-col-xl-6 hover:bg-gray-100"
+                to={`${makeCollectivitePlansActionsSyntheseVueUrl({
                   collectiviteId,
                   vue: graph.id,
                 })}${
@@ -72,8 +59,20 @@ const SyntheseGraphsList = ({
                     ? `?axes=${selectedPlan.id}`
                     : ''
                 }`}
-                customStyle={{height: '350px', borderBottomWidth: '4px'}}
-              />
+              >
+                <ChartCard
+                  chartType="donut"
+                  chartProps={{
+                    data: graph.data,
+                    label: graph.id === 'statuts' || graph.id === 'priorites',
+                  }}
+                  chartInfo={{
+                    title: graph.title,
+                  }}
+                  customStyle={{height: '350px', borderBottomWidth: '4px'}}
+                  classNames="group-hover:bg-gray-50"
+                />
+              </Link>
             </div>
           )
       )}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
@@ -8,6 +8,7 @@ import {
 } from 'app/paths';
 import {PlanActionFilter} from './FiltersPlanAction';
 import {generateSyntheseGraphData} from './utils';
+import classNames from 'classnames';
 
 type SyntheseGraphsListProps = {
   collectiviteId: number;
@@ -51,15 +52,21 @@ const SyntheseGraphsList = ({
             <div key={graph.title} className="fr-col-sm-12 fr-col-xl-6">
               <Link
                 data-test={`lien-graph-${graph.id}`}
-                className="group fr-col-sm-12 fr-col-xl-6 hover:bg-gray-100"
-                to={`${makeCollectivitePlansActionsSyntheseVueUrl({
-                  collectiviteId,
-                  vue: graph.id,
-                })}${
-                  typeof selectedPlan.id === 'number'
-                    ? `?axes=${selectedPlan.id}`
-                    : ''
-                }`}
+                className={classNames('group fr-col-sm-12 fr-col-xl-6', {
+                  'cursor-default': graph.id === 'echeance',
+                })}
+                to={
+                  graph.id === 'echeance'
+                    ? '#'
+                    : `${makeCollectivitePlansActionsSyntheseVueUrl({
+                        collectiviteId,
+                        vue: graph.id,
+                      })}${
+                        typeof selectedPlan.id === 'number'
+                          ? `?axes=${selectedPlan.id}`
+                          : ''
+                      }`
+                }
               >
                 <ChartCard
                   chartType="donut"
@@ -71,7 +78,9 @@ const SyntheseGraphsList = ({
                     title: graph.title,
                   }}
                   customStyle={{height: '350px', borderBottomWidth: '4px'}}
-                  classNames="group-hover:bg-gray-50"
+                  classNames={classNames({
+                    'group-hover:bg-gray-50': graph.id !== 'echeance',
+                  })}
                 />
               </Link>
             </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseGraphsList.tsx
@@ -1,4 +1,3 @@
-import {defaultColors, nivoColorsSet} from 'ui/charts/chartsTheme';
 import {usePlanActionTableauDeBord} from './data/usePlanActionTableauDeBord';
 import PictoLeaf from 'ui/pictogrammes/PictoLeaf';
 import ChartCard from 'ui/charts/ChartCard';
@@ -8,54 +7,7 @@ import {
   makeCollectivitePlansActionsSyntheseVueUrl,
 } from 'app/paths';
 import {PlanActionFilter} from './FiltersPlanAction';
-import {generateSyntheseGraphData} from './utils';
-
-const getLegendColor = (
-  data: {id: string; value: number; color?: any},
-  dataLength: number,
-  index: number
-) => {
-  if (data.color) {
-    return data.color;
-  }
-  if (dataLength <= defaultColors.length) {
-    return defaultColors[index % defaultColors.length];
-  }
-  return nivoColorsSet[index % nivoColorsSet.length];
-};
-
-const getCustomLegend = (data: {id: string; value: number; color?: any}[]) => {
-  // Limitation du nombre d'éléments visibles dans la légende
-  const legendMaxSize = 9;
-
-  // Légendes associées au données sans label
-  const withoutLabelLegends = [
-    'Sans statut',
-    'Sans pilote',
-    'Sans élu·e référent·e',
-    'Non priorisé',
-  ];
-
-  // Légende réduite à afficher
-  const legend = data.slice(0, legendMaxSize).map((d, index) => ({
-    name: d.id,
-    color: getLegendColor(d, data.length, index),
-  }));
-
-  const lastElement = data[data.length - 1];
-
-  if (
-    withoutLabelLegends.includes(lastElement.id) &&
-    data.length > legendMaxSize
-  ) {
-    legend.push({
-      name: lastElement.id,
-      color: getLegendColor(lastElement, data.length, data.length - 1),
-    });
-  }
-
-  return legend;
-};
+import {generateSyntheseGraphData, getCustomLegend} from './utils';
 
 type SyntheseGraphsListProps = {
   collectiviteId: number;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimaireEcheance.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimaireEcheance.tsx
@@ -1,0 +1,40 @@
+import TagFilters from 'ui/shared/filters/TagFilters';
+import {ITEM_ALL} from 'ui/shared/filters/commons';
+import {ficheActionEcheanceOptions} from '../../../FicheAction/data/options/listesStatiques';
+import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
+import {TFicheActionEcheances} from 'types/alias';
+
+type Props = {
+  filtersOptions: TFichesActionsListe;
+};
+
+const FiltrePrimaireEcheance = ({filtersOptions}: Props) => {
+  const {filters, setFilters} = filtersOptions;
+
+  const selectEcheance = (echeance: string) => {
+    const newFilters = filters;
+    if (echeance === ITEM_ALL) {
+      delete newFilters.echeance;
+      return {...newFilters};
+    } else {
+      return {
+        ...newFilters,
+        echeance: echeance as TFicheActionEcheances,
+      };
+    }
+  };
+
+  return (
+    <TagFilters
+      defaultOption={filters.echeance}
+      name="echeances"
+      options={[
+        {value: ITEM_ALL, label: 'Toutes les échéances'},
+        ...ficheActionEcheanceOptions,
+      ]}
+      onChange={echeance => setFilters(selectEcheance(echeance))}
+    />
+  );
+};
+
+export default FiltrePrimaireEcheance;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePersonne.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePersonne.tsx
@@ -1,0 +1,90 @@
+import TagFilters from 'ui/shared/filters/TagFilters';
+import {ITEM_ALL, getIsAllSelected} from 'ui/shared/filters/commons';
+import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
+import {usePersonneListe} from '../../../FicheAction/data/options/usePersonneListe';
+import {TOption} from 'ui/shared/select/commons';
+import {getPersonneId} from '../../../FicheAction/data/utils';
+
+type Props = {
+  filterKey: 'pilotes' | 'referents';
+  filtersOptions: TFichesActionsListe;
+};
+
+const FiltrePrimairePersonne = ({filterKey, filtersOptions}: Props) => {
+  const {filters, setFilters} = filtersOptions;
+  const {data: personnes} = usePersonneListe();
+
+  // Initialisation du tableau d'options pour le multi-select
+  const options: TOption[] = [];
+
+  // Ajoute l'option "Tous" s'il y a plus d'une option
+  if (personnes && personnes.length > 1) {
+    options.push({
+      value: ITEM_ALL,
+      label: `Tous les personnes ${
+        (filterKey === 'pilotes' && 'pilotes') ||
+        (filterKey === 'referents' && 'référentes')
+      }`,
+    });
+  }
+
+  // Transformation et ajout des personnes aux options
+  personnes &&
+    personnes.forEach(personne =>
+      options.push({
+        value: getPersonneId(personne),
+        label: personne.nom!,
+      })
+    );
+
+  // Renvoie la bonne valeur en fonction du filtre personne utlisé
+  const getDefaultOption = () => {
+    if (filterKey === 'pilotes' && filters.pilotes) {
+      return filters.pilotes[0];
+    }
+    if (filterKey === 'pilotes' && filters.referents) {
+      return filters.referents[0];
+    }
+    return ITEM_ALL;
+  };
+
+  // onSelect en fonction du filtre personne utilisé
+  const onChange = (value: string) => {
+    // onClick "tous" ou toggle option
+    if (getIsAllSelected([value])) {
+      const newFilters = filters;
+      if (filterKey === 'referents') {
+        delete newFilters.referents;
+      }
+      if (filterKey === 'pilotes') {
+        delete newFilters.pilotes;
+      }
+      setFilters({...newFilters});
+      // d'une option à l'autre
+    } else {
+      if (filterKey === 'referents') {
+        setFilters({
+          ...filters,
+          referents: [value],
+        });
+      }
+      if (filterKey === 'pilotes') {
+        setFilters({
+          ...filters,
+          pilotes: [value],
+        });
+      }
+    }
+  };
+
+  return (
+    <TagFilters
+      defaultOption={getDefaultOption()}
+      name={filterKey}
+      options={options}
+      onChange={onChange}
+    />
+  );
+};
+
+export default FiltrePrimairePersonne;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePersonne.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePersonne.tsx
@@ -1,5 +1,5 @@
 import TagFilters from 'ui/shared/filters/TagFilters';
-import {ITEM_ALL, getIsAllSelected} from 'ui/shared/filters/commons';
+import {ITEM_ALL} from 'ui/shared/filters/commons';
 import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
 import {usePersonneListe} from '../../../FicheAction/data/options/usePersonneListe';
 import {TOption} from 'ui/shared/select/commons';
@@ -21,9 +21,9 @@ const FiltrePrimairePersonne = ({filterKey, filtersOptions}: Props) => {
   if (personnes && personnes.length > 1) {
     options.push({
       value: ITEM_ALL,
-      label: `Tous les personnes ${
-        (filterKey === 'pilotes' && 'pilotes') ||
-        (filterKey === 'referents' && 'référentes')
+      label: `${
+        (filterKey === 'pilotes' && 'Toutes les personnes pilotes') ||
+        (filterKey === 'referents' && 'Tou·tes les élu·es référent·es')
       }`,
     });
   }
@@ -37,12 +37,32 @@ const FiltrePrimairePersonne = ({filterKey, filtersOptions}: Props) => {
       })
     );
 
+  if (filterKey === 'pilotes') {
+    options.push({
+      value: 'sans_pilote',
+      label: 'Sans pilote',
+    });
+  }
+
+  if (filterKey === 'referents') {
+    options.push({
+      value: 'sans_referent',
+      label: 'Sans élu·e référent·e',
+    });
+  }
+
   // Renvoie la bonne valeur en fonction du filtre personne utlisé
   const getDefaultOption = () => {
+    if (filters.sans_pilote) {
+      return 'sans_pilote';
+    }
+    if (filters.sans_referent) {
+      return 'sans_referent';
+    }
     if (filterKey === 'pilotes' && filters.pilotes) {
       return filters.pilotes[0];
     }
-    if (filterKey === 'pilotes' && filters.referents) {
+    if (filterKey === 'referents' && filters.referents) {
       return filters.referents[0];
     }
     return ITEM_ALL;
@@ -50,30 +70,30 @@ const FiltrePrimairePersonne = ({filterKey, filtersOptions}: Props) => {
 
   // onSelect en fonction du filtre personne utilisé
   const onChange = (value: string) => {
-    // onClick "tous" ou toggle option
-    if (getIsAllSelected([value])) {
-      const newFilters = filters;
+    const newFilters = filters;
+    if (value === 'tous') {
+      delete newFilters.sans_pilote;
+      delete newFilters.sans_referent;
       if (filterKey === 'referents') {
         delete newFilters.referents;
       }
       if (filterKey === 'pilotes') {
         delete newFilters.pilotes;
       }
-      setFilters({...newFilters});
-      // d'une option à l'autre
+      return {...newFilters};
+    } else if (value === 'sans_pilote') {
+      delete newFilters.pilotes;
+      return {...newFilters, sans_pilote: 1};
+    } else if (value === 'sans_referent') {
+      delete newFilters.referents;
+      return {...newFilters, sans_referent: 1};
     } else {
-      if (filterKey === 'referents') {
-        setFilters({
-          ...filters,
-          referents: [value],
-        });
-      }
-      if (filterKey === 'pilotes') {
-        setFilters({
-          ...filters,
-          pilotes: [value],
-        });
-      }
+      delete newFilters.sans_pilote;
+      delete newFilters.sans_referent;
+      return {
+        ...newFilters,
+        [filterKey]: [value],
+      };
     }
   };
 
@@ -82,7 +102,7 @@ const FiltrePrimairePersonne = ({filterKey, filtersOptions}: Props) => {
       defaultOption={getDefaultOption()}
       name={filterKey}
       options={options}
-      onChange={onChange}
+      onChange={value => setFilters(onChange(value))}
     />
   );
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePersonne.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePersonne.tsx
@@ -4,6 +4,7 @@ import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFilt
 import {usePersonneListe} from '../../../FicheAction/data/options/usePersonneListe';
 import {TOption} from 'ui/shared/select/commons';
 import {getPersonneId} from '../../../FicheAction/data/utils';
+import {SANS_PILOTE, SANS_REFERENT} from '../../../FicheAction/data/filters';
 
 type Props = {
   filterKey: 'pilotes' | 'referents';
@@ -28,6 +29,20 @@ const FiltrePrimairePersonne = ({filterKey, filtersOptions}: Props) => {
     });
   }
 
+  if (filterKey === 'pilotes') {
+    options.push({
+      value: SANS_PILOTE,
+      label: 'Sans pilote',
+    });
+  }
+
+  if (filterKey === 'referents') {
+    options.push({
+      value: SANS_REFERENT,
+      label: 'Sans élu·e référent·e',
+    });
+  }
+
   // Transformation et ajout des personnes aux options
   personnes &&
     personnes.forEach(personne =>
@@ -37,27 +52,13 @@ const FiltrePrimairePersonne = ({filterKey, filtersOptions}: Props) => {
       })
     );
 
-  if (filterKey === 'pilotes') {
-    options.push({
-      value: 'sans_pilote',
-      label: 'Sans pilote',
-    });
-  }
-
-  if (filterKey === 'referents') {
-    options.push({
-      value: 'sans_referent',
-      label: 'Sans élu·e référent·e',
-    });
-  }
-
   // Renvoie la bonne valeur en fonction du filtre personne utlisé
   const getDefaultOption = () => {
     if (filters.sans_pilote) {
-      return 'sans_pilote';
+      return SANS_PILOTE;
     }
     if (filters.sans_referent) {
-      return 'sans_referent';
+      return SANS_REFERENT;
     }
     if (filterKey === 'pilotes' && filters.pilotes) {
       return filters.pilotes[0];
@@ -81,10 +82,10 @@ const FiltrePrimairePersonne = ({filterKey, filtersOptions}: Props) => {
         delete newFilters.pilotes;
       }
       return {...newFilters};
-    } else if (value === 'sans_pilote') {
+    } else if (value === SANS_PILOTE) {
       delete newFilters.pilotes;
       return {...newFilters, sans_pilote: 1};
-    } else if (value === 'sans_referent') {
+    } else if (value === SANS_REFERENT) {
       delete newFilters.referents;
       return {...newFilters, sans_referent: 1};
     } else {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePriorites.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePriorites.tsx
@@ -1,0 +1,41 @@
+import TagFilters from 'ui/shared/filters/TagFilters';
+import {ITEM_ALL, getIsAllSelected} from 'ui/shared/filters/commons';
+import {ficheActionNiveauPrioriteOptions} from '../../../FicheAction/data/options/listesStatiques';
+import {TFicheActionNiveauxPriorite} from 'types/alias';
+import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
+
+type Props = {
+  filtersOptions: TFichesActionsListe;
+};
+
+const FiltrePrimairePriorites = ({filtersOptions}: Props) => {
+  return (
+    <TagFilters
+      defaultOption={
+        filtersOptions.filters.priorites
+          ? filtersOptions.filters.priorites[0]
+          : ITEM_ALL
+      }
+      name="priorites"
+      options={[
+        {value: ITEM_ALL, label: 'Tous les niveaux de priorité'},
+        ...ficheActionNiveauPrioriteOptions,
+      ]}
+      onChange={priorite => {
+        if (getIsAllSelected([priorite])) {
+          const newFilters = filtersOptions.filters;
+          delete newFilters.priorites;
+          filtersOptions.setFilters({...newFilters});
+          // d'une option à l'autre
+        } else {
+          filtersOptions.setFilters({
+            ...filtersOptions.filters,
+            priorites: [priorite as TFicheActionNiveauxPriorite],
+          });
+        }
+      }}
+    />
+  );
+};
+
+export default FiltrePrimairePriorites;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePriorites.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePriorites.tsx
@@ -1,39 +1,55 @@
 import TagFilters from 'ui/shared/filters/TagFilters';
-import {ITEM_ALL, getIsAllSelected} from 'ui/shared/filters/commons';
+import {ITEM_ALL} from 'ui/shared/filters/commons';
 import {ficheActionNiveauPrioriteOptions} from '../../../FicheAction/data/options/listesStatiques';
 import {TFicheActionNiveauxPriorite} from 'types/alias';
 import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
+import {SANS_PRIORITE} from '../../../FicheAction/data/filters';
 
 type Props = {
   filtersOptions: TFichesActionsListe;
 };
 
 const FiltrePrimairePriorites = ({filtersOptions}: Props) => {
+  const {filters, setFilters} = filtersOptions;
+
+  const getDefaultOption = () => {
+    if (filters.sans_niveau) {
+      return SANS_PRIORITE;
+    }
+    if (filters.priorites) {
+      return filters.priorites[0];
+    }
+    return ITEM_ALL;
+  };
+
+  const selectPriorite = (priorite: string) => {
+    const newFilters = filters;
+    if (priorite === ITEM_ALL) {
+      delete newFilters.sans_niveau;
+      delete newFilters.priorites;
+      return {...newFilters};
+    } else if (priorite === SANS_PRIORITE) {
+      delete newFilters.priorites;
+      return {...newFilters, sans_niveau: 1};
+    } else {
+      delete newFilters.sans_niveau;
+      return {
+        ...newFilters,
+        priorites: [priorite as TFicheActionNiveauxPriorite],
+      };
+    }
+  };
+
   return (
     <TagFilters
-      defaultOption={
-        filtersOptions.filters.priorites
-          ? filtersOptions.filters.priorites[0]
-          : ITEM_ALL
-      }
+      defaultOption={getDefaultOption()}
       name="priorites"
       options={[
         {value: ITEM_ALL, label: 'Tous les niveaux de priorité'},
+        {value: SANS_PRIORITE, label: 'Sans priorité'},
         ...ficheActionNiveauPrioriteOptions,
       ]}
-      onChange={priorite => {
-        if (getIsAllSelected([priorite])) {
-          const newFilters = filtersOptions.filters;
-          delete newFilters.priorites;
-          filtersOptions.setFilters({...newFilters});
-          // d'une option à l'autre
-        } else {
-          filtersOptions.setFilters({
-            ...filtersOptions.filters,
-            priorites: [priorite as TFicheActionNiveauxPriorite],
-          });
-        }
-      }}
+      onChange={priorite => setFilters(selectPriorite(priorite))}
     />
   );
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePriorites.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimairePriorites.tsx
@@ -46,7 +46,7 @@ const FiltrePrimairePriorites = ({filtersOptions}: Props) => {
       name="priorites"
       options={[
         {value: ITEM_ALL, label: 'Tous les niveaux de priorité'},
-        {value: SANS_PRIORITE, label: 'Sans priorité'},
+        {value: SANS_PRIORITE, label: 'Non priorisé'},
         ...ficheActionNiveauPrioriteOptions,
       ]}
       onChange={priorite => setFilters(selectPriorite(priorite))}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimaireStatuts.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimaireStatuts.tsx
@@ -1,39 +1,52 @@
 import TagFilters from 'ui/shared/filters/TagFilters';
-import {ITEM_ALL, getIsAllSelected} from 'ui/shared/filters/commons';
+import {ITEM_ALL} from 'ui/shared/filters/commons';
 import {ficheActionStatutOptions} from '../../../FicheAction/data/options/listesStatiques';
 import {TFicheActionStatuts} from 'types/alias';
 import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
+import {SANS_STATUT} from '../../../FicheAction/data/filters';
 
 type Props = {
   filtersOptions: TFichesActionsListe;
 };
 
 const FiltrePrimaireStatuts = ({filtersOptions}: Props) => {
+  const {filters, setFilters} = filtersOptions;
+
+  const getDefaultOption = () => {
+    if (filters.sans_statut) {
+      return SANS_STATUT;
+    }
+    if (filters.statuts) {
+      return filters.statuts[0];
+    }
+    return ITEM_ALL;
+  };
+
+  const selectStatut = (statut: string) => {
+    const newFilters = filters;
+    if (statut === ITEM_ALL) {
+      delete newFilters.sans_statut;
+      delete newFilters.statuts;
+      return {...newFilters};
+    } else if (statut === SANS_STATUT) {
+      delete newFilters.statuts;
+      return {...newFilters, sans_statut: 1};
+    } else {
+      delete newFilters.sans_statut;
+      return {...newFilters, statuts: [statut as TFicheActionStatuts]};
+    }
+  };
+
   return (
     <TagFilters
-      defaultOption={
-        filtersOptions.filters.statuts
-          ? filtersOptions.filters.statuts[0]
-          : ITEM_ALL
-      }
+      defaultOption={getDefaultOption()}
       name="statuts"
       options={[
         {value: ITEM_ALL, label: 'Tous les statuts'},
+        {value: SANS_STATUT, label: 'Sans statut'},
         ...ficheActionStatutOptions,
       ]}
-      onChange={statut => {
-        if (getIsAllSelected([statut])) {
-          const newFilters = filtersOptions.filters;
-          delete newFilters.statuts;
-          filtersOptions.setFilters({...newFilters});
-          // d'une option à l'autre
-        } else {
-          filtersOptions.setFilters({
-            ...filtersOptions.filters,
-            statuts: [statut as TFicheActionStatuts],
-          });
-        }
-      }}
+      onChange={statut => setFilters(selectStatut(statut))}
     />
   );
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimaireStatuts.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltrePrimaireStatuts.tsx
@@ -1,0 +1,41 @@
+import TagFilters from 'ui/shared/filters/TagFilters';
+import {ITEM_ALL, getIsAllSelected} from 'ui/shared/filters/commons';
+import {ficheActionStatutOptions} from '../../../FicheAction/data/options/listesStatiques';
+import {TFicheActionStatuts} from 'types/alias';
+import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
+
+type Props = {
+  filtersOptions: TFichesActionsListe;
+};
+
+const FiltrePrimaireStatuts = ({filtersOptions}: Props) => {
+  return (
+    <TagFilters
+      defaultOption={
+        filtersOptions.filters.statuts
+          ? filtersOptions.filters.statuts[0]
+          : ITEM_ALL
+      }
+      name="statuts"
+      options={[
+        {value: ITEM_ALL, label: 'Tous les statuts'},
+        ...ficheActionStatutOptions,
+      ]}
+      onChange={statut => {
+        if (getIsAllSelected([statut])) {
+          const newFilters = filtersOptions.filters;
+          delete newFilters.statuts;
+          filtersOptions.setFilters({...newFilters});
+          // d'une option à l'autre
+        } else {
+          filtersOptions.setFilters({
+            ...filtersOptions.filters,
+            statuts: [statut as TFicheActionStatuts],
+          });
+        }
+      }}
+    />
+  );
+};
+
+export default FiltrePrimaireStatuts;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltresPrimaires.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltresPrimaires.tsx
@@ -1,0 +1,22 @@
+import {FiltersKeys} from '../../../FicheAction/data/filters';
+import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
+import FiltrePrimairePersonne from './FiltrePrimairePersonne';
+import FiltrePrimairePriorites from './FiltrePrimairePriorites';
+import FiltrePrimaireStatuts from './FiltrePrimaireStatuts';
+
+type Props = {
+  vue: FiltersKeys;
+  filters: TFichesActionsListe;
+};
+
+const FiltresPrimaires = ({vue, filters}: Props) => {
+  if (vue === 'statuts')
+    return <FiltrePrimaireStatuts filtersOptions={filters} />;
+  if (vue === 'pilotes' || vue === 'referents')
+    return <FiltrePrimairePersonne filterKey={vue} filtersOptions={filters} />;
+  if (vue === 'priorites')
+    return <FiltrePrimairePriorites filtersOptions={filters} />;
+  return null;
+};
+
+export default FiltresPrimaires;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltresPrimaires.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresPrimaires/FiltresPrimaires.tsx
@@ -1,5 +1,6 @@
 import {FiltersKeys} from '../../../FicheAction/data/filters';
 import {TFichesActionsListe} from '../../../FicheAction/data/useFichesActionFiltresListe';
+import FiltrePrimaireEcheance from './FiltrePrimaireEcheance';
 import FiltrePrimairePersonne from './FiltrePrimairePersonne';
 import FiltrePrimairePriorites from './FiltrePrimairePriorites';
 import FiltrePrimaireStatuts from './FiltrePrimaireStatuts';
@@ -16,6 +17,8 @@ const FiltresPrimaires = ({vue, filters}: Props) => {
     return <FiltrePrimairePersonne filterKey={vue} filtersOptions={filters} />;
   if (vue === 'priorites')
     return <FiltrePrimairePriorites filtersOptions={filters} />;
+  if (vue === 'echeance')
+    return <FiltrePrimaireEcheance filtersOptions={filters} />;
   return null;
 };
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresSecondaires.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresSecondaires.tsx
@@ -1,0 +1,64 @@
+import {FiltersKeys} from '../../FicheAction/data/filters';
+import {TFichesActionsListe} from '../../FicheAction/data/useFichesActionFiltresListe';
+import FiltreEcheance from '../../PlanAction/PlanActionFiltres/FiltreEcheance';
+import FiltrePersonnes from '../../PlanAction/PlanActionFiltres/FiltrePersonnes';
+import FiltrePriorites from '../../PlanAction/PlanActionFiltres/FiltrePriorites';
+import FiltreStatuts from '../../PlanAction/PlanActionFiltres/FiltreStatuts';
+
+type Props = {
+  filtresSecondaires: FiltersKeys[];
+  filters: TFichesActionsListe;
+};
+
+const FiltresSecondaires = ({filtresSecondaires, filters}: Props) => {
+  return (
+    <>
+      {filtresSecondaires.map(
+        filtre =>
+          (filtre === 'pilotes' && (
+            <FiltrePersonnes
+              key={filtre}
+              dataTest="filtre-personne-pilote"
+              label="Personne pilote"
+              filterKey="pilotes"
+              filters={filters.filters}
+              setFilters={filters.setFilters}
+            />
+          )) ||
+          (filtre === 'referents' && (
+            <FiltrePersonnes
+              key={filtre}
+              dataTest="filtre-personne-referentes"
+              label="Personne référentes"
+              filterKey="referents"
+              filters={filters.filters}
+              setFilters={filters.setFilters}
+            />
+          )) ||
+          (filtre === 'priorites' && (
+            <FiltrePriorites
+              key={filtre}
+              filters={filters.filters}
+              setFilters={filters.setFilters}
+            />
+          )) ||
+          (filtre === 'statuts' && (
+            <FiltreStatuts
+              key={filtre}
+              filters={filters.filters}
+              setFilters={filters.setFilters}
+            />
+          )) ||
+          (filtre === 'echeance' && (
+            <FiltreEcheance
+              key={filtre}
+              filters={filters.filters}
+              setFilters={filters.setFilters}
+            />
+          ))
+      )}
+    </>
+  );
+};
+
+export default FiltresSecondaires;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresSecondaires.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/FiltresSecondaires.tsx
@@ -29,7 +29,7 @@ const FiltresSecondaires = ({filtresSecondaires, filters}: Props) => {
             <FiltrePersonnes
               key={filtre}
               dataTest="filtre-personne-referentes"
-              label="Personne référentes"
+              label="Élu·e référent·e"
               filterKey="referents"
               filters={filters.filters}
               setFilters={filters.setFilters}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -159,7 +159,7 @@ const SyntheseVue = () => {
             </>
           ) : (
             <div className="mt-20 text-center text-gray-500">
-              Sélectionnez des filtres pour afficher la liste des fiches action
+              Sélectionner des filtres pour afficher la liste des fiches action
             </div>
           )}
         </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {Link, useParams} from 'react-router-dom';
 import HeaderTitle from '../../components/HeaderTitle';
 import {
@@ -17,7 +18,6 @@ import FiltresSecondaires from './FiltresSecondaires';
 import {generateSyntheseVue} from '../utils';
 import {ITEM_ALL} from 'ui/shared/filters/commons';
 import SyntheseVueGraph from './SyntheseVueGraph';
-import {useState} from 'react';
 
 const SyntheseVue = () => {
   const collectivite_id = useCollectiviteId();
@@ -63,7 +63,7 @@ const SyntheseVue = () => {
   if (!vue) return null;
 
   return (
-    <div className="w-full">
+    <div data-test="PageGraphSynthese" className="w-full">
       <HeaderTitle
         customClass={{
           container: 'bg-indigo-700',
@@ -88,11 +88,11 @@ const SyntheseVue = () => {
 
         {/** Graph */}
         <div className="min-h-[27rem] border border-b-4 border-gray-200">
-        <SyntheseVueGraph vue={vue} plan={plan} />
+          <SyntheseVueGraph vue={vue} plan={plan} />
         </div>
 
         {/** Filtres */}
-        <div className="flex flex-col gap-6 mt-8 mb-6">
+        <div data-test="Filtres" className="flex flex-col gap-6 mt-8 mb-6">
           <FiltersPlanAction
             collectiviteId={collectivite_id!}
             initialPlan={
@@ -118,7 +118,10 @@ const SyntheseVue = () => {
         <div className="my-8 border-b border-gray-200" />
         <div className="mb-16">
           <div className="flex items-baseline mb-8">
-            <p className="mb-0 mr-6 text-gray-500">
+            <p
+              data-test="NombreFichesAction"
+              className="mb-0 mr-6 text-gray-500"
+            >
               {total} fiche{total > 1 && 's'} action correspond
               {total > 1 && 'ent'} à votre recherche
             </p>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -87,7 +87,9 @@ const SyntheseVue = () => {
         </div>
 
         {/** Graph */}
+        <div className="min-h-[27rem] border border-b-4 border-gray-200">
         <SyntheseVueGraph vue={vue} plan={plan} />
+        </div>
 
         {/** Filtres */}
         <div className="flex flex-col gap-6 mt-8 mb-6">

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -1,0 +1,142 @@
+import {Link, useParams} from 'react-router-dom';
+import HeaderTitle from '../../components/HeaderTitle';
+import {
+  makeCollectiviteFicheNonClasseeUrl,
+  makeCollectivitePlanActionFicheUrl,
+  makeCollectivitePlansActionsSyntheseUrl,
+  makeCollectivitePlansActionsSyntheseVueUrl,
+} from 'app/paths';
+import {useCollectiviteId} from 'core-logic/hooks/params';
+import {DesactiverLesFiltres} from 'ui/shared/filters/DesactiverLesFiltres';
+import FiltersPlanAction, {PlanActionFilter} from '../FiltersPlanAction';
+import {FiltersKeys} from '../../FicheAction/data/filters';
+import {useFichesActionFiltresListe} from '../../FicheAction/data/useFichesActionFiltresListe';
+import FicheActionCard from '../../FicheAction/FicheActionCard';
+import {getIsAllSelected} from 'ui/shared/filters/commons';
+import FiltresPrimaires from './FiltresPrimaires/FiltresPrimaires';
+import FiltresSecondaires from './FiltresSecondaires';
+import {generateVue} from '../utils';
+
+const SyntheseVue = () => {
+  const collectivite_id = useCollectiviteId();
+  const {syntheseVue} = useParams<{syntheseVue: FiltersKeys}>();
+
+  const pageUrl = makeCollectivitePlansActionsSyntheseVueUrl({
+    collectiviteId: collectivite_id!,
+    vue: syntheseVue,
+  });
+
+  const vue = generateVue(syntheseVue);
+
+  const filters = useFichesActionFiltresListe({
+    url: pageUrl,
+    initialFilters: {
+      collectivite_id: collectivite_id!,
+    },
+  });
+
+  const selectPlan = (plan: PlanActionFilter) => {
+    if (plan.id === 'tous' || plan.id === 'nc') {
+      return undefined;
+    }
+    return [plan.id];
+  };
+
+  if (!vue) return null;
+
+  return (
+    <div className="w-full">
+      <HeaderTitle
+        customClass={{
+          container: 'bg-indigo-700',
+          text: 'text-[1.375rem]',
+        }}
+        titre={vue.titre}
+        isReadonly
+      />
+      <div className="px-6">
+        {/** Header */}
+        <div className="py-6">
+          <Link
+            className="p-1 shrink-0 text-xs text-gray-500 underline !bg-none !shadow-none hover:text-gray-600"
+            to={makeCollectivitePlansActionsSyntheseUrl({
+              collectiviteId: collectivite_id!,
+            })}
+          >
+            <span className="mr-1 fr-icon-arrow-left-line before:scale-75" />
+            Retour à la synthèse
+          </Link>
+        </div>
+
+        {/** Graph */}
+
+        {/** Filtres */}
+        <div className="flex items-baseline ">
+          <h5 className="mb-0 mr-6">Filtrer</h5>
+          <DesactiverLesFiltres
+            onClick={() => filters.setFilters(filters.initialFilters)}
+          />
+        </div>
+        <div className="flex flex-col gap-6 my-6">
+          <FiltersPlanAction
+            collectiviteId={collectivite_id!}
+            initialPlan={
+              filters.filters.axes && filters.filters.axes[0].toString()
+            }
+            onChangePlan={plan => {
+              if (typeof plan.id === 'string' && getIsAllSelected([plan.id])) {
+                const newFilters = filters.filters;
+                delete newFilters.axes;
+                filters.setFilters({...newFilters});
+                // d'une option à l'autre
+              } else {
+                filters.setFilters({
+                  ...filters.filters,
+                  axes: selectPlan(plan),
+                });
+              }
+            }}
+          />
+          <FiltresPrimaires vue={vue.id} filters={filters} />
+        </div>
+        <div className="grid sm:grid-cols-2 gap-x-8 gap-y-6">
+          <FiltresSecondaires
+            filtresSecondaires={vue.filtresSecondaires}
+            filters={filters}
+          />
+        </div>
+
+        {/** Fiches */}
+        <div className="my-8 border-b border-gray-200" />
+        <div className="mb-16">
+          <p className="text-gray-500">
+            {filters.total} fiche{filters.total > 1 && 's'} action correspond
+            {filters.total > 1 && 'ent'} à votre recherche
+          </p>
+          <div className="grid grid-cols-2 gap-6">
+            {filters.items.map(fiche => (
+              <FicheActionCard
+                key={fiche.id}
+                ficheAction={fiche}
+                link={
+                  fiche.axes && fiche.axes.length !== 0
+                    ? makeCollectivitePlanActionFicheUrl({
+                        collectiviteId: collectivite_id!,
+                        planActionUid: fiche.axes[0].id?.toString()!,
+                        ficheUid: fiche.id?.toString()!,
+                      })
+                    : makeCollectiviteFicheNonClasseeUrl({
+                        collectiviteId: collectivite_id!,
+                        ficheUid: fiche.id?.toString()!,
+                      })
+                }
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SyntheseVue;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -166,7 +166,10 @@ const SyntheseVue = () => {
               </div>
             </>
           ) : (
-            <div className="mt-20 text-center text-gray-500">
+            <div
+              data-test="SelectionnerFiltre"
+              className="mt-20 text-center text-gray-500"
+            >
               Sélectionner des filtres pour afficher la liste des fiches action
             </div>
           )}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -117,12 +117,13 @@ const SyntheseVue = () => {
             {filters.items.map(fiche => (
               <FicheActionCard
                 key={fiche.id}
+                displayAxe
                 ficheAction={fiche}
                 link={
-                  fiche.axes && fiche.axes.length !== 0
+                  fiche.plans && fiche.plans[0]
                     ? makeCollectivitePlanActionFicheUrl({
                         collectiviteId: collectivite_id!,
-                        planActionUid: fiche.axes[0].id?.toString()!,
+                        planActionUid: fiche.plans[0].id?.toString()!,
                         ficheUid: fiche.id?.toString()!,
                       })
                     : makeCollectiviteFicheNonClasseeUrl({

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react';
-import {Link, useParams} from 'react-router-dom';
+import {Link, useLocation, useParams} from 'react-router-dom';
 import HeaderTitle from '../../components/HeaderTitle';
 import {
   makeCollectiviteFicheNonClasseeUrl,
@@ -22,6 +22,7 @@ import SyntheseVueGraph from './SyntheseVueGraph';
 const SyntheseVue = () => {
   const collectivite_id = useCollectiviteId();
   const {syntheseVue} = useParams<{syntheseVue: FiltersKeys}>();
+  const {search} = useLocation();
 
   const pageUrl = makeCollectivitePlansActionsSyntheseVueUrl({
     collectiviteId: collectivite_id!,
@@ -114,44 +115,53 @@ const SyntheseVue = () => {
           />
         </div>
 
-        {/** Fiches */}
+        {/** Divider */}
         <div className="my-8 border-b border-gray-200" />
+        {/** Fiches */}
         <div className="mb-16">
-          <div className="flex items-baseline mb-8">
-            <p
-              data-test="NombreFichesAction"
-              className="mb-0 mr-6 text-gray-500"
-            >
-              {total} fiche{total > 1 && 's'} action correspond
-              {total > 1 && 'ent'} à votre recherche
-            </p>
-            {filtersCount > 1 && (
-              <DesactiverLesFiltres
-                onClick={() => setFilters(initialFilters)}
-              />
-            )}
-          </div>
-          <div className="grid grid-cols-2 gap-6">
-            {items.map(fiche => (
-              <FicheActionCard
-                key={fiche.id}
-                displayAxe
-                ficheAction={fiche}
-                link={
-                  fiche.plans && fiche.plans[0]
-                    ? makeCollectivitePlanActionFicheUrl({
-                        collectiviteId: collectivite_id!,
-                        planActionUid: fiche.plans[0].id?.toString()!,
-                        ficheUid: fiche.id?.toString()!,
-                      })
-                    : makeCollectiviteFicheNonClasseeUrl({
-                        collectiviteId: collectivite_id!,
-                        ficheUid: fiche.id?.toString()!,
-                      })
-                }
-              />
-            ))}
-          </div>
+          {search.length && search.length > 1 ? (
+            <>
+              <div className="flex items-baseline mb-8">
+                <p
+                  data-test="NombreFichesAction"
+                  className="mb-0 mr-6 text-gray-500"
+                >
+                  {total} fiche{total > 1 && 's'} action correspond
+                  {total > 1 && 'ent'} à votre recherche
+                </p>
+                {filtersCount > 1 && (
+                  <DesactiverLesFiltres
+                    onClick={() => setFilters(initialFilters)}
+                  />
+                )}
+              </div>
+              <div className="grid grid-cols-2 gap-6">
+                {items.map(fiche => (
+                  <FicheActionCard
+                    key={fiche.id}
+                    displayAxe
+                    ficheAction={fiche}
+                    link={
+                      fiche.plans && fiche.plans[0]
+                        ? makeCollectivitePlanActionFicheUrl({
+                            collectiviteId: collectivite_id!,
+                            planActionUid: fiche.plans[0].id?.toString()!,
+                            ficheUid: fiche.id?.toString()!,
+                          })
+                        : makeCollectiviteFicheNonClasseeUrl({
+                            collectiviteId: collectivite_id!,
+                            ficheUid: fiche.id?.toString()!,
+                          })
+                    }
+                  />
+                ))}
+              </div>
+            </>
+          ) : (
+            <div className="mt-20 text-center text-gray-500">
+              Sélectionnez des filtres pour afficher la liste des fiches action
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -18,6 +18,7 @@ import FiltresSecondaires from './FiltresSecondaires';
 import {generateSyntheseVue} from '../utils';
 import {ITEM_ALL} from 'ui/shared/filters/commons';
 import SyntheseVueGraph from './SyntheseVueGraph';
+import {FicheResume} from '../../FicheAction/data/types';
 
 const SyntheseVue = () => {
   const collectivite_id = useCollectiviteId();
@@ -140,12 +141,19 @@ const SyntheseVue = () => {
                   <FicheActionCard
                     key={fiche.id}
                     displayAxe
-                    ficheAction={fiche}
+                    ficheAction={
+                      ficheWithSelectedPlan(fiche, plan) as FicheResume
+                    }
                     link={
-                      fiche.plans && fiche.plans[0]
+                      plan.id !== 'nc'
                         ? makeCollectivitePlanActionFicheUrl({
                             collectiviteId: collectivite_id!,
-                            planActionUid: fiche.plans[0].id?.toString()!,
+                            planActionUid:
+                              fiche.plans &&
+                              fiche.plans[0] &&
+                              plan.id === ITEM_ALL
+                                ? fiche.plans[0].id?.toString()!
+                                : plan.id.toString(),
                             ficheUid: fiche.id?.toString()!,
                           })
                         : makeCollectiviteFicheNonClasseeUrl({
@@ -169,3 +177,14 @@ const SyntheseVue = () => {
 };
 
 export default SyntheseVue;
+
+const ficheWithSelectedPlan = (fiche: FicheResume, plan: PlanActionFilter) => {
+  if (plan.id !== ITEM_ALL && fiche.plans && fiche.plans) {
+    const index = fiche.plans.findIndex(p => p?.id === plan.id);
+    return {
+      ...fiche,
+      plans: [fiche.plans[index]],
+    };
+  }
+  return fiche;
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue.tsx
@@ -16,6 +16,8 @@ import FiltresPrimaires from './FiltresPrimaires/FiltresPrimaires';
 import FiltresSecondaires from './FiltresSecondaires';
 import {generateSyntheseVue} from '../utils';
 import {ITEM_ALL} from 'ui/shared/filters/commons';
+import SyntheseVueGraph from './SyntheseVueGraph';
+import {useState} from 'react';
 
 const SyntheseVue = () => {
   const collectivite_id = useCollectiviteId();
@@ -27,6 +29,11 @@ const SyntheseVue = () => {
   });
 
   const vue = generateSyntheseVue(syntheseVue);
+
+  const [plan, setPlan] = useState<PlanActionFilter>({
+    id: ITEM_ALL,
+    name: 'tous',
+  });
 
   const filtersData = useFichesActionFiltresListe({
     url: pageUrl,
@@ -80,18 +87,20 @@ const SyntheseVue = () => {
         </div>
 
         {/** Graph */}
-        {/* <ChartCard chartType="donut" chartProps={} /> */}
+        <SyntheseVueGraph vue={vue} plan={plan} />
 
         {/** Filtres */}
-        <div className="flex flex-col gap-6 my-6">
+        <div className="flex flex-col gap-6 mt-8 mb-6">
           <FiltersPlanAction
             collectiviteId={collectivite_id!}
             initialPlan={
               (filters.sans_plan && 'nc') ||
               (filters.axes && filters.axes[0].toString())
             }
+            getInitialPlan={plan => setPlan(plan)}
             onChangePlan={plan => {
               setFilters(selectPlan(plan));
+              setPlan(plan);
             }}
           />
           <FiltresPrimaires vue={vue.id} filters={filtersData} />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVueGraph.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVueGraph.tsx
@@ -33,57 +33,55 @@ const SyntheseVueGraph = ({vue, plan}: Props) => {
   if (!graph) return null;
 
   return (
-    <div className="border border-b-4 border-gray-200">
-      <div className="relative">
-        {/* Bouton de téléchargement, affiché si un nom de fichier est fourni */}
-        <div className="absolute right-4 top-4 z-10">
-          <DownloadButton
-            containerRef={chartWrapperRef}
-            fileName={`repartition-${graph.id}${
-              plan.id === 'nc'
-                ? '-fiches-non-classees'
-                : plan.id !== 'tous'
-                ? `-${plan.name.toLowerCase().split(' ').join('-')}`
-                : ''
-            }`}
-            fileType="png"
-            onClick={
-              () => null
-              //   tracker({fonction: 'graphique', action: 'telechargement'})
-            }
+    <div className="relative">
+      {/* Bouton de téléchargement, affiché si un nom de fichier est fourni */}
+      <div className="absolute right-4 top-4 z-10">
+        <DownloadButton
+          containerRef={chartWrapperRef}
+          fileName={`repartition-${graph.id}${
+            plan.id === 'nc'
+              ? '-fiches-non-classees'
+              : plan.id !== 'tous'
+              ? `-${plan.name.toLowerCase().split(' ').join('-')}`
+              : ''
+          }`}
+          fileType="png"
+          onClick={
+            () => null
+            //   tracker({fonction: 'graphique', action: 'telechargement'})
+          }
+        />
+      </div>
+
+      <div ref={chartWrapperRef} className="p-6">
+        {/* Titre du graphe */}
+        <p className="mb-1 mr-12 font-bold">{graph.title}</p>
+
+        {/** Titre du plan */}
+        <div className="text-gray-500">
+          {plan.id === 'nc'
+            ? 'Fiches non classées'
+            : plan.id === 'tous'
+            ? 'Toutes les fiches'
+            : plan.name}
+        </div>
+
+        {/* Graphe agrandi */}
+        <div className="w-full h-80">
+          <DonutChart
+            {...({
+              data: graph.data,
+              label: true,
+            } as DonutChartProps)}
           />
         </div>
 
-        <div ref={chartWrapperRef} className="p-6">
-          {/* Titre du graphe */}
-          <p className="mb-1 mr-12 font-bold">{graph.title}</p>
-
-          {/** Titre du plan */}
-          <div className="text-gray-500">
-            {plan.id === 'nc'
-              ? 'Fiches non classées'
-              : plan.id === 'tous'
-              ? 'Toutes les fiches'
-              : plan.name}
+        {/* Légende */}
+        {getCustomLegend(graph.data) && (
+          <div className="-mt-8 -mb-6">
+            <Legend legend={getCustomLegend(graph.data)} />
           </div>
-
-          {/* Graphe agrandi */}
-          <div className="w-full h-80">
-            <DonutChart
-              {...({
-                data: graph.data,
-                label: true,
-              } as DonutChartProps)}
-            />
-          </div>
-
-          {/* Légende */}
-          {getCustomLegend(graph.data) && (
-            <div className="-mt-8 -mb-6">
-              <Legend legend={getCustomLegend(graph.data)} />
-            </div>
-          )}
-        </div>
+        )}
       </div>
     </div>
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVueGraph.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVueGraph.tsx
@@ -1,0 +1,92 @@
+import {Legend} from 'ui/charts/ChartCard';
+import {Graph, TSyntheseVue, getCustomLegend, getGraphData} from '../utils';
+import {useCollectiviteId} from 'core-logic/hooks/params';
+import {usePlanActionTableauDeBord} from '../data/usePlanActionTableauDeBord';
+import {PlanActionFilter} from '../FiltersPlanAction';
+import DonutChart, {DonutChartProps} from 'ui/charts/DonutChart';
+import DownloadButton from 'ui/buttons/DownloadButton';
+import {useRef} from 'react';
+
+type Props = {
+  vue: TSyntheseVue;
+  plan: PlanActionFilter;
+};
+
+const SyntheseVueGraph = ({vue, plan}: Props) => {
+  const collectivite_id = useCollectiviteId();
+
+  const data = usePlanActionTableauDeBord(
+    collectivite_id!,
+    plan.id === 'tous' || plan.id === 'nc' ? null : plan.id,
+    plan.id === 'nc' || null
+  );
+
+  // Référence utilisée pour le téléchargement du graphe
+  const chartWrapperRef = useRef<HTMLDivElement>(null);
+
+  const graph: Graph | null = data && {
+    id: vue.id,
+    title: vue.graphTitre,
+    data: getGraphData(vue.id, data),
+  };
+
+  if (!graph) return null;
+
+  return (
+    <div className="border border-b-4 border-gray-200">
+      <div className="relative">
+        {/* Bouton de téléchargement, affiché si un nom de fichier est fourni */}
+        <div className="absolute right-4 top-4 z-10">
+          <DownloadButton
+            containerRef={chartWrapperRef}
+            fileName={`repartition-${graph.id}${
+              plan.id === 'nc'
+                ? '-fiches-non-classees'
+                : plan.id !== 'tous'
+                ? `-${plan.name.toLowerCase().split(' ').join('-')}`
+                : ''
+            }`}
+            fileType="png"
+            onClick={
+              () => null
+              //   tracker({fonction: 'graphique', action: 'telechargement'})
+            }
+          />
+        </div>
+
+        <div ref={chartWrapperRef} className="p-6">
+          {/* Titre du graphe */}
+          <p className="mb-1 mr-12 font-bold">{graph.title}</p>
+
+          {/** Titre du plan */}
+          <div className="text-gray-500">
+            {plan.id === 'nc'
+              ? 'Fiches non classées'
+              : plan.id === 'tous'
+              ? 'Toutes les fiches'
+              : plan.name}
+          </div>
+
+          {/* Graphe agrandi */}
+          <div className="w-full h-80">
+            <DonutChart
+              {...({
+                data: graph.data,
+                label: true,
+              } as DonutChartProps)}
+            />
+          </div>
+
+          {/* Légende */}
+          {getCustomLegend(graph.data) && (
+            <div className="-mt-8 -mb-6">
+              <Legend legend={getCustomLegend(graph.data)} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SyntheseVueGraph;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVuePage.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVuePage.tsx
@@ -1,0 +1,20 @@
+import {lazy, Suspense} from 'react';
+import {renderLoader} from 'utils/renderLoader';
+
+const Vue = lazy(
+  () =>
+    import(
+      'app/pages/collectivite/PlansActions/Synthese/SyntheseVue/SyntheseVue'
+    )
+);
+
+/**
+ * Page d'une vue synthèse des plans d'action
+ */
+export const SyntheseVuePage = () => {
+  return (
+    <Suspense fallback={renderLoader()}>
+      <Vue />
+    </Suspense>
+  );
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
@@ -39,6 +39,13 @@ export const generateSyntheseVue = (
       filtresSecondaires: ['pilotes', 'referents', 'statuts', 'echeance'],
     };
   }
+  if (vueId === 'echeance') {
+    return {
+      id: vueId,
+      titre: 'Répartition des fiches par échéance',
+      filtresSecondaires: ['pilotes', 'referents', 'statuts', 'priorites'],
+    };
+  }
 };
 
 type Graph = {
@@ -92,6 +99,11 @@ export const generateSyntheseGraphData = (
                 id: pr.id !== 'NC' ? pr.id : 'Non priorisé',
               }))
             : [],
+        },
+        {
+          id: 'echeance',
+          title: 'Répartition par échéance',
+          data: data.echeances,
         },
         // {
         //   title: 'Répartition par direction pilote',

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
@@ -105,7 +105,15 @@ export const getGraphData = (
         })) || []
       );
     case 'echeance':
-      return data.echeances;
+      return (
+        data['echeances'].map(echeance => ({
+          ...echeance,
+          id:
+            echeance.id !== 'Date de fin non renseignée'
+              ? echeance.id
+              : 'Sans échéance',
+        })) || []
+      );
     default:
       return [];
   }

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
@@ -8,7 +8,9 @@ type TSyntheseVue = {
   filtresSecondaires: FiltersKeys[];
 };
 
-export const generateVue = (vueId: FiltersKeys): TSyntheseVue | undefined => {
+export const generateSyntheseVue = (
+  vueId: FiltersKeys
+): TSyntheseVue | undefined => {
   if (vueId === 'statuts') {
     return {
       id: vueId,
@@ -45,7 +47,9 @@ type Graph = {
   data: {id: string; value: number; color?: any}[];
 };
 
-export const generateGraphData = (data: TPlanActionTableauDeBord): Graph[] =>
+export const generateSyntheseGraphData = (
+  data: TPlanActionTableauDeBord
+): Graph[] =>
   data
     ? [
         {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
@@ -1,0 +1,101 @@
+import {statusColor} from 'ui/charts/chartsTheme';
+import {FiltersKeys} from '../FicheAction/data/filters';
+import {TPlanActionTableauDeBord} from './data/usePlanActionTableauDeBord';
+
+type TSyntheseVue = {
+  id: FiltersKeys;
+  titre: string;
+  filtresSecondaires: FiltersKeys[];
+};
+
+export const generateVue = (vueId: FiltersKeys): TSyntheseVue | undefined => {
+  if (vueId === 'statuts') {
+    return {
+      id: vueId,
+      titre: 'Répartition des fiches par statut',
+      filtresSecondaires: ['pilotes', 'referents', 'priorites', 'echeance'],
+    };
+  }
+  if (vueId === 'pilotes') {
+    return {
+      id: vueId,
+      titre: 'Répartition des fiches par personne pilote',
+      filtresSecondaires: ['statuts', 'referents', 'priorites', 'echeance'],
+    };
+  }
+  if (vueId === 'referents') {
+    return {
+      id: vueId,
+      titre: 'Répartition des fiches par élu·e référent·e',
+      filtresSecondaires: ['statuts', 'pilotes', 'priorites', 'echeance'],
+    };
+  }
+  if (vueId === 'priorites') {
+    return {
+      id: vueId,
+      titre: 'Répartition des fiches par niveau de priorité',
+      filtresSecondaires: ['pilotes', 'referents', 'statuts', 'echeance'],
+    };
+  }
+};
+
+type Graph = {
+  id: FiltersKeys;
+  title: string;
+  data: {id: string; value: number; color?: any}[];
+};
+
+export const generateGraphData = (data: TPlanActionTableauDeBord): Graph[] =>
+  data
+    ? [
+        {
+          id: 'statuts',
+          title: "Répartition par statut d'avancement",
+          data: data.statuts
+            ? data.statuts.map(st => ({
+                ...st,
+                id: st.id !== 'NC' ? st.id : 'Sans statut',
+                color: statusColor[st.id],
+              }))
+            : [],
+        },
+        {
+          id: 'pilotes',
+          title: 'Répartition par personne pilote',
+          data: data.pilotes
+            ? data.pilotes.map(pi => ({
+                ...pi,
+                id: pi.id !== 'NC' ? pi.id : 'Sans pilote',
+              }))
+            : [],
+        },
+        {
+          id: 'referents',
+          title: 'Répartition par élu·e référent·e',
+          data: data.referents
+            ? data.referents.map(ref => ({
+                ...ref,
+                id: ref.id !== 'NC' ? ref.id : 'Sans élu·e référent·e',
+              }))
+            : [],
+        },
+        {
+          id: 'priorites',
+          title: 'Répartition par niveau de priorité',
+          data: data.priorites
+            ? data.priorites.map(pr => ({
+                ...pr,
+                id: pr.id !== 'NC' ? pr.id : 'Non priorisé',
+              }))
+            : [],
+        },
+        // {
+        //   title: 'Répartition par direction pilote',
+        //   data: [],
+        // },
+        // {
+        //   title: 'Répartition par budget prévisionnel',
+        //   data: [],
+        // },
+      ]
+    : [];

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/Synthese/utils.ts
@@ -1,10 +1,21 @@
-import {statusColor} from 'ui/charts/chartsTheme';
+import {defaultColors, nivoColorsSet, statusColor} from 'ui/charts/chartsTheme';
 import {FiltersKeys} from '../FicheAction/data/filters';
 import {TPlanActionTableauDeBord} from './data/usePlanActionTableauDeBord';
 
-type TSyntheseVue = {
+const statutsGraphTitre = "Répartition par statut d'avancement";
+const pilotesGraphTitre = 'Répartition par personne pilote';
+const referentsGraphTitre = 'Répartition par élu·e référent·e';
+const prioritesGraphTitre = 'Répartition par niveau de priorité';
+const echeanceGraphTitre = 'Répartition par échéance';
+
+/**
+ * VUE DE SYNTHESE
+ */
+
+export type TSyntheseVue = {
   id: FiltersKeys;
   titre: string;
+  graphTitre: string;
   filtresSecondaires: FiltersKeys[];
 };
 
@@ -15,6 +26,7 @@ export const generateSyntheseVue = (
     return {
       id: vueId,
       titre: 'Répartition des fiches par statut',
+      graphTitre: statutsGraphTitre,
       filtresSecondaires: ['pilotes', 'referents', 'priorites', 'echeance'],
     };
   }
@@ -22,6 +34,7 @@ export const generateSyntheseVue = (
     return {
       id: vueId,
       titre: 'Répartition des fiches par personne pilote',
+      graphTitre: pilotesGraphTitre,
       filtresSecondaires: ['statuts', 'referents', 'priorites', 'echeance'],
     };
   }
@@ -29,6 +42,7 @@ export const generateSyntheseVue = (
     return {
       id: vueId,
       titre: 'Répartition des fiches par élu·e référent·e',
+      graphTitre: referentsGraphTitre,
       filtresSecondaires: ['statuts', 'pilotes', 'priorites', 'echeance'],
     };
   }
@@ -36,6 +50,7 @@ export const generateSyntheseVue = (
     return {
       id: vueId,
       titre: 'Répartition des fiches par niveau de priorité',
+      graphTitre: prioritesGraphTitre,
       filtresSecondaires: ['pilotes', 'referents', 'statuts', 'echeance'],
     };
   }
@@ -43,15 +58,63 @@ export const generateSyntheseVue = (
     return {
       id: vueId,
       titre: 'Répartition des fiches par échéance',
+      graphTitre: echeanceGraphTitre,
       filtresSecondaires: ['pilotes', 'referents', 'statuts', 'priorites'],
     };
   }
 };
 
-type Graph = {
+/**
+ * GRAPHIQUES
+ */
+
+type GraphData = {id: string; value: number; color?: any}[];
+
+export const getGraphData = (
+  graphId: FiltersKeys,
+  data: TPlanActionTableauDeBord
+): GraphData => {
+  switch (graphId) {
+    case 'statuts':
+      return (
+        data[graphId].map(st => ({
+          ...st,
+          id: st.id !== 'NC' ? st.id : 'Sans statut',
+          color: statusColor[st.id],
+        })) || []
+      );
+    case 'pilotes':
+      return (
+        data[graphId].map(p => ({
+          ...p,
+          id: p.id !== 'NC' ? p.id : 'Sans pilote',
+        })) || []
+      );
+    case 'referents':
+      return (
+        data[graphId].map(r => ({
+          ...r,
+          id: r.id !== 'NC' ? r.id : 'Sans élu·e référent·e',
+        })) || []
+      );
+    case 'priorites':
+      return (
+        data[graphId].map(prio => ({
+          ...prio,
+          id: prio.id !== 'NC' ? prio.id : 'Non priorisé',
+        })) || []
+      );
+    case 'echeance':
+      return data.echeances;
+    default:
+      return [];
+  }
+};
+
+export type Graph = {
   id: FiltersKeys;
   title: string;
-  data: {id: string; value: number; color?: any}[];
+  data: GraphData;
 };
 
 export const generateSyntheseGraphData = (
@@ -61,48 +124,27 @@ export const generateSyntheseGraphData = (
     ? [
         {
           id: 'statuts',
-          title: "Répartition par statut d'avancement",
-          data: data.statuts
-            ? data.statuts.map(st => ({
-                ...st,
-                id: st.id !== 'NC' ? st.id : 'Sans statut',
-                color: statusColor[st.id],
-              }))
-            : [],
+          title: statutsGraphTitre,
+          data: getGraphData('statuts', data),
         },
         {
           id: 'pilotes',
-          title: 'Répartition par personne pilote',
-          data: data.pilotes
-            ? data.pilotes.map(pi => ({
-                ...pi,
-                id: pi.id !== 'NC' ? pi.id : 'Sans pilote',
-              }))
-            : [],
+          title: pilotesGraphTitre,
+          data: getGraphData('pilotes', data),
         },
         {
           id: 'referents',
-          title: 'Répartition par élu·e référent·e',
-          data: data.referents
-            ? data.referents.map(ref => ({
-                ...ref,
-                id: ref.id !== 'NC' ? ref.id : 'Sans élu·e référent·e',
-              }))
-            : [],
+          title: referentsGraphTitre,
+          data: getGraphData('referents', data),
         },
         {
           id: 'priorites',
-          title: 'Répartition par niveau de priorité',
-          data: data.priorites
-            ? data.priorites.map(pr => ({
-                ...pr,
-                id: pr.id !== 'NC' ? pr.id : 'Non priorisé',
-              }))
-            : [],
+          title: prioritesGraphTitre,
+          data: getGraphData('priorites', data),
         },
         {
           id: 'echeance',
-          title: 'Répartition par échéance',
+          title: echeanceGraphTitre,
           data: data.echeances,
         },
         // {
@@ -115,3 +157,52 @@ export const generateSyntheseGraphData = (
         // },
       ]
     : [];
+
+const getLegendColor = (
+  data: {id: string; value: number; color?: any},
+  dataLength: number,
+  index: number
+) => {
+  if (data.color) {
+    return data.color;
+  }
+  if (dataLength <= defaultColors.length) {
+    return defaultColors[index % defaultColors.length];
+  }
+  return nivoColorsSet[index % nivoColorsSet.length];
+};
+
+export const getCustomLegend = (
+  data: {id: string; value: number; color?: any}[]
+) => {
+  // Limitation du nombre d'éléments visibles dans la légende
+  const legendMaxSize = 9;
+
+  // Légendes associées au données sans label
+  const withoutLabelLegends = [
+    'Sans statut',
+    'Sans pilote',
+    'Sans élu·e référent·e',
+    'Non priorisé',
+  ];
+
+  // Légende réduite à afficher
+  const legend = data.slice(0, legendMaxSize).map((d, index) => ({
+    name: d.id,
+    color: getLegendColor(d, data.length, index),
+  }));
+
+  const lastElement = data[data.length - 1];
+
+  if (
+    withoutLabelLegends.includes(lastElement.id) &&
+    data.length > legendMaxSize
+  ) {
+    legend.push({
+      name: lastElement.id,
+      color: getLegendColor(lastElement, data.length, data.length - 1),
+    });
+  }
+
+  return legend;
+};

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/components/HeaderTitle.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/components/HeaderTitle.tsx
@@ -6,16 +6,29 @@ import {generateTitle} from '../FicheAction/data/utils';
 type Props = {
   titre: string | null;
   onUpdate?: (value: string) => void;
-  bgColorClassName?: string;
-  type?: 'fiche' | 'plan' | 'axe';
+
+  customClass?: {
+    container: string;
+    text: string;
+  };
   isReadonly: boolean;
 };
 
+/**
+ * Titre d'une page plan d'action
+ * @param titre - le titre de la page
+ * @param onUpdate - rend le titre éditable
+ * @param customClass - les classes permettant de styliser le header
+ * @param isReadonly - est ce que le titre peut-il être éditer
+ * @returns
+ */
 const HeaderTitle = ({
   titre,
   onUpdate,
-  type = 'fiche',
-  bgColorClassName,
+  customClass = {
+    container: 'bg-indigo-400',
+    text: 'text-[1.375rem]',
+  },
   isReadonly,
 }: Props) => {
   const titreInputRef = useRef<HTMLTextAreaElement>(null);
@@ -57,32 +70,23 @@ const HeaderTitle = ({
       className={classNames(
         'group flex items-center mx-auto py-6 px-10 xl:mr-6',
         {'cursor-text': !isReadonly},
-        {'bg-indigo-300': type === 'axe'},
-        {'bg-indigo-700': type === 'plan'},
-        {'bg-indigo-400': type === 'fiche'},
-        bgColorClassName
+        customClass.container
       )}
       onClick={!isReadonly ? handleEditFocus : undefined}
     >
       <p
-        className={classNames('flex grow m-0 font-bold text-white', {
-          'text-[1.375rem] leading-snug': type === 'fiche',
-          'text-[2rem] leading-snug': type === 'plan',
-          'text-[1.75rem] leading-snug text-gray-800': type === 'axe',
-        })}
+        className={classNames(
+          'flex grow m-0 font-bold leading-snug text-white',
+          customClass.text
+        )}
       >
         {onUpdate ? (
           <TextareaControlled
             data-test="HeaderTitleInput"
             ref={titreInputRef}
             className={classNames(
-              'w-full placeholder:text-white focus:placeholder:text-gray-200 disabled:text-white !outline-none !resize-none',
-              {
-                'text-[1.375rem] leading-snug': type === 'fiche',
-                'text-[2rem] leading-snug': type === 'plan',
-                'text-[1.75rem] leading-snug placeholder:text-gray-800 focus:placeholder:text-gray-500 disabled:text-gray-800':
-                  type === 'axe',
-              }
+              'w-full leading-snug placeholder:text-white focus:placeholder:text-gray-200 disabled:text-white !outline-none !resize-none',
+              customClass.text
             )}
             initialValue={titre}
             placeholder={'Sans titre'}

--- a/app.territoiresentransitions.react/src/app/paths.ts
+++ b/app.territoiresentransitions.react/src/app/paths.ts
@@ -175,16 +175,6 @@ export const makeCollectiviteLabellisationUrl = ({
     .replace(`:${referentielParam}`, referentielId)
     .replace(`:${labellisationVueParam}`, labellisationVue || 'suivi');
 
-export const makeCollectivitePlansActionsBaseUrl = ({
-  collectiviteId,
-}: {
-  collectiviteId: number;
-}) =>
-  collectivitePlansActionsBasePath.replace(
-    `:${collectiviteParam}`,
-    collectiviteId.toString()
-  );
-
 export const makeCollectivitePlansActionsNouveauUrl = ({
   collectiviteId,
 }: {

--- a/app.territoiresentransitions.react/src/app/paths.ts
+++ b/app.territoiresentransitions.react/src/app/paths.ts
@@ -61,11 +61,13 @@ export const collectiviteJournalPath = `${collectivitePath}/historique`;
 const ficheParam = 'ficheUid';
 const planParam = 'planUid';
 const axeParam = 'axeUid';
+const syntheseParam = 'syntheseVue';
 export const collectivitePlansActionsBasePath = `${collectivitePath}/plans`;
 export const collectivitePlansActionsNouveauPath = `${collectivitePlansActionsBasePath}/nouveau`;
 export const collectivitePlansActionsCreerPath = `${collectivitePlansActionsBasePath}/creer`;
 export const collectivitePlansActionsImporterPath = `${collectivitePlansActionsBasePath}/importer`;
 export const collectivitePlansActionsSynthesePath = `${collectivitePlansActionsBasePath}/synthese`;
+export const collectivitePlansActionsSyntheseVuePath = `${collectivitePlansActionsSynthesePath}/:${syntheseParam}`;
 export const collectivitePlanActionPath = `${collectivitePlansActionsBasePath}/plan/:${planParam}`;
 export const collectivitePlanActionFichePath = `${collectivitePlanActionPath}/fiche/:${ficheParam}`;
 export const collectivitePlanActionAxePath = `${collectivitePlanActionPath}/:${axeParam}`;
@@ -214,6 +216,17 @@ export const makeCollectivitePlansActionsSyntheseUrl = ({
     `:${collectiviteParam}`,
     collectiviteId.toString()
   );
+
+export const makeCollectivitePlansActionsSyntheseVueUrl = ({
+  collectiviteId,
+  vue,
+}: {
+  collectiviteId: number;
+  vue: string;
+}) =>
+  collectivitePlansActionsSyntheseVuePath
+    .replace(`:${collectiviteParam}`, collectiviteId.toString())
+    .replace(`:${syntheseParam}`, vue);
 
 export const makeCollectiviteFichesNonClasseesUrl = ({
   collectiviteId,

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useLocalisation.tsx
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useLocalisation.tsx
@@ -77,8 +77,15 @@ const locationFromPath = (path: string): Localisation => {
     page = 'fiche';
   } else if (path.includes('/plan/')) {
     page = 'plan';
-  } else if (path.endsWith('/plans/synthese')) {
+  } else if (path.includes('/plans/synthese')) {
+    //page
     page = 'synthese_plans';
+    //tag
+    if (path.includes('/statuts')) tag = 'statuts';
+    else if (path.includes('/pilotes')) tag = 'pilotes';
+    else if (path.includes('/referents')) tag = 'referents';
+    else if (path.includes('/priorites')) tag = 'priorites';
+    else if (path.includes('/echeance')) tag = 'echeances';
   } else if (path.endsWith('/plans/fiches')) {
     page = 'fiches_non_classees';
   } else if (path.endsWith('/plans/nouveau')) {

--- a/app.territoiresentransitions.react/src/types/alias.ts
+++ b/app.territoiresentransitions.react/src/types/alias.ts
@@ -79,6 +79,8 @@ export type TFicheActionResultatsAttendus =
   Database['public']['Enums']['fiche_action_resultats_attendus'];
 export type TFicheActionStatuts =
   Database['public']['Enums']['fiche_action_statuts'];
+export type TFicheActionEcheances =
+  Database['public']['Enums']['fiche_action_echeances'];
 
 export type TActionRelationInsert =
   Database['public']['Tables']['action_relation']['Insert'];

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -6469,36 +6469,6 @@ export interface Database {
       time_bucket:
         | {
             Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -6580,6 +6550,36 @@ export interface Database {
             Args: {
               bucket_width: number
               ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
             }
             Returns: number
           }

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -4833,12 +4833,18 @@ export interface Database {
           pilotes?: Database["public"]["CompositeTypes"]["personne"][]
           sans_referent?: boolean
           referents?: Database["public"]["CompositeTypes"]["personne"][]
+          sans_niveau?: boolean
           niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][]
+          sans_statut?: boolean
           statuts?: Database["public"]["Enums"]["fiche_action_statuts"][]
+          sans_thematique?: boolean
           thematiques?: unknown[]
+          sans_sous_thematique?: boolean
           sous_thematiques?: unknown[]
+          sans_budget?: boolean
           budget_min?: number
           budget_max?: number
+          sans_date?: boolean
           date_debut?: string
           date_fin?: string
           echeance?: Database["public"]["Enums"]["fiche_action_echeances"]
@@ -6519,6 +6525,7 @@ export interface Database {
               bucket_width: unknown
               ts: string
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
             }
             Returns: string
@@ -6566,6 +6573,8 @@ export interface Database {
               bucket_width: unknown
               ts: string
 >>>>>>> bd0b6d67b (MAJ database.types.ts)
+=======
+>>>>>>> d8b0e10a9 (update types)
               offset: unknown
             }
             Returns: string

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -6469,6 +6469,36 @@ export interface Database {
       time_bucket:
         | {
             Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -6550,36 +6580,6 @@ export interface Database {
             Args: {
               bucket_width: number
               ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
             }
             Returns: number
           }

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -6524,57 +6524,6 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
->>>>>>> bd0b6d67b (MAJ database.types.ts)
-=======
->>>>>>> d8b0e10a9 (update types)
               offset: unknown
             }
             Returns: string

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -4827,57 +4827,30 @@ export interface Database {
       filter_fiches_action: {
         Args: {
           collectivite_id: number
+          sans_plan?: boolean
           axes_id?: number[]
+          sans_pilote?: boolean
           pilotes?: Database["public"]["CompositeTypes"]["personne"][]
+          sans_referent?: boolean
+          referents?: Database["public"]["CompositeTypes"]["personne"][]
           niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][]
           statuts?: Database["public"]["Enums"]["fiche_action_statuts"][]
-          referents?: Database["public"]["CompositeTypes"]["personne"][]
+          thematiques?: unknown[]
+          sous_thematiques?: unknown[]
+          budget_min?: number
+          budget_max?: number
+          date_debut?: string
+          date_fin?: string
+          echeance?: Database["public"]["Enums"]["fiche_action_echeances"]
           limit?: number
         }
         Returns: {
-          actions: unknown[] | null
-          amelioration_continue: boolean | null
-          axes: unknown[] | null
-          budget_previsionnel: number | null
-          calendrier: string | null
-          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null
           collectivite_id: number | null
-          created_at: string | null
-          date_debut: string | null
-          date_fin_provisoire: string | null
-          description: string | null
-          fiches_liees: unknown[] | null
-          financements: string | null
-          financeurs:
-            | Database["public"]["CompositeTypes"]["financeur_montant"][]
-            | null
           id: number | null
-          indicateurs:
-            | Database["public"]["CompositeTypes"]["indicateur_generique"][]
-            | null
-          maj_termine: boolean | null
           modified_at: string | null
-          modified_by: string | null
-          niveau_priorite:
-            | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null
-          notes_complementaires: string | null
-          objectifs: string | null
-          partenaires: unknown[] | null
-          piliers_eci:
-            | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null
           pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
-          referents: Database["public"]["CompositeTypes"]["personne"][] | null
-          ressources: string | null
-          resultats_attendus:
-            | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null
-          services: unknown[] | null
-          sous_thematiques: unknown[] | null
+          plans: unknown[] | null
           statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          structures: unknown[] | null
-          thematiques: unknown[] | null
           titre: string | null
         }[]
       }
@@ -6545,6 +6518,54 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
+<<<<<<< HEAD
+=======
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+>>>>>>> bd0b6d67b (MAJ database.types.ts)
               offset: unknown
             }
             Returns: string
@@ -6840,6 +6861,13 @@ export interface Database {
         | "Collectivité elle-même"
         | "Elus locaux"
         | "Agents"
+      fiche_action_echeances:
+        | "Action en amélioration continue"
+        | "Sans échéance"
+        | "Échéance dépassée"
+        | "Échéance dans moins de trois mois"
+        | "Échéance entre trois mois et 1 an"
+        | "Échéance dans plus d’un an"
       fiche_action_niveaux_priorite: "Élevé" | "Moyen" | "Bas"
       fiche_action_piliers_eci:
         | "Approvisionnement durable"

--- a/app.territoiresentransitions.react/src/ui/charts/ChartCard.tsx
+++ b/app.territoiresentransitions.react/src/ui/charts/ChartCard.tsx
@@ -4,7 +4,6 @@ import DownloadButton from 'ui/buttons/DownloadButton';
 import Modal from 'ui/shared/floating-ui/Modal';
 import BarChart, {BarChartProps} from './BarChart';
 import DonutChart, {DonutChartProps} from './DonutChart';
-import {Link} from 'react-router-dom';
 
 export const Legend = ({
   legend,
@@ -130,9 +129,9 @@ type ChartCardProps = {
     downloadedFileName?: string;
     additionalInfo?: string | string[];
   };
-  link?: string;
   topElement?: (id?: string) => JSX.Element;
   customStyle?: React.CSSProperties;
+  classNames?: string;
 };
 
 /**
@@ -141,7 +140,6 @@ type ChartCardProps = {
  * @param chartType 'bar' | 'daughnut'
  * @param chartProps BarChartProps | DoughnutChartProps
  * @param chartInfo title, legend, expandable, downloadFileName, additionalInfo
- * @param link Lien au click du titre, il doit donc il y avoir un titre de donné
  * @param topElement JSX.Element (affiché entre le titre et le graphe)
  * @param customStyle React.CSSProperties
  */
@@ -150,9 +148,9 @@ const ChartCard = ({
   chartType,
   chartProps,
   chartInfo,
-  link,
   topElement,
   customStyle,
+  classNames,
 }: ChartCardProps) => {
   const tracker = useFonctionTracker();
 
@@ -176,7 +174,7 @@ const ChartCard = ({
     <div
       className={`border border-gray-200 bg-white flex flex-col w-full h-96 relative ${
         chartInfo?.title || chartInfo?.expandable ? 'pt-6' : ''
-      }`}
+      } ${classNames ? classNames : ''}`}
       style={customStyle}
     >
       {/* En-tête de la carte */}

--- a/app.territoiresentransitions.react/src/ui/charts/ChartCard.tsx
+++ b/app.territoiresentransitions.react/src/ui/charts/ChartCard.tsx
@@ -4,8 +4,9 @@ import DownloadButton from 'ui/buttons/DownloadButton';
 import Modal from 'ui/shared/floating-ui/Modal';
 import BarChart, {BarChartProps} from './BarChart';
 import DonutChart, {DonutChartProps} from './DonutChart';
+import {Link} from 'react-router-dom';
 
-const Legend = ({
+export const Legend = ({
   legend,
 }: {
   legend: {name: string; color: string}[];
@@ -42,7 +43,7 @@ type ChartCardModalContentProps = {
   topElement?: (id?: string) => JSX.Element;
 };
 
-const ChartCardModalContent = ({
+export const ChartCardModalContent = ({
   chart,
   chartInfo,
   topElement,
@@ -129,6 +130,7 @@ type ChartCardProps = {
     downloadedFileName?: string;
     additionalInfo?: string | string[];
   };
+  link?: string;
   topElement?: (id?: string) => JSX.Element;
   customStyle?: React.CSSProperties;
 };
@@ -139,6 +141,7 @@ type ChartCardProps = {
  * @param chartType 'bar' | 'daughnut'
  * @param chartProps BarChartProps | DoughnutChartProps
  * @param chartInfo title, legend, expandable, downloadFileName, additionalInfo
+ * @param link Lien au click du titre, il doit donc il y avoir un titre de donné
  * @param topElement JSX.Element (affiché entre le titre et le graphe)
  * @param customStyle React.CSSProperties
  */
@@ -147,6 +150,7 @@ const ChartCard = ({
   chartType,
   chartProps,
   chartInfo,
+  link,
   topElement,
   customStyle,
 }: ChartCardProps) => {

--- a/app.territoiresentransitions.react/src/ui/shared/Tag.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/Tag.tsx
@@ -14,10 +14,10 @@ const Tag = ({className, title, onCloseClick, isUserCreated}: TTag) => {
   return (
     <div
       className={classNames(
-        'flex items-center px-3 py-0.5 bg-white border border-gray-300 text-gray-900 rounded-full',
+        'flex items-center px-3 py-0.5 text-white bg-bf500  rounded-full',
         {'pr-2': onCloseClick},
         {
-          '!text-white !bg-bf500': isUserCreated,
+          '!bg-white !border !border-gray-300 !text-gray-900': isUserCreated,
         },
         className
       )}

--- a/app.territoiresentransitions.react/src/ui/shared/__snapshots__/Tag.stories.storyshot
+++ b/app.territoiresentransitions.react/src/ui/shared/__snapshots__/Tag.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots ui/shared/Tag Avec Icon 1`] = `
   className="flex"
 >
   <div
-    className="flex items-center px-3 py-0.5 bg-white border border-gray-300 text-gray-900 rounded-full pr-2"
+    className="flex items-center px-3 py-0.5 text-white bg-bf500  rounded-full pr-2"
   >
     <span
       className="py-0.5 text-sm"
@@ -29,7 +29,7 @@ exports[`Storyshots ui/shared/Tag Cree Par Utilisateur 1`] = `
   className="flex"
 >
   <div
-    className="flex items-center px-3 py-0.5 bg-white border border-gray-300 text-gray-900 rounded-full !text-white !bg-bf500"
+    className="flex items-center px-3 py-0.5 text-white bg-bf500  rounded-full !bg-white !border !border-gray-300 !text-gray-900"
   >
     <span
       className="py-0.5 text-sm"
@@ -45,7 +45,7 @@ exports[`Storyshots ui/shared/Tag Default 1`] = `
   className="flex"
 >
   <div
-    className="flex items-center px-3 py-0.5 bg-white border border-gray-300 text-gray-900 rounded-full"
+    className="flex items-center px-3 py-0.5 text-white bg-bf500  rounded-full"
   >
     <span
       className="py-0.5 text-sm"

--- a/app.territoiresentransitions.react/src/ui/shared/filters/TagFilters.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/filters/TagFilters.tsx
@@ -1,10 +1,12 @@
 import {ChangeEvent, Fragment, useEffect, useState} from 'react';
 import './TagFilters.css';
+import {TOption} from '../select/commons';
+import {ITEM_ALL} from './commons';
 
 type TagFiltersProps = {
   name: string;
   id?: string;
-  options: {value: string; label: string}[];
+  options: TOption[];
   defaultOption?: string;
   className?: string;
   small?: boolean;
@@ -34,7 +36,7 @@ const TagFilters = ({
   name,
   id,
   options,
-  defaultOption = 'default',
+  defaultOption = ITEM_ALL,
   className = '',
   small = false,
   onChange,
@@ -58,13 +60,13 @@ const TagFilters = ({
             className="hidden"
             type="radio"
             name={`${name}${id ? `-${id}` : ''}`}
-            id={opt.value}
+            id={`${name}-${opt.value}`}
             value={opt.value}
             checked={selectedOption === opt.value}
             onChange={handleChange}
           />
           <label
-            htmlFor={opt.value}
+            htmlFor={`${name}-${opt.value}`}
             className={`block relative m-0 px-4 py-1 rounded-2xl ${
               small ? 'text-xs' : 'text-sm'
             } text-bf500 bg-bf925 hover:bg-bf925hover cursor-pointer`}

--- a/app.territoiresentransitions.react/src/ui/shared/select/AutocompleteInputSelect.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/select/AutocompleteInputSelect.tsx
@@ -23,6 +23,8 @@ const AutocompleteInputSelect = <T extends string>({
   options,
   onSelect,
   renderOption,
+  buttonClassName,
+  dsfrButton,
   placement,
   placeholderText,
   containerWidthMatchButton,
@@ -56,7 +58,10 @@ const AutocompleteInputSelect = <T extends string>({
     >
       <AutocompleteButton
         data-test={dataTest}
-        buttonClassName={DSFRbuttonClassname}
+        buttonClassName={classNames(
+          dsfrButton && DSFRbuttonClassname,
+          buttonClassName
+        )}
         options={options}
         values={values}
         inputValue={inputValue}

--- a/app.territoiresentransitions.react/src/ui/shared/select/MultiSelectDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/select/MultiSelectDropdown.tsx
@@ -5,6 +5,7 @@ import DropdownFloater from 'ui/shared/floating-ui/DropdownFloater';
 import {
   buttonDisplayedClassname,
   buttonDisplayedPlaceholderClassname,
+  DSFRbuttonClassname,
   ExpandCollapseIcon,
   getOptions,
   TOption,
@@ -29,6 +30,8 @@ export type TMultiSelectDropdownProps<T extends string> =
     renderOption?: (option: TOption) => React.ReactElement;
     /** appelée quand les options sélectionnées changent (reçoit les nouvelles valeurs) */
     onSelect: (values: T[]) => void;
+    /** Applique les styles DSFR au bouton de sélection */
+    dsfrButton?: boolean;
   };
 
 /**
@@ -38,6 +41,7 @@ const MultiSelectDropdown = <T extends string>({
   values,
   options,
   buttonClassName,
+  dsfrButton,
   containerWidthMatchButton,
   placeholderText = 'Sélectionnez une ou plusieurs options',
   onSelect,
@@ -61,7 +65,10 @@ const MultiSelectDropdown = <T extends string>({
     )}
   >
     <MultiSelectButton
-      buttonClassName={buttonClassName}
+      buttonClassName={classNames(
+        dsfrButton && DSFRbuttonClassname,
+        buttonClassName
+      )}
       options={options}
       values={values}
       placeholderText={placeholderText}

--- a/app.territoiresentransitions.react/src/ui/shared/select/MultiSelectFilter.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/select/MultiSelectFilter.tsx
@@ -10,6 +10,7 @@ import {getOptions} from './commons';
 export const MultiSelectFilter = <T extends string>({
   values,
   options,
+  dsfrButton,
   buttonClassName,
   placeholderText,
   onSelect,
@@ -46,6 +47,7 @@ export const MultiSelectFilter = <T extends string>({
   return (
     <MultiSelectDropdown
       data-test={dataTest}
+      dsfrButton={dsfrButton}
       buttonClassName={buttonClassName}
       values={values}
       options={options}

--- a/app.territoiresentransitions.react/src/ui/shared/select/MultiSelectTagsDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/select/MultiSelectTagsDropdown.tsx
@@ -6,11 +6,13 @@ import MultiSelectDropdown from './MultiSelectDropdown';
 type TMultiSelectTagsDropdown<T extends string> = TSelectBase & {
   values?: T[];
   onSelect: (values: T[]) => void;
+  dsfrButton?: boolean;
 };
 
 const MultiSelectTagsDropdown = <T extends string>({
   values,
   options,
+  dsfrButton,
   buttonClassName,
   placeholderText,
   onSelect,
@@ -21,6 +23,7 @@ const MultiSelectTagsDropdown = <T extends string>({
   return (
     <MultiSelectDropdown
       data-test={dataTest}
+      dsfrButton={dsfrButton}
       buttonClassName={classNames(buttonClassName)}
       containerWidthMatchButton={containerWidthMatchButton}
       values={values}

--- a/app.territoiresentransitions.react/src/ui/shared/select/__snapshots__/AutocompleteInputSelect.stories.storyshot
+++ b/app.territoiresentransitions.react/src/ui/shared/select/__snapshots__/AutocompleteInputSelect.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots ui/shared/select/AutocompleteInputSelect Default 1`] = `
   onPointerDown={[Function]}
 >
   <div
-    className="flex items-center w-full p-2 text-left text-sm fr-select !flex !px-4 !bg-none !bg-grey975"
+    className="flex items-center w-full p-2 text-left text-sm"
     onClick={[Function]}
   >
     <div

--- a/data_layer/sqitch/deploy/plan_action/fiches.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches.sql
@@ -2,18 +2,44 @@
 
 BEGIN;
 
+create type fiche_action_echeances as enum(
+    'Action en amélioration continue',
+    'Sans échéance',
+    'Échéance dépassée',
+    'Échéance dans moins de trois mois',
+    'Échéance entre trois mois et 1 an',
+    'Échéance dans plus d’un an'
+    );
+
+
 drop function filter_fiches_action;
 create function
     filter_fiches_action(
     collectivite_id integer,
+    sans_plan boolean default false,
     axes_id integer[] default null,
+    sans_pilote boolean default false,
     pilotes personne[] default null,
-    niveaux_priorite fiche_action_niveaux_priorite[] default null,
-    statuts fiche_action_statuts[] default null,
+    sans_referent boolean default false,
     referents personne[] default null,
+    sans_niveau boolean default false,
+    niveaux_priorite fiche_action_niveaux_priorite[] default null,
+    sans_statut boolean default false,
+    statuts fiche_action_statuts[] default null,
+    sans_thematique boolean default false,
+    thematiques thematique[] default null,
+    sans_sous_thematique boolean default false,
+    sous_thematiques sous_thematique[] default null,
+    sans_budget boolean default false,
+    budget_min integer default null,
+    budget_max integer default null,
+    sans_date boolean default false,
+    date_debut timestamptz default null,
+    date_fin timestamptz default null,
+    echeance fiche_action_echeances default null,
     "limit" integer default 10
 )
-    returns setof fiches_action
+    returns setof fiche_resume
 as
 $$
     # variable_conflict use_variable
@@ -24,12 +50,15 @@ begin
     end if;
 
     return query
-        select *
-        from fiches_action fa
-        where fa.collectivite_id = collectivite_id
-          and case
+        select fr.*
+        from fiche_resume fr
+                 join fiche_action fa on fr.id = fa.id
+        where fr.collectivite_id = filter_fiches_action.collectivite_id
+          and case -- axes_id
+                  when sans_plan then
+                          fr.id not in (select distinct fiche_id from fiche_action_axe)
                   when axes_id is null then true
-                  else fa.id in (with child as (select a.axe_id as axe_id
+                  else fr.id in (with child as (select a.axe_id as axe_id
                                                 from axe_descendants a
                                                 where a.parents && (axes_id)
                                                    or a.axe_id in (select * from unnest(axes_id)))
@@ -37,30 +66,97 @@ begin
                                  from child
                                           join fiche_action_axe using (axe_id))
             end
-          and case
+          and case -- pilotes
+                  when sans_pilote then
+                          fr.id not in (select distinct fiche_id from fiche_action_pilote)
                   when pilotes is null then true
-                  else fa.id in
+                  else fr.id in
                        (select fap.fiche_id
                         from fiche_action_pilote fap
                         where fap.tag_id in (select (pi::personne).tag_id from unnest(pilotes) pi)
                            or fap.user_id in (select (pi::personne).user_id from unnest(pilotes) pi))
             end
-          and case
+          and case -- referents
+                  when sans_referent then
+                          fr.id not in (select distinct fiche_id from fiche_action_referent)
                   when referents is null then true
-                  else fa.id in
+                  else fr.id in
                        (select far.fiche_id
                         from fiche_action_referent far
                         where far.tag_id in (select (re::personne).tag_id from unnest(referents) re)
                            or far.user_id in (select (re::personne).user_id from unnest(referents) re))
             end
-          and case
+          and case -- niveaux_priorite
+                  when sans_niveau then fa.niveau_priorite is null
                   when niveaux_priorite is null then true
                   else fa.niveau_priorite in (select * from unnest(niveaux_priorite::fiche_action_niveaux_priorite[]))
             end
-          and case
+          and case -- statuts
+                  when sans_statut then fa.statut is null
                   when statuts is null then true
-                  else fa.statut in (select * from unnest(statuts::fiche_action_statuts[]))
+                  else fr.statut in (select * from unnest(statuts::fiche_action_statuts[]))
             end
+          and case -- thematiques
+                  when sans_thematique then
+                          fr.id not in (select distinct fiche_id from fiche_action_thematique)
+                  when thematiques is null then true
+                  else fr.id in
+                       (select fat.fiche_id
+                        from fiche_action_thematique fat
+                        where fat.thematique in (select * from unnest(thematiques::thematique[]) th))
+            end
+          and case -- sous_thematiques
+                  when sans_sous_thematique then
+                          fr.id not in (select distinct fiche_id from fiche_action_sous_thematique)
+                  when sous_thematiques is null then true
+                  else fr.id in
+                       (select fast.fiche_id
+                        from fiche_action_sous_thematique fast
+                        where fast.thematique_id in (select (sth::sous_thematique).id
+                                                     from unnest(sous_thematiques::sous_thematique[]) sth))
+            end
+          and case -- budget_min
+                  when sans_budget then fa.budget_previsionnel is null
+                  when budget_min is null then true
+                  when fa.budget_previsionnel is null then false
+                  else fa.budget_previsionnel>=budget_min
+            end
+          and case -- budget_max
+                  when sans_budget then fa.budget_previsionnel is null
+                  when budget_max is null then true
+                  when fa.budget_previsionnel is null then false
+                  else fa.budget_previsionnel<=budget_max
+            end
+          and case -- date_debut
+                  when sans_date then fa.date_debut is null
+                  when filter_fiches_action.date_debut is null then true
+                  when fa.date_debut is null then false
+                  else fa.date_debut<=filter_fiches_action.date_debut
+            end
+          and case -- date_fin
+                  when sans_date then fa.date_fin_provisoire is null
+                  when date_fin is null then true
+                  when fa.date_fin_provisoire is null then false
+                  else fa.date_fin_provisoire<=date_fin
+            end
+          and case -- echeances
+                  when echeance is null then true
+                  when echeance = 'Action en amélioration continue'
+                      then fa.amelioration_continue
+                  when echeance = 'Sans échéance'
+                      then fa.date_fin_provisoire is null
+                  when echeance = 'Échéance dépassée'
+                      then fa.date_fin_provisoire>now()
+                  when echeance = 'Échéance dans moins de trois mois'
+                      then fa.date_fin_provisoire < (now() + interval '3 months')
+                  when echeance = 'Échéance entre trois mois et 1 an'
+                      then fa.date_fin_provisoire >= (now() + interval '3 months')
+                      and fa.date_fin_provisoire < (now() + interval '1 year')
+                  when echeance = 'Échéance dans plus d’un an'
+                      then fa.date_fin_provisoire > (now() + interval '1 year')
+                  else false
+            end
+        order by naturalsort(fr.titre)
         limit filter_fiches_action."limit";
 end;
 $$ language plpgsql security definer

--- a/data_layer/sqitch/deploy/plan_action/fiches@v2.41.0.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches@v2.41.0.sql
@@ -3,7 +3,6 @@
 BEGIN;
 
 drop function filter_fiches_action;
-drop type fiche_action_echeances;
 create function
     filter_fiches_action(
     collectivite_id integer,

--- a/data_layer/sqitch/revert/plan_action/fiches@v2.41.0.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches@v2.41.0.sql
@@ -3,7 +3,6 @@
 BEGIN;
 
 drop function filter_fiches_action;
-drop type fiche_action_echeances;
 create function
     filter_fiches_action(
     collectivite_id integer,
@@ -11,8 +10,7 @@ create function
     pilotes personne[] default null,
     niveaux_priorite fiche_action_niveaux_priorite[] default null,
     statuts fiche_action_statuts[] default null,
-    referents personne[] default null,
-    "limit" integer default 10
+    referents personne[] default null
 )
     returns setof fiches_action
 as
@@ -61,8 +59,7 @@ begin
           and case
                   when statuts is null then true
                   else fa.statut in (select * from unnest(statuts::fiche_action_statuts[]))
-            end
-        limit filter_fiches_action."limit";
+            end;
 end;
 $$ language plpgsql security definer
                     stable;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -421,6 +421,7 @@ labellisation/export 2023-06-19T09:04:41Z Amandine Jacquelin <conta@LanceLibre> 
 cron/refresh_export_score_audit 2023-06-28T14:03:20Z Amandine Jacquelin <conta@LanceLibre> # Ajoute le cron de export_score_audit
 @v2.44.0 2023-07-06T07:57:08Z Florian <florian@derfurth.com> # Statuts à la sous-action et export scores pre et post-audit
 
+plan_action/fiches [plan_action/fiches@v2.41.0] 2023-06-22T08:59:13Z Amandine Jacquelin <conta@LanceLibre> # Ajoute des filtres à filter_fiches_action et retourne fiche_resume au lieu de fiches_action
 utilisateur/visite [utilisateur/visite@v2.44.0] 2023-07-10T09:40:14Z Florian <florian@derfurth.com> # Ajoute les pages synthèse au tracker
 @v2.45.0 2023-07-12T09:51:00Z Florian <florian@derfurth.com> # Tracking pour les futures pages de synthèse
 

--- a/data_layer/sqitch/verify/plan_action/fiches.sql
+++ b/data_layer/sqitch/verify/plan_action/fiches.sql
@@ -2,6 +2,32 @@
 
 BEGIN;
 
-select has_function_privilege('filter_fiches_action( integer,  integer[],  personne[],  fiche_action_niveaux_priorite[],  fiche_action_statuts[],  personne[], integer)', 'execute');
+select has_function_privilege(
+               'filter_fiches_action(
+               integer,
+               boolean,
+               integer[],
+               boolean,
+               personne[],
+               boolean,
+               personne[],
+               boolean,
+               fiche_action_niveaux_priorite[],
+               boolean,
+               fiche_action_statuts[],
+               boolean,
+               thematique[],
+               boolean,
+               sous_thematique[],
+               boolean,
+               integer,
+               integer,
+               boolean,
+               timestamptz,
+               timestamptz,
+               fiche_action_echeances,
+               integer
+               )'
+           , 'execute');
 
 ROLLBACK;

--- a/data_layer/sqitch/verify/plan_action/fiches@v2.41.0.sql
+++ b/data_layer/sqitch/verify/plan_action/fiches@v2.41.0.sql
@@ -1,0 +1,7 @@
+-- Verify tet:plan_action/fiches on pg
+
+BEGIN;
+
+select has_function_privilege('filter_fiches_action( integer,  integer[],  personne[],  fiche_action_niveaux_priorite[],  fiche_action_statuts[],  personne[], integer)', 'execute');
+
+ROLLBACK;

--- a/data_layer/tests/plan_action/filtres.sql
+++ b/data_layer/tests/plan_action/filtres.sql
@@ -5,12 +5,13 @@ update fiche_action set statut = 'En cours' where id = 1 or id = 2 or id = 5;
 update fiche_action set niveau_priorite = 'Moyen' where id = 1 or id = 6;
 update fiche_action set niveau_priorite = 'Bas' where id = 2;
 select test.identify_as('yolo@dodo.com');
-select ok ((select count(*)=2 from filter_fiches_action(
+select ok ((select * from filter_fiches_action(
         collectivite_id := 1,
+        sans_plan := false,
         axes_id := (array [1, 12])::integer[],
+        sans_pilote := false,
         pilotes := null,
-        niveaux_priorite := (array ['Bas', 'Moyen'])::fiche_action_niveaux_priorite[],
-        statuts := (array ['En cours'])::fiche_action_statuts[],
+        sans_referent := false,
         referents := (select array_agg(distinct pe.*::personne)
                       from ((select nom, collectivite_id, id as tag_id, null as user_id
                              from personne_tag
@@ -18,6 +19,22 @@ select ok ((select count(*)=2 from filter_fiches_action(
                             union
                             (select null as nom, 1, null as tag_id, dcp.user_id as user_id
                              from dcp
-                             where user_id = '17440546-f389-4d4f-bfdb-b0c94a1bd0f9')) pe))),
+                             where user_id = '17440546-f389-4d4f-bfdb-b0c94a1bd0f9')) pe),
+        sans_niveau := false,
+        niveaux_priorite := (array ['Bas', 'Moyen'])::fiche_action_niveaux_priorite[],
+        sans_statut := false,
+        statuts := (array ['En cours'])::fiche_action_statuts[],
+        sans_thematique := false,
+        thematiques := null,
+        sans_sous_thematique := false,
+        sous_thematiques := null,
+        sans_budget := false,
+        budget_min := null,
+        budget_max := null,
+        sans_date := false,
+        date_debut := null,
+        date_fin := null,
+        echeance := null,
+        "limit" := 10)),
            'Le filtre devrait retourner 2 résultats');
 rollback;

--- a/e2e/cypress/integration/16-plan-action.feature
+++ b/e2e/cypress/integration/16-plan-action.feature
@@ -61,7 +61,7 @@ Fonctionnalité: Gérer les fiches et les plans d'action
     Quand je clique en dehors de la boîte de dialogue
     Alors le fil d'ariane de la fiche contient "Axe 1: les tests passent"
 
-  
+
   Scénario: Ajouter, éditer et supprimer un plan d'action
     Etant donné que je suis connecté en tant que "yolo"
     Et que je suis sur la page "Plans action" de la collectivité "1"
@@ -174,4 +174,4 @@ Fonctionnalité: Gérer les fiches et les plans d'action
     # Alors "1" fiches action s'affichent
 
     Quand je clique sur le bouton "Désactiver tous les filtres"
-    Alors "13" fiches action s'affichent
+    Alors un message demandant à l'utilisateur de sélectionner un filtre s'affiche

--- a/e2e/cypress/integration/16-plan-action.feature
+++ b/e2e/cypress/integration/16-plan-action.feature
@@ -61,7 +61,7 @@ Fonctionnalité: Gérer les fiches et les plans d'action
     Quand je clique en dehors de la boîte de dialogue
     Alors le fil d'ariane de la fiche contient "Axe 1: les tests passent"
 
-    @focus
+  
   Scénario: Ajouter, éditer et supprimer un plan d'action
     Etant donné que je suis connecté en tant que "yolo"
     Et que je suis sur la page "Plans action" de la collectivité "1"
@@ -150,3 +150,28 @@ Fonctionnalité: Gérer les fiches et les plans d'action
 
     Quand je filtre les fiches par "Michel Sapasse" du filtre "personne-pilote"
     Alors la fiche contenant "Pilote : Michel Sapasse" est visible
+
+  Scénario: Visiter page graphique de synthèse et filter les fiches
+    Etant donné que je suis connecté en tant que "yolo"
+    Et que je suis sur la page "Plans action" de la collectivité "1"
+
+    Quand je clique sur le bouton "Répartition par pilote"
+    Alors le "Page graph de synthèse" est visible
+
+    Quand je filtre par "Plan Vélo 2020-2024"
+    Alors "6" fiches action s'affichent
+
+    Quand je filtre par "Sans pilote"
+    Alors "2" fiches action s'affichent
+
+    Quand je filtre par "Harry Cot"
+    Alors "2" fiches action s'affichent
+
+    Quand je filtre les fiches par "Sans élu·e référent·e" du filtre "personne-referentes"
+    Alors "1" fiches action s'affichent
+
+    # Quand je recharge la page
+    # Alors "1" fiches action s'affichent
+
+    Quand je clique sur le bouton "Désactiver tous les filtres"
+    Alors "13" fiches action s'affichent

--- a/e2e/cypress/integration/16-plan-action/selectors.js
+++ b/e2e/cypress/integration/16-plan-action/selectors.js
@@ -23,6 +23,15 @@ export const LocalSelectors = {
   'Filtrer les fiches': {
     selector: '[data-test=FiltrerFiches]',
   },
+  'Répartition par pilote': {
+    selector: '[data-test=lien-graph-pilotes]',
+  },
+  'Page graph de synthèse': {
+    selector: '[data-test=PageGraphSynthese]',
+  },
+  'Désactiver tous les filtres': {
+    selector: '[data-test=desactiver-les-filtres]',
+  },
   'Modale ranger fiche action': {
     selector: '[data-test=RangerFicheModale]',
   },

--- a/e2e/cypress/integration/16-plan-action/steps.js
+++ b/e2e/cypress/integration/16-plan-action/steps.js
@@ -221,3 +221,12 @@ When(/aucune fiche n'est présente/, () => {
 When(/la fiche contenant "([^"]*)" est visible/, value => {
   cy.get('[data-test=ActionCarte]').contains(value).should('be.visible');
 });
+
+/** SYNTHESE */
+When(/je filtre par "([^"]*)"/, value => {
+  cy.get('[data-test=Filtres]').contains(value).click();
+});
+
+When(/"([^"]*)" fiches action s'affichent/, value => {
+  cy.get('[data-test=NombreFichesAction]').contains(value).should('be.visible');
+});

--- a/e2e/cypress/integration/16-plan-action/steps.js
+++ b/e2e/cypress/integration/16-plan-action/steps.js
@@ -230,3 +230,10 @@ When(/je filtre par "([^"]*)"/, value => {
 When(/"([^"]*)" fiches action s'affichent/, value => {
   cy.get('[data-test=NombreFichesAction]').contains(value).should('be.visible');
 });
+
+When(
+  /un message demandant à l'utilisateur de sélectionner un filtre s'affiche/,
+  value => {
+    cy.get('[data-test=SelectionnerFiltre]').should('exist');
+  }
+);

--- a/e2e/cypress/integration/common/views.js
+++ b/e2e/cypress/integration/common/views.js
@@ -47,7 +47,7 @@ export const CollectivitePages = {
     selector: '[data-test^=Action]',
   },
   'Plans action': {
-    route: 'plans',
+    route: 'plans/synthese',
     selector: '[data-test=PlansAction]',
   },
   'Fiches non classees': {

--- a/site/app/database.types.ts
+++ b/site/app/database.types.ts
@@ -6469,36 +6469,6 @@ export interface Database {
       time_bucket:
         | {
             Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -6580,6 +6550,36 @@ export interface Database {
             Args: {
               bucket_width: number
               ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
             }
             Returns: number
           }

--- a/site/app/database.types.ts
+++ b/site/app/database.types.ts
@@ -4833,12 +4833,18 @@ export interface Database {
           pilotes?: Database["public"]["CompositeTypes"]["personne"][]
           sans_referent?: boolean
           referents?: Database["public"]["CompositeTypes"]["personne"][]
+          sans_niveau?: boolean
           niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][]
+          sans_statut?: boolean
           statuts?: Database["public"]["Enums"]["fiche_action_statuts"][]
+          sans_thematique?: boolean
           thematiques?: unknown[]
+          sans_sous_thematique?: boolean
           sous_thematiques?: unknown[]
+          sans_budget?: boolean
           budget_min?: number
           budget_max?: number
+          sans_date?: boolean
           date_debut?: string
           date_fin?: string
           echeance?: Database["public"]["Enums"]["fiche_action_echeances"]
@@ -6519,6 +6525,7 @@ export interface Database {
               bucket_width: unknown
               ts: string
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
             }
             Returns: string
@@ -6566,6 +6573,8 @@ export interface Database {
               bucket_width: unknown
               ts: string
 >>>>>>> bd0b6d67b (MAJ database.types.ts)
+=======
+>>>>>>> d8b0e10a9 (update types)
               offset: unknown
             }
             Returns: string

--- a/site/app/database.types.ts
+++ b/site/app/database.types.ts
@@ -6469,6 +6469,36 @@ export interface Database {
       time_bucket:
         | {
             Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -6550,36 +6580,6 @@ export interface Database {
             Args: {
               bucket_width: number
               ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
             }
             Returns: number
           }

--- a/site/app/database.types.ts
+++ b/site/app/database.types.ts
@@ -6524,57 +6524,6 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
-              origin: string
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              bucket_width: unknown
-              ts: string
->>>>>>> bd0b6d67b (MAJ database.types.ts)
-=======
->>>>>>> d8b0e10a9 (update types)
               offset: unknown
             }
             Returns: string

--- a/site/app/database.types.ts
+++ b/site/app/database.types.ts
@@ -4827,57 +4827,30 @@ export interface Database {
       filter_fiches_action: {
         Args: {
           collectivite_id: number
+          sans_plan?: boolean
           axes_id?: number[]
+          sans_pilote?: boolean
           pilotes?: Database["public"]["CompositeTypes"]["personne"][]
+          sans_referent?: boolean
+          referents?: Database["public"]["CompositeTypes"]["personne"][]
           niveaux_priorite?: Database["public"]["Enums"]["fiche_action_niveaux_priorite"][]
           statuts?: Database["public"]["Enums"]["fiche_action_statuts"][]
-          referents?: Database["public"]["CompositeTypes"]["personne"][]
+          thematiques?: unknown[]
+          sous_thematiques?: unknown[]
+          budget_min?: number
+          budget_max?: number
+          date_debut?: string
+          date_fin?: string
+          echeance?: Database["public"]["Enums"]["fiche_action_echeances"]
           limit?: number
         }
         Returns: {
-          actions: unknown[] | null
-          amelioration_continue: boolean | null
-          axes: unknown[] | null
-          budget_previsionnel: number | null
-          calendrier: string | null
-          cibles: Database["public"]["Enums"]["fiche_action_cibles"][] | null
           collectivite_id: number | null
-          created_at: string | null
-          date_debut: string | null
-          date_fin_provisoire: string | null
-          description: string | null
-          fiches_liees: unknown[] | null
-          financements: string | null
-          financeurs:
-            | Database["public"]["CompositeTypes"]["financeur_montant"][]
-            | null
           id: number | null
-          indicateurs:
-            | Database["public"]["CompositeTypes"]["indicateur_generique"][]
-            | null
-          maj_termine: boolean | null
           modified_at: string | null
-          modified_by: string | null
-          niveau_priorite:
-            | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
-            | null
-          notes_complementaires: string | null
-          objectifs: string | null
-          partenaires: unknown[] | null
-          piliers_eci:
-            | Database["public"]["Enums"]["fiche_action_piliers_eci"][]
-            | null
           pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
-          referents: Database["public"]["CompositeTypes"]["personne"][] | null
-          ressources: string | null
-          resultats_attendus:
-            | Database["public"]["Enums"]["fiche_action_resultats_attendus"][]
-            | null
-          services: unknown[] | null
-          sous_thematiques: unknown[] | null
+          plans: unknown[] | null
           statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
-          structures: unknown[] | null
-          thematiques: unknown[] | null
           titre: string | null
         }[]
       }
@@ -6545,6 +6518,54 @@ export interface Database {
             Args: {
               bucket_width: unknown
               ts: string
+<<<<<<< HEAD
+=======
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+              origin: string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              bucket_width: unknown
+              ts: string
+>>>>>>> bd0b6d67b (MAJ database.types.ts)
               offset: unknown
             }
             Returns: string
@@ -6840,6 +6861,13 @@ export interface Database {
         | "Collectivité elle-même"
         | "Elus locaux"
         | "Agents"
+      fiche_action_echeances:
+        | "Action en amélioration continue"
+        | "Sans échéance"
+        | "Échéance dépassée"
+        | "Échéance dans moins de trois mois"
+        | "Échéance entre trois mois et 1 an"
+        | "Échéance dans plus d’un an"
       fiche_action_niveaux_priorite: "Élevé" | "Moyen" | "Bas"
       fiche_action_piliers_eci:
         | "Approvisionnement durable"


### PR DESCRIPTION
Nouvelles pages synthèse des plans d'action par graphique avec possibilité de filtrage.
Les nouvelles pages:
- statuts
- pilotes
- référents
- priorité
- échéances

Comportements attendus:
- les pages sont accessibles via le titre des graphique de la page synthèse des plans d'action
- si un plan est sélectionné sur la synthèse, il doit aussi être sélectionné sur la page du graphique
- si on change le filtre du plan, le graphique s'adapte mais pas quand on change les autres
- le graphique est téléchargeable
- tous les filtres mettent à jour la liste de fiche en bas de page
- quand au moins 1 filtre est sélectionné, le bouton "désactiver tous les filtres" apparait et permet de réinitialiser les filtres même les plans
- les cartes des fiches permettent d'accéder à leur page
- quand des filtres sont sélectionnés et que l'on recharge la page, les filtres sont conservés

Améliorations:
- ajouter une pagination car pour le moment on affiche que 10 fiches au maximum dans la liste (impossible en l'état, il faut le notifier aux utilisateurs), on peut cependant augmenter le nombre de fiches à lister, peut être que l'on peut monter à 20.
- la liste des fiches est triée par ordre alpha-num mais pas par plan (pour le filtre toutes les fiches), cela est compliqué à faire en back comme les fiches peuvent appartenir à plusieurs plans.

Bug:
- j'ai l'impression qu'il y a un bug avec les "échéances dépassées" et les "échéances dans moins de trois mois" @amandinejacquelin - Fixé

Tracker?