### PR TITLE
Évolution de la vue tabulaire “Détail des tâches”

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/AuditSuivi/__snapshots__/FiltreAuditStatut.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/AuditSuivi/__snapshots__/FiltreAuditStatut.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots app/pages/collectivite/AuditSuivi/FiltreAuditStatut Selectio
   onPointerDown={[Function]}
 >
   <span
-    className="fr-fi--sm w-full text-center text-bf500 font-bold fr-fi-filter-fill"
+    className="fr-fi--sm w-full text-center text-bf500 font-bold mt-1 fr-fi-filter-fill"
   >
      
     Avancement audit
@@ -35,7 +35,7 @@ exports[`Storyshots app/pages/collectivite/AuditSuivi/FiltreAuditStatut Tous 1`]
   onPointerDown={[Function]}
 >
   <span
-    className="fr-fi--sm w-full text-center text-bf500 font-bold fr-fi-filter-line"
+    className="fr-fi--sm w-full text-center text-bf500 font-bold mt-1 fr-fi-filter-line"
   >
      
     Avancement audit

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/AuditSuivi/__snapshots__/FiltreOrdreDuJour.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/AuditSuivi/__snapshots__/FiltreOrdreDuJour.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots app/pages/collectivite/AuditSuivi/FiltreOrdreDuJour Selectio
   onPointerDown={[Function]}
 >
   <span
-    className="fr-fi--sm w-full text-center text-bf500 font-bold fr-fi-filter-fill"
+    className="fr-fi--sm w-full text-center text-bf500 font-bold mt-1 fr-fi-filter-fill"
   >
      
     A discuter - Séance d'audit
@@ -35,7 +35,7 @@ exports[`Storyshots app/pages/collectivite/AuditSuivi/FiltreOrdreDuJour Tous 1`]
   onPointerDown={[Function]}
 >
   <span
-    className="fr-fi--sm w-full text-center text-bf500 font-bold fr-fi-filter-line"
+    className="fr-fi--sm w-full text-center text-bf500 font-bold mt-1 fr-fi-filter-line"
   >
      
     A discuter - Séance d'audit

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/DetailTaches/CellStatut.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/DetailTaches/CellStatut.tsx
@@ -1,25 +1,61 @@
 import {useCallback} from 'react';
 import {TCellProps} from './DetailTacheTable';
 import {useEditActionStatutIsDisabled} from 'core-logic/hooks/useActionStatut';
-import {SelectActionStatut} from 'ui/shared/actions/SelectActionStatut';
+import {
+  DEFAULT_ITEMS,
+  SelectActionStatut,
+} from 'ui/shared/actions/SelectActionStatut';
 
 /** Affiche le sélecteur permettant de mettre à jour le statut d'une tâche */
 export const CellStatut = ({row, value, updateStatut}: TCellProps) => {
-  const {have_children, action_id} = row.original;
+  const {action_id, type} = row.original;
   const isDisabled = useEditActionStatutIsDisabled(action_id);
+  const filled =
+    row.original.avancement_descendants?.filter(av => av !== 'non_renseigne')
+      .length > 0;
+
+  let items = DEFAULT_ITEMS;
+
+  if (type === 'sous-action' && value !== 'non_renseigne' && filled) {
+    items = items.filter(item => item !== 'non_renseigne');
+  }
+
+  if (type === 'sous-action' && value !== 'detaille') {
+    items = items.filter(item => item !== 'detaille');
+  }
 
   const handleChange = useCallback(
     (value: string) => {
-      updateStatut(action_id, value);
+      const newStatus =
+        type === 'sous-action' && value === 'detaille'
+          ? 'non_renseigne'
+          : value;
+
+      updateStatut(action_id, newStatus);
+
+      if (type === 'tache') {
+        const sousActionId = action_id
+          .split('.')
+          .slice(0, action_id.split('.').length - 1)
+          .join('.');
+
+        // Le setTimeout évite des problèmes de raffraichissement
+        setTimeout(() => {
+          updateStatut(sousActionId, 'non_renseigne');
+        }, 1000);
+      }
     },
     [action_id]
   );
 
-  return have_children ? null : (
-    <SelectActionStatut
-      disabled={isDisabled}
-      value={value}
-      onChange={handleChange}
-    />
-  );
+  return type === 'sous-action' || type === 'tache' ? (
+    <div className="ml-auto" onClick={evt => evt.stopPropagation()}>
+      <SelectActionStatut
+        items={items}
+        disabled={isDisabled}
+        value={value}
+        onChange={handleChange}
+      />
+    </div>
+  ) : null;
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/DetailTaches/DetailTacheTable.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/DetailTaches/DetailTacheTable.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef} from 'react';
+import {useEffect, useMemo} from 'react';
 import {
   Column,
   CellProps,
@@ -27,7 +27,7 @@ export type TColumn = Column<TacheDetail>;
 const COLUMNS: TColumn[] = [
   {
     accessor: 'nom', // la clé pour accéder à la valeur
-    Header: 'Tâches', // rendu dans la ligne d'en-tête
+    Header: 'Statuts', // rendu dans la ligne d'en-tête
     Cell: CellAction, // rendu d'une cellule
     width: '100%',
   },
@@ -57,16 +57,17 @@ export const DetailTacheTable = (props: TDetailTacheTableProps) => {
     useExpanded,
     useFlexLayout
   );
-  const {toggleAllRowsExpanded} = tableInstance;
+  const {toggleAllRowsExpanded, toggleRowExpanded} = tableInstance;
 
-  // initialement tout est déplié
-  const isInitialLoading = useRef(true);
+  // Initialement, on déplie jusqu'à la sous-action, et jusqu'aux tâches
+  // pour les sous-actions détaillées
   useEffect(() => {
-    if (table?.data?.length && isInitialLoading.current) {
-      isInitialLoading.current = false;
-      toggleAllRowsExpanded(true);
+    if (tableInstance.flatRows.length && !isSaving) {
+      tableInstance.flatRows.forEach(row =>
+        toggleRowExpanded([row.original.identifiant], row.original.isExpanded)
+      );
     }
-  }, [table?.data?.length, toggleAllRowsExpanded, isInitialLoading]);
+  }, [table?.data?.length, toggleAllRowsExpanded, filters.statut.length]);
 
   // rendu de la table
   return (

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/DetailTaches/__snapshots__/FiltreStatut.stories.storyshot
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/DetailTaches/__snapshots__/FiltreStatut.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots app/pages/collectivite/DetailTaches/FiltreStatut All 1`] = `
   onPointerDown={[Function]}
 >
   <span
-    className="fr-fi--sm w-full text-center text-bf500 font-bold fr-fi-filter-line"
+    className="fr-fi--sm w-full text-center text-bf500 font-bold mt-1 fr-fi-filter-line"
   >
      
     Statut
@@ -35,7 +35,7 @@ exports[`Storyshots app/pages/collectivite/DetailTaches/FiltreStatut Multi Selec
   onPointerDown={[Function]}
 >
   <span
-    className="fr-fi--sm w-full text-center text-bf500 font-bold fr-fi-filter-fill"
+    className="fr-fi--sm w-full text-center text-bf500 font-bold mt-1 fr-fi-filter-fill"
   >
      
     Statut

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/DetailTaches/index.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/DetailTaches/index.tsx
@@ -5,14 +5,23 @@ import {DisableAllFilters} from '../ReferentielTable/DisableAllFilters';
 
 const DetailTaches = () => {
   const tableData = useTableData();
-  const {count, total, setFilters, filtersCount} = tableData;
+  const {
+    count,
+    sousActionsCount,
+    total,
+    sousActionsTotal,
+    setFilters,
+    filtersCount,
+  } = tableData;
   const labelFilters = filtersCount > 1 ? 'filtres actifs' : 'filtre actif';
+  const labelSousActions = `sous-action${sousActionsCount > 1 ? 's' : ''}`;
   const labelTaches = 'tâche' + (count > 1 ? 's' : '');
 
   return (
     <>
       <p>
-        {filtersCount} {labelFilters} ; {count} {labelTaches} sur {total}
+        {filtersCount} {labelFilters} ; {sousActionsCount} {labelSousActions}{' '}
+        sur {sousActionsTotal} ; {count} {labelTaches} sur {total}
         <DisableAllFilters
           filtersCount={filtersCount}
           onClick={() => setFilters(noFilters)}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/ActionFollowUp.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/ActionFollowUp.tsx
@@ -7,10 +7,12 @@ import ExpandAllButton from 'ui/buttons/ExpandAllButton';
 import SubActionCard from './SubActionCard';
 import {phaseToLabel} from 'ui/referentiels/utils';
 import {SuiviScoreRow} from '../data/useScoreRealise';
+import {TCycleLabellisationStatus} from 'app/pages/collectivite/ParcoursLabellisation/useCycleLabellisation';
 
 type ActionFollowUpProps = {
   action: ActionDefinitionSummary;
   actionScores: {[actionId: string]: SuiviScoreRow};
+  auditStatus: TCycleLabellisationStatus;
 };
 
 /**
@@ -21,6 +23,7 @@ type ActionFollowUpProps = {
 const ActionFollowUp = ({
   action,
   actionScores,
+  auditStatus,
 }: ActionFollowUpProps): JSX.Element => {
   const subActions = useSortedActionSummaryChildren(action);
 
@@ -85,6 +88,7 @@ const ActionFollowUp = ({
                     key={subAction.id}
                     subAction={subAction}
                     actionScores={actionScores}
+                    auditStatus={auditStatus}
                     forceOpen={openAll}
                     onOpenSubAction={updateOpenedSubActionsCount}
                   />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/ActionFollowUp.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/ActionFollowUp.tsx
@@ -1,5 +1,4 @@
-import {useEffect, useState} from 'react';
-import {useLocation} from 'react-router-dom';
+import {useState} from 'react';
 import {ActionDefinitionSummary} from 'core-logic/api/endpoints/ActionDefinitionSummaryReadEndpoint';
 import {useSortedActionSummaryChildren} from 'core-logic/hooks/referentiel';
 import {ActionCommentaire} from 'ui/shared/actions/ActionCommentaire';
@@ -51,16 +50,6 @@ const ActionFollowUp = ({
     if (isOpen) setOpenedSubActionsCount(prevState => prevState + 1);
     else setOpenedSubActionsCount(prevState => prevState - 1);
   };
-
-  // déplie tout si une tâche est indiquée dans l'url (afin que le
-  // scrollIntoView dans `SubActionTask` fonctionne)
-  const {hash} = useLocation();
-  useEffect(() => {
-    const id = hash.slice(1); // enlève le "#" au début du hash
-    if (id) {
-      setOpenAll(true);
-    }
-  }, [hash]);
 
   return (
     <section>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionCard.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionCard.tsx
@@ -1,3 +1,4 @@
+import {TCycleLabellisationStatus} from 'app/pages/collectivite/ParcoursLabellisation/useCycleLabellisation';
 import {ActionDefinitionSummary} from 'core-logic/api/endpoints/ActionDefinitionSummaryReadEndpoint';
 import {useCollectiviteId} from 'core-logic/hooks/params';
 import {useActionSummaryChildren} from 'core-logic/hooks/referentiel';
@@ -14,6 +15,7 @@ import SubActionTasksList from './SubActionTasksList';
 type SubActionCardProps = {
   subAction: ActionDefinitionSummary;
   actionScores: {[actionId: string]: SuiviScoreRow};
+  auditStatus: TCycleLabellisationStatus;
   forceOpen: boolean;
   onOpenSubAction: (isOpen: boolean) => void;
 };
@@ -27,6 +29,7 @@ type SubActionCardProps = {
 const SubActionCard = ({
   subAction,
   actionScores,
+  auditStatus,
   forceOpen,
   onOpenSubAction,
 }: SubActionCardProps): JSX.Element => {
@@ -81,6 +84,9 @@ const SubActionCard = ({
         action={subAction}
         actionScores={actionScores}
         displayProgressBar={shouldDisplayProgressBar}
+        displayActionCommentaire={
+          auditStatus === 'audit_en_cours' && !openSubAction
+        }
         openSubAction={openSubAction}
         onToggleOpen={handleToggleOpen}
       />
@@ -89,7 +95,9 @@ const SubActionCard = ({
       {openSubAction && (
         <div className="p-6">
           {/* Commentaire associé à la sous-action */}
-          <ActionCommentaire action={subAction} className="mb-10" />
+          {(auditStatus !== 'audit_en_cours' || openSubAction) && (
+            <ActionCommentaire action={subAction} className="mb-10" />
+          )}
 
           {/* Section Description et Exemples */}
           {subAction.referentiel === 'eci' &&

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionHeader.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionHeader.tsx
@@ -9,12 +9,14 @@ import {Tooltip} from 'ui/shared/floating-ui/Tooltip';
 import ScoreDisplay from 'ui/referentiels/ScoreDisplay';
 import ActionProgressBar from 'ui/referentiels/ActionProgressBar';
 import {SuiviScoreRow} from '../data/useScoreRealise';
+import {ActionCommentaire} from 'ui/shared/actions/ActionCommentaire';
 
 type SubActionHeaderProps = {
   action: ActionDefinitionSummary;
   actionScores: {[actionId: string]: SuiviScoreRow};
   hideStatus?: boolean;
   displayProgressBar?: boolean;
+  displayActionCommentaire?: boolean;
   openSubAction?: boolean;
   onToggleOpen?: () => void;
   onSaveStatus?: (payload: StatusToSavePayload) => void;
@@ -29,6 +31,7 @@ const SubActionHeader = ({
   actionScores,
   hideStatus = false,
   displayProgressBar = false,
+  displayActionCommentaire = false,
   openSubAction = false,
   onToggleOpen,
   onSaveStatus,
@@ -46,7 +49,7 @@ const SubActionHeader = ({
 
   return (
     <div
-      className={classNames('grid grid-cols-12 gap-4 items-start py-4', {
+      className={classNames('py-4 group', {
         'rounded-lg cursor-pointer px-6': isSubAction,
         'px-0': isTask,
         'bg-[#f5f5fE]': isSubAction && open,
@@ -54,68 +57,82 @@ const SubActionHeader = ({
       })}
       onClick={handleOnClick}
     >
-      {/* Identifiant de l'action et bouton open / close */}
-      <div
-        className={classNames('flex justify-between lg:col-span-1 col-span-2', {
-          'font-bold': isSubAction,
-        })}
-      >
-        {isSubAction && (
-          <span
-            className={classNames('text-bf500', {
-              'fr-icon-arrow-down-s-fill': open,
-              'fr-icon-arrow-right-s-fill': !open,
-            })}
-          />
-        )}
-        {action.identifiant}
-      </div>
-
-      {/* Nom de l'action et score réalisé */}
-      <div className="lg:col-span-9 col-span-7 flex flex-col gap-3">
-        <div className={classNames({'font-bold': isSubAction})}>
-          {action.nom}
-          {action.description &&
-            ((isSubAction && action.referentiel === 'cae') || isTask) && (
-              <span onClick={evt => evt.stopPropagation()}>
-                <Tooltip label={action.description} activatedBy="click">
-                  <span className="fr-fi-information-line pl-2 text-bf500 cursor-pointer" />
-                </Tooltip>
-              </span>
-            )}
+      <div className="grid grid-cols-12 gap-4 items-start">
+        {/* Identifiant de l'action et bouton open / close */}
+        <div
+          className={classNames(
+            'flex justify-between lg:col-span-1 col-span-2',
+            {
+              'font-bold': isSubAction,
+            }
+          )}
+        >
+          {isSubAction && (
+            <span
+              className={classNames('text-bf500', {
+                'fr-icon-arrow-down-s-fill': open,
+                'fr-icon-arrow-right-s-fill': !open,
+              })}
+            />
+          )}
+          {action.identifiant}
         </div>
 
-        {isSubAction && (
-          <div className="flex gap-2">
-            <div className="w-[140px]">
-              <ScoreDisplay
-                score={actionScores[action.id]?.points_realises ?? null}
-                scoreMax={
-                  actionScores[action.id]?.points_max_personnalises ?? null
-                }
-                size="xs"
-              />
-            </div>
-
-            {displayProgressBar && (
-              <div className="flex justify-end w-[155px]">
-                <ActionProgressBar action={action} />
-              </div>
-            )}
+        {/* Nom de l'action et score réalisé */}
+        <div className="lg:col-span-9 col-span-7 flex flex-col gap-3">
+          <div className={classNames({'font-bold': isSubAction})}>
+            {action.nom}
+            {action.description &&
+              ((isSubAction && action.referentiel === 'cae') || isTask) && (
+                <span onClick={evt => evt.stopPropagation()}>
+                  <Tooltip label={action.description} activatedBy="click">
+                    <span className="fr-fi-information-line pl-2 text-bf500 cursor-pointer" />
+                  </Tooltip>
+                </span>
+              )}
           </div>
-        )}
-      </div>
 
-      {/* Menu de sélection du statut */}
-      <div className="lg:col-span-2 col-span-3">
-        {!hideStatus && (
-          <ActionStatusDropdown
-            action={action}
-            actionScores={actionScores}
-            onSaveStatus={onSaveStatus}
-          />
-        )}
+          {isSubAction && (
+            <div className="flex gap-2">
+              <div className="w-[140px]">
+                <ScoreDisplay
+                  score={actionScores[action.id]?.points_realises ?? null}
+                  scoreMax={
+                    actionScores[action.id]?.points_max_personnalises ?? null
+                  }
+                  size="xs"
+                />
+              </div>
+
+              {displayProgressBar && (
+                <div className="flex justify-end w-[155px]">
+                  <ActionProgressBar action={action} />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Menu de sélection du statut */}
+        <div className="lg:col-span-2 col-span-3">
+          {!hideStatus && (
+            <ActionStatusDropdown
+              action={action}
+              actionScores={actionScores}
+              onSaveStatus={onSaveStatus}
+            />
+          )}
+        </div>
       </div>
+      {displayActionCommentaire && (
+        <div onClick={evt => evt.stopPropagation()}>
+          <ActionCommentaire
+            action={action}
+            className="mt-10"
+            backgroundClassName="!bg-[#f6f6f6] group-hover:!bg-[#eee]"
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionTask.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionTask.tsx
@@ -1,4 +1,4 @@
-import {useLayoutEffect, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useLocation} from 'react-router-dom';
 import {ActionDefinitionSummary} from 'core-logic/api/endpoints/ActionDefinitionSummaryReadEndpoint';
 import {useActionCommentaire} from 'core-logic/hooks/useActionCommentaire';
@@ -30,14 +30,19 @@ const SubActionTask = ({
 
   // scroll jusqu'à la tâche indiquée dans l'url
   const {hash} = useLocation();
-  useLayoutEffect(() => {
+
+  useEffect(() => {
     const id = hash.slice(1); // enlève le "#" au début du hash
-    if (id === task.id && ref.current) {
-      ref.current.scrollIntoView({
-        behavior: 'smooth',
-      });
+    if (id === task.id && ref && ref.current) {
+      setTimeout(() => {
+        ref.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'nearest',
+        });
+      }, 0);
     }
-  }, [hash, ref.current]);
+  }, [hash, ref]);
 
   return (
     <div data-test={`task-${task.id}`} ref={ref}>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/ReferentielTable/CellAction.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/ReferentielTable/CellAction.tsx
@@ -19,15 +19,14 @@ const paddingByLevel: Record<ReferentielParamOption, Record<number, number>> = {
     2: 16,
     // au dessus de 2 un décalage supplémentaire est appliqué par l'affichage de l'identifiant, il n'est donc pâs reporté ici
     3: 16,
-    4: 26,
-    5: 36,
+    4: 32,
+    5: 48,
   },
   eci: {
     1: 0,
-    2: 4,
-    3: 16,
-    4: 26,
-    5: 36,
+    2: 16,
+    3: 32,
+    4: 48,
   },
 };
 
@@ -84,7 +83,8 @@ export const CellAction = (props: TCellProps) => {
           {depth > 0 ? (
             depth > idDepth ? (
               <Link
-                className="hover:underline"
+                className="hover:underline active:underline active:!bg-transparent"
+                onClick={evt => evt.stopPropagation()}
                 to={makeCollectiviteTacheUrl({
                   collectiviteId,
                   actionId: row.original.action_id,
@@ -129,7 +129,7 @@ const Expand = ({row, referentielId}: TCellProps) => {
   const {depth} = original;
   const invertColor = depth < (referentielId === 'cae' ? 3 : 2);
   const className = [
-    'fr-mr-1w',
+    'fr-mr-1w hover:!bg-transparent',
     isExpanded ? 'arrow-down' : 'arrow-right',
     invertColor ? 'before:bg-white' : 'before:bg-black',
   ].join(' ');
@@ -143,6 +143,10 @@ const Expand = ({row, referentielId}: TCellProps) => {
         {...row.getToggleRowExpandedProps()}
         onMouseOver={undefined}
         title=""
+        onClick={evt => {
+          evt.stopPropagation();
+          row.toggleRowExpanded();
+        }}
       />
     </Tooltip>
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/ReferentielTable/Row.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/ReferentielTable/Row.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import {Row} from 'react-table';
 
 type RowRendererFactory = <T extends Record<string, unknown>>(
@@ -11,7 +12,7 @@ type RowRendererFactory = <T extends Record<string, unknown>>(
 export const makeRowRenderer: RowRendererFactory =
   (prepareRow, customCellProps) => (row, index, rows) => {
     prepareRow(row);
-    const {original, isExpanded} = row;
+    const {original, isExpanded, canExpand} = row;
     const {depth, nom} = original;
     // dernière ligne avant une nouvelle section
     const isLast =
@@ -24,7 +25,8 @@ export const makeRowRenderer: RowRendererFactory =
     return (
       <div
         {...row.getRowProps()}
-        className={className}
+        onClick={() => row.toggleRowExpanded()}
+        className={classNames(className, {'cursor-pointer': canExpand})}
         title={(nom as string) || ''}
       >
         {row.cells.map(cell => {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/ReferentielTable/styles.css
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/ReferentielTable/styles.css
@@ -56,10 +56,8 @@
   padding: 1rem;
 }
 
-/** curseur au dessus des lignes */
 .referentiel-table .body .row,
 .referentiel-table .body .row:hover {
-  cursor: pointer;
   overflow: hidden;
   line-height: 36px;
 }

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/Action.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/Action.tsx
@@ -27,6 +27,7 @@ import {useActionPreuvesCount} from 'ui/shared/preuves/Bibliotheque/usePreuves';
 import ActionFollowUp from '../EtatDesLieux/Referentiel/SuiviAction/ActionFollowUp';
 import {FichesActionLiees} from './FichesActionLiees';
 import {useScoreRealise} from '../EtatDesLieux/Referentiel/data/useScoreRealise';
+import {useCycleLabellisation} from '../ParcoursLabellisation/useCycleLabellisation';
 
 // index des onglets de la page Action
 const TABS_INDEX: Record<ActionVueParamOption, number> = {
@@ -51,6 +52,8 @@ const Action = ({action}: {action: ActionDefinitionSummary}) => {
     useActionLinkedIndicateurDefinitions(action?.id);
 
   const actionScores = useScoreRealise(action);
+
+  const {status: auditStatus} = useCycleLabellisation(action.referentiel);
 
   if (!action || !collectivite) {
     return <Link to="./referentiels" />;
@@ -118,7 +121,11 @@ const Action = ({action}: {action: ActionDefinitionSummary}) => {
           className="fr-mt-9v"
         >
           <Tab label="Suivi de l'action" icon="seedling">
-            <ActionFollowUp action={action} actionScores={actionScores} />
+            <ActionFollowUp
+              action={action}
+              actionScores={actionScores}
+              auditStatus={auditStatus}
+            />
           </Tab>
           <Tab
             label={`Documents${

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/ReferentielTabs.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/ReferentielTabs.tsx
@@ -80,7 +80,7 @@ const ReferentielTabs = () => {
             '...'
           )}
         </Tab>
-        <Tab label="Détail des tâches">
+        <Tab label="Détail des statuts">
           {activeTab === TABS_INDEX['detail'] ? <DetailTacheTable /> : '...'}
         </Tab>
       </Tabs>

--- a/app.territoiresentransitions.react/src/core-logic/hooks/useActionStatut.ts
+++ b/app.territoiresentransitions.react/src/core-logic/hooks/useActionStatut.ts
@@ -4,23 +4,24 @@ import {useCurrentCollectivite} from './useCurrentCollectivite';
 import {useAudit, useIsAuditeur} from 'app/pages/collectivite/Audit/useAudit';
 import {useActionScore} from './scoreHooks';
 import {Database} from 'types/database.types';
+import {useCollectiviteId} from './params';
 
 /**
  * Charge le statut d'une action
  */
-export const useActionStatut = (args: TActionStatutParams) => {
-  const {action_id, collectivite_id} = args;
+export const useActionStatut = (actionId: string) => {
+  const collectivite_id = useCollectiviteId();
   const {data, isLoading} = useQuery(['action_statut', collectivite_id], () =>
-    fetchCollectiviteActionStatuts(collectivite_id)
+    fetchCollectiviteActionStatuts(collectivite_id ?? undefined)
   );
 
-  const statut = data?.find(action => action.action_id === action_id) || null;
+  const statut = data?.find(action => action.action_id === actionId) || null;
 
   const filled =
     data?.find(
       action =>
-        action.action_id.includes(action_id) &&
-        action.action_id.split(action_id)[1] !== '' &&
+        action.action_id.includes(actionId) &&
+        action.action_id.split(actionId)[1] !== '' &&
         action.avancement !== 'non_renseigne'
     ) !== undefined || null;
 
@@ -29,11 +30,6 @@ export const useActionStatut = (args: TActionStatutParams) => {
     filled,
     isLoading,
   };
-};
-
-type TActionStatutParams = {
-  collectivite_id?: number;
-  action_id: string;
 };
 
 const fetchCollectiviteActionStatuts = async (collectivite_id?: number) => {
@@ -55,8 +51,8 @@ const fetchCollectiviteActionStatuts = async (collectivite_id?: number) => {
 /**
  * Met à jour le statut d'une action
  */
-export const useSaveActionStatut = (args: TActionStatutParams) => {
-  const {collectivite_id} = args;
+export const useSaveActionStatut = () => {
+  const collectivite_id = useCollectiviteId();
   const queryClient = useQueryClient();
   const {isLoading, mutate: saveActionStatut} = useMutation(write, {
     mutationKey: 'action_statut',

--- a/app.territoiresentransitions.react/src/ui/referentiels/ActionStatusDropdown.tsx
+++ b/app.territoiresentransitions.react/src/ui/referentiels/ActionStatusDropdown.tsx
@@ -63,7 +63,7 @@ export const ActionStatusDropdown = ({
     action_id: action.id,
     collectivite_id: collectivite?.collectivite_id || 0,
   };
-  const {statut, filled} = useActionStatut(args);
+  const {statut, filled} = useActionStatut(action.id);
   const {avancement, avancement_detaille, concerne} = statut || {};
 
   const score = actionScores[action.id] ?? {};
@@ -74,7 +74,7 @@ export const ActionStatusDropdown = ({
     concerne,
   });
 
-  const {saveActionStatut} = useSaveActionStatut(args);
+  const {saveActionStatut} = useSaveActionStatut();
 
   const [localAvancement, setLocalAvancement] = useState(avancementExt);
   const [localAvancementDetaille, setLocalAvancementDetaille] =

--- a/app.territoiresentransitions.react/src/ui/shared/actions/ActionCommentaire.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/actions/ActionCommentaire.tsx
@@ -7,10 +7,12 @@ import {
   useSaveActionCommentaire,
 } from 'core-logic/hooks/useActionCommentaire';
 import React, {useEffect, useState} from 'react';
+import classNames from 'classnames';
 
 type ActionCommentaireProps = {
   action: ActionDefinitionSummary;
   className?: string;
+  backgroundClassName?: string;
   autoFocus?: boolean;
   onSave?: () => void;
 };
@@ -18,6 +20,7 @@ type ActionCommentaireProps = {
 export const ActionCommentaire = ({
   action,
   className,
+  backgroundClassName,
   autoFocus,
   onSave,
 }: ActionCommentaireProps) => {
@@ -28,6 +31,7 @@ export const ActionCommentaire = ({
     <div className={className}>
       {!isLoading && (
         <ActionCommentaireField
+          backgroundClassName={backgroundClassName}
           action={action}
           initialValue={actionCommentaire?.commentaire || ''}
           autoFocus={autoFocus}
@@ -39,6 +43,7 @@ export const ActionCommentaire = ({
 };
 
 export type ActionCommentaireFieldProps = {
+  backgroundClassName?: string;
   action: ActionDefinitionSummary;
   initialValue: string;
   autoFocus?: boolean;
@@ -46,6 +51,7 @@ export type ActionCommentaireFieldProps = {
 };
 
 export const ActionCommentaireField = ({
+  backgroundClassName,
   action,
   initialValue,
   autoFocus = false,
@@ -66,7 +72,9 @@ export const ActionCommentaireField = ({
       )}
       <Textarea
         data-test={`comm-${action.id}`}
-        className="fr-input !outline-none !bg-[#f6f6f6]"
+        className={classNames('fr-input !outline-none', backgroundClassName, {
+          '!bg-[#f6f6f6]': !backgroundClassName,
+        })}
         minHeight={action.type === 'tache' ? undefined : '5rem'}
         value={commentaire}
         onInputChange={() => null}

--- a/app.territoiresentransitions.react/src/ui/shared/select/MultiSelectFilter.tsx
+++ b/app.territoiresentransitions.react/src/ui/shared/select/MultiSelectFilter.tsx
@@ -83,7 +83,7 @@ export const MultiSelectFilterTitle = (props: TMultiSelectFilterTitleProps) => {
   return (
     <span
       className={classNames(
-        'fr-fi--sm w-full text-center text-bf500 font-bold',
+        'fr-fi--sm w-full text-center text-bf500 font-bold mt-1',
         {'fr-fi-filter-fill': !values.includes(ITEM_ALL)},
         {'fr-fi-filter-line': values.includes(ITEM_ALL)}
       )}


### PR DESCRIPTION
[Ticket notion](https://www.notion.so/territoires-en-transitions/volution-action-r-f-rentiel-volution-de-la-vue-tabulaire-D-tail-des-t-ches-fba8c50e3a99477aa2a2da8f3f5242b6)

1. Mises à jour sur la page suivi de l'action
- Déplacement du champ d'explication à la sous-action lors d'un audit
- Mise à jour de la condition pour déplier automatiquement les tâches d'une sous-action en fonction du référentiel et statut "détaillé" ou non

2. Mises jour sur l'onglet "Détail des tâches"
- Ajout des statuts à la sous-action (sans l'option "détaillé", ni "non renseigné" si certaines tâches sont complétées)
- Expand au niveau des sous-actions et non plus des tâches, sauf dans le cas d'une sous-action de statut "détaillé"
- Ajout d'un compteur pour les sous-actions
- Corrections des liens de redirection des sous-actions + Mise à jour pour ne déplier que la sous-action concernée dans l'onglet suivi de l'action
- Rend toute la ligne clickable pour la déplier, et si ne peut pas être dépliée, changement du curseur pour un curseur classique
 