### PR TITLE
dl: Répare et améliore le comptage des réponses par thématique

### DIFF
--- a/data_layer/sqitch/deploy/evaluation/thematique_completude.sql
+++ b/data_layer/sqitch/deploy/evaluation/thematique_completude.sql
@@ -3,43 +3,23 @@
 
 BEGIN;
 
-comment on function private.question_count_for_thematique
-    is 'Le nombre de questions applicables pour une collectivité sur une thématique.';
-
-
-create function private.reponse_count_by_thematique(collectivite_id integer, thematique_id character varying) returns integer
+create or replace function private.reponse_count_by_thematique(collectivite_id integer, thematique_id character varying) returns integer
     stable
     language sql
 begin
     atomic
     select count(*)
     from question q
-             left join reponse_binaire rb on rb.question_id = q.id
-             left join reponse_proportion rp on rp.question_id = q.id
-             left join reponse_choix rc on rc.question_id = q.id
-    where rb.collectivite_id = reponse_count_by_thematique.collectivite_id
-      and q.thematique_id = reponse_count_by_thematique.thematique_id;
+             left join reponse_binaire rb
+                       on rb.question_id = q.id
+                           and rb.collectivite_id = reponse_count_by_thematique.collectivite_id
+             left join reponse_proportion rp
+                       on rp.question_id = q.id
+                           and rp.collectivite_id = reponse_count_by_thematique.collectivite_id
+             left join reponse_choix rc
+                       on rc.question_id = q.id
+                           and rc.collectivite_id = reponse_count_by_thematique.collectivite_id
+    where q.thematique_id = reponse_count_by_thematique.thematique_id;
 end;
-comment on function private.reponse_count_by_thematique
-    is 'Le nombre de réponses d''une collectivités sur une question.';
-
-
-create or replace view question_thematique_completude as
-select c.id    as collectivite_id,
-       qtd.id,
-       qtd.nom,
-       qtd.referentiels,
-       case
-           when private.reponse_count_by_thematique(c.id, qt.id) =
-                private.question_count_for_thematique(c.id, qt.id)
-               then 'complete'::thematique_completude
-           else 'a_completer'::thematique_completude
-           end as completude
-from collectivite c
-         left join question_thematique qt on true
-         left join question_thematique_display qtd on qtd.id = qt.id
-where referentiels is not null
-  and est_verifie()
-order by (case when qtd.id = 'identite' then '0' else qtd.nom end);
 
 COMMIT;

--- a/data_layer/sqitch/deploy/evaluation/thematique_completude@v2.57.0.sql
+++ b/data_layer/sqitch/deploy/evaluation/thematique_completude@v2.57.0.sql
@@ -1,0 +1,45 @@
+-- Deploy tet:evaluation/thematique_completude to pg
+-- requires: evaluation/question
+
+BEGIN;
+
+comment on function private.question_count_for_thematique
+    is 'Le nombre de questions applicables pour une collectivité sur une thématique.';
+
+
+create function private.reponse_count_by_thematique(collectivite_id integer, thematique_id character varying) returns integer
+    stable
+    language sql
+begin
+    atomic
+    select count(*)
+    from question q
+             left join reponse_binaire rb on rb.question_id = q.id
+             left join reponse_proportion rp on rp.question_id = q.id
+             left join reponse_choix rc on rc.question_id = q.id
+    where rb.collectivite_id = reponse_count_by_thematique.collectivite_id
+      and q.thematique_id = reponse_count_by_thematique.thematique_id;
+end;
+comment on function private.reponse_count_by_thematique
+    is 'Le nombre de réponses d''une collectivités sur une question.';
+
+
+create or replace view question_thematique_completude as
+select c.id    as collectivite_id,
+       qtd.id,
+       qtd.nom,
+       qtd.referentiels,
+       case
+           when private.reponse_count_by_thematique(c.id, qt.id) =
+                private.question_count_for_thematique(c.id, qt.id)
+               then 'complete'::thematique_completude
+           else 'a_completer'::thematique_completude
+           end as completude
+from collectivite c
+         left join question_thematique qt on true
+         left join question_thematique_display qtd on qtd.id = qt.id
+where referentiels is not null
+  and est_verifie()
+order by (case when qtd.id = 'identite' then '0' else qtd.nom end);
+
+COMMIT;

--- a/data_layer/sqitch/revert/evaluation/thematique_completude.sql
+++ b/data_layer/sqitch/revert/evaluation/thematique_completude.sql
@@ -3,37 +3,18 @@
 
 BEGIN;
 
-create or replace view question_thematique_completude(collectivite_id, id, nom, referentiels, completude) as
-WITH any_reponse AS (SELECT q.id                                                                 AS question_id,
-                            q.thematique_id,
-                            COALESCE(rb.collectivite_id, rp.collectivite_id, rc.collectivite_id) AS collectivite_id
-                     FROM question q
-                              LEFT JOIN reponse_binaire rb ON rb.question_id::text = q.id::text
-                              LEFT JOIN reponse_proportion rp ON rp.question_id::text = q.id::text
-                              LEFT JOIN reponse_choix rc ON rc.question_id::text = q.id::text),
-     reponse_thematique_count AS (SELECT ar.thematique_id,
-                                         ar.collectivite_id,
-                                         count(*) AS count
-                                  FROM any_reponse ar
-                                  GROUP BY ar.thematique_id, ar.collectivite_id)
-SELECT c.id    AS collectivite_id,
-       qtd.id,
-       qtd.nom,
-       qtd.referentiels,
-       CASE
-           WHEN rtc.count = private.question_count_for_thematique(c.id, rtc.thematique_id) THEN 'complete'::thematique_completude
-           ELSE 'a_completer'::thematique_completude
-           END AS completude
-FROM collectivite c
-         LEFT JOIN question_thematique qt ON true
-         LEFT JOIN reponse_thematique_count rtc ON rtc.thematique_id::text = qt.id::text AND rtc.collectivite_id = c.id
-         LEFT JOIN question_thematique_display qtd ON qtd.id::text = qt.id::text
-WHERE qtd.referentiels IS NOT NULL
-  and est_verifie()
-ORDER BY (CASE
-              WHEN qtd.id::text = 'identite'::text THEN '0'::text
-              ELSE qtd.nom END);
-
-drop function private.reponse_count_by_thematique;
+create or replace function private.reponse_count_by_thematique(collectivite_id integer, thematique_id character varying) returns integer
+    stable
+    language sql
+begin
+    atomic
+    select count(*)
+    from question q
+             left join reponse_binaire rb on rb.question_id = q.id
+             left join reponse_proportion rp on rp.question_id = q.id
+             left join reponse_choix rc on rc.question_id = q.id
+    where rb.collectivite_id = reponse_count_by_thematique.collectivite_id
+      and q.thematique_id = reponse_count_by_thematique.thematique_id;
+end;
 
 COMMIT;

--- a/data_layer/sqitch/revert/evaluation/thematique_completude@v2.57.0.sql
+++ b/data_layer/sqitch/revert/evaluation/thematique_completude@v2.57.0.sql
@@ -1,0 +1,39 @@
+-- Deploy tet:evaluation/thematique_completude to pg
+-- requires: evaluation/question
+
+BEGIN;
+
+create or replace view question_thematique_completude(collectivite_id, id, nom, referentiels, completude) as
+WITH any_reponse AS (SELECT q.id                                                                 AS question_id,
+                            q.thematique_id,
+                            COALESCE(rb.collectivite_id, rp.collectivite_id, rc.collectivite_id) AS collectivite_id
+                     FROM question q
+                              LEFT JOIN reponse_binaire rb ON rb.question_id::text = q.id::text
+                              LEFT JOIN reponse_proportion rp ON rp.question_id::text = q.id::text
+                              LEFT JOIN reponse_choix rc ON rc.question_id::text = q.id::text),
+     reponse_thematique_count AS (SELECT ar.thematique_id,
+                                         ar.collectivite_id,
+                                         count(*) AS count
+                                  FROM any_reponse ar
+                                  GROUP BY ar.thematique_id, ar.collectivite_id)
+SELECT c.id    AS collectivite_id,
+       qtd.id,
+       qtd.nom,
+       qtd.referentiels,
+       CASE
+           WHEN rtc.count = private.question_count_for_thematique(c.id, rtc.thematique_id) THEN 'complete'::thematique_completude
+           ELSE 'a_completer'::thematique_completude
+           END AS completude
+FROM collectivite c
+         LEFT JOIN question_thematique qt ON true
+         LEFT JOIN reponse_thematique_count rtc ON rtc.thematique_id::text = qt.id::text AND rtc.collectivite_id = c.id
+         LEFT JOIN question_thematique_display qtd ON qtd.id::text = qt.id::text
+WHERE qtd.referentiels IS NOT NULL
+  and est_verifie()
+ORDER BY (CASE
+              WHEN qtd.id::text = 'identite'::text THEN '0'::text
+              ELSE qtd.nom END);
+
+drop function private.reponse_count_by_thematique;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -471,3 +471,5 @@ collectivite/departement [collectivite/departement@v2.55.0] 2023-09-01T07:36:29Z
 
 automatisation/crm [automatisation/crm@v2.56.0] 2023-09-01T14:43:31Z Florian <florian@derfurth.com> # Ajoute les colonnes plan d'action aux usages
 @v2.57.0 2023-09-01T15:00:35Z Florian <florian@derfurth.com> # Amélioration de la table usage du CRM
+
+evaluation/thematique_completude [evaluation/thematique_completude@v2.57.0] 2023-09-05T16:12:42Z Florian <florian@derfurth.com> # Répare et améliore le comptage des réponses par thématique

--- a/data_layer/sqitch/verify/evaluation/thematique_completude@v2.57.0.sql
+++ b/data_layer/sqitch/verify/evaluation/thematique_completude@v2.57.0.sql
@@ -1,0 +1,11 @@
+-- Verify tet:evaluation/thematique_completude on pg
+
+BEGIN;
+
+comment on type thematique_completude is '';
+select has_function_privilege('private.question_count_for_thematique(integer, varchar)', 'execute');
+select collectivite_id, id, nom, referentiels, completude
+from question_thematique_completude
+where false;
+
+ROLLBACK;


### PR DESCRIPTION
La page `Personnalisation des référentiels` est lente à répondre et seules les réponses oui non étaient prises en compte.

La fonction `reponse_count_by_thematique` entrainait des scans des tables réponses. La nouvelle fonction s’appuie sur les indexes.