### PR TITLE
Corrige le droit vérifié lors d'une invitation

### DIFF
--- a/data_layer/sqitch/deploy/utilisateur/dcp.sql
+++ b/data_layer/sqitch/deploy/utilisateur/dcp.sql
@@ -3,75 +3,30 @@
 
 BEGIN;
 
-create table utilisateur_verifie
-(
-    user_id  uuid references dcp on delete cascade primary key,
-    verifie boolean not null default false
-);
-alter table utilisateur_verifie enable row level security;
-create policy allow_read on utilisateur_verifie for update using (is_service_role() or user_id = auth.uid());
-create policy allow_update on utilisateur_verifie for update using (is_service_role());
-
-
-
-create table utilisateur_support
-(
-    user_id  uuid references dcp on delete cascade not null primary key,
-    support boolean not null default false
-);
-alter table utilisateur_support enable row level security;
-create policy allow_read on utilisateur_support for update using (is_service_role() or user_id = auth.uid());
-create policy allow_update on utilisateur_support for update using (is_service_role());
-
-create function est_verifie()
-    returns boolean
-    security definer
-begin
-    atomic
-    select verifie
-    from utilisateur_verifie
-    where user_id = auth.uid()
-      and is_authenticated();
-end;
-comment on function est_verifie is 'Vrai si l''utilisateur courant est vérifié';
-
-create function est_support()
-    returns boolean
-    security definer
-begin
-    atomic
-    select support
-    from utilisateur_support
-    where user_id = auth.uid()
-      and is_authenticated();
-end;
-comment on function est_support is 'Vrai si l''utilisateur courant fait parti du support';
-
 create or replace function after_insert_dcp_add_rights() returns trigger
 as
 $$
+declare
+    invitation boolean;
 begin
     insert into utilisateur_support (user_id) values(new.user_id);
-    if (
-        -- Vérifie s'il existe une invitiation et si oui met en vérifié
-        select count(*)=0
-        from private_utilisateur_droit pud
-        where pud.user_id = new.user_id
-          and invitation_id is not null
-    ) then
-        insert into utilisateur_verifie (user_id) values(new.user_id);
-    else
-        insert into utilisateur_verifie (user_id, verifie) values(new.user_id, true);
-    end if;
+
+
+    -- Vérifie s'il existe une invitiation et si oui met en vérifié
+    select count(*)!=0
+    from private_utilisateur_droit pud
+    where pud.user_id = new.user_id
+      and invitation_id is not null
+    into invitation;
+
+    -- On vérifie si l'enregistrement existe déjà
+    -- car l'ordre d'exécution entre l'insert dans dcp et consume_invitation peut varier
+    insert into utilisateur_verifie (user_id, verifie) values(new.user_id, invitation)
+    on conflict (user_id) do update set verifie = invitation;
+
     return new;
 end;
 $$ language plpgsql security definer;
 comment on function after_insert_dcp_add_rights() is 'Ajoute le droit support et verifie';
-
-create trigger after_insert_droit
-    after insert
-    on dcp
-    for each row
-execute procedure after_insert_dcp_add_rights();
 
 COMMIT;

--- a/data_layer/sqitch/deploy/utilisateur/dcp@v2.60.0.sql
+++ b/data_layer/sqitch/deploy/utilisateur/dcp@v2.60.0.sql
@@ -1,0 +1,77 @@
+-- Deploy tet:dcp to pg
+-- requires: base
+
+BEGIN;
+
+create table utilisateur_verifie
+(
+    user_id  uuid references dcp on delete cascade primary key,
+    verifie boolean not null default false
+);
+alter table utilisateur_verifie enable row level security;
+create policy allow_read on utilisateur_verifie for update using (is_service_role() or user_id = auth.uid());
+create policy allow_update on utilisateur_verifie for update using (is_service_role());
+
+
+
+create table utilisateur_support
+(
+    user_id  uuid references dcp on delete cascade not null primary key,
+    support boolean not null default false
+);
+alter table utilisateur_support enable row level security;
+create policy allow_read on utilisateur_support for update using (is_service_role() or user_id = auth.uid());
+create policy allow_update on utilisateur_support for update using (is_service_role());
+
+create function est_verifie()
+    returns boolean
+    security definer
+begin
+    atomic
+    select verifie
+    from utilisateur_verifie
+    where user_id = auth.uid()
+      and is_authenticated();
+end;
+comment on function est_verifie is 'Vrai si l''utilisateur courant est vérifié';
+
+create function est_support()
+    returns boolean
+    security definer
+begin
+    atomic
+    select support
+    from utilisateur_support
+    where user_id = auth.uid()
+      and is_authenticated();
+end;
+comment on function est_support is 'Vrai si l''utilisateur courant fait parti du support';
+
+create or replace function after_insert_dcp_add_rights() returns trigger
+as
+$$
+begin
+    insert into utilisateur_support (user_id) values(new.user_id);
+    if (
+        -- Vérifie s'il existe une invitiation et si oui met en vérifié
+        select count(*)=0
+        from private_utilisateur_droit pud
+        where pud.user_id = new.user_id
+          and invitation_id is not null
+    ) then
+        insert into utilisateur_verifie (user_id) values(new.user_id);
+    else
+        insert into utilisateur_verifie (user_id, verifie) values(new.user_id, true);
+    end if;
+    return new;
+end;
+$$ language plpgsql security definer;
+comment on function after_insert_dcp_add_rights() is 'Ajoute le droit support et verifie';
+
+create trigger after_insert_droit
+    after insert
+    on dcp
+    for each row
+execute procedure after_insert_dcp_add_rights();
+
+COMMIT;

--- a/data_layer/sqitch/deploy/utilisateur/invitation_v2.sql
+++ b/data_layer/sqitch/deploy/utilisateur/invitation_v2.sql
@@ -3,192 +3,7 @@
 
 BEGIN;
 
--- Drop deprecated invitation flow.
-drop function create_agent_invitation;
-drop function latest_invitation;
-drop function accept_invitation;
-truncate table private_collectivite_invitation;
-drop table private_collectivite_invitation;
-
-
--- Create the invitation table in utilisateur schema.
-create table utilisateur.invitation
-(
-    id              uuid primary key default gen_random_uuid(),
-    niveau          niveau_acces                               not null,
-    email           text                                       not null,
-    collectivite_id integer references collectivite            not null,
-
-    created_by      uuid references auth.users                 not null,
-    created_at      timestamptz      default CURRENT_TIMESTAMP not null,
-
-    accepted_at     timestamptz,
-    consumed        bool generated always as (accepted_at is not null) stored,
-    pending         bool generated always as (accepted_at is null and active) stored,
-    active          bool             default true
-);
-comment on table utilisateur.invitation is
-    'Permet d''inviter un utilisateur sur une collectivité.';
-
--- Add a reference to invitation in private_utilisateur_droit.
-alter table private_utilisateur_droit
-    add invitation_id uuid references utilisateur.invitation;
-comment on column private_utilisateur_droit.invitation_id is
-    'L''id de l''invitation utilisée pour obtenir ce droit.';
-
--- Invitation RLS
-alter table utilisateur.invitation
-    enable row level security;
-
-create policy allow_read -- so we expose the data in views for admin purposes.
-    on utilisateur.invitation
-    using (true);
-
-
--- Add a new constraint on droits.
-alter table private_utilisateur_droit
-    add constraint unique_user_collectivite unique (user_id, collectivite_id);
-comment on constraint unique_user_collectivite on private_utilisateur_droit is
-    'Un utilisateur ne peut avoir qu''un seul droit par collectivité.';
-
--- Internal functions.
-create function
-    utilisateur.associate(
-    collectivite_id integer,
-    user_id uuid,
-    niveau niveau_acces,
-    invitation_id uuid
-)
-    returns void
-as
-$$
-insert into private_utilisateur_droit (user_id, collectivite_id, active, niveau_acces, invitation_id)
-values (associate.user_id, associate.collectivite_id, true, associate.niveau, associate.invitation_id)
-on conflict (user_id, collectivite_id)
-    do update set active        = true,
-                  niveau_acces  = associate.niveau,
-                  invitation_id = associate.invitation_id;
-$$ language sql;
-comment on function utilisateur.associate is
-    'Associe un utilisateur à une collectivité avec un niveau d''accès.';
-
-
-create function
-    utilisateur.invite(
-    collectivite_id integer,
-    email text,
-    niveau niveau_acces
-)
-    returns uuid
-as
-$$
-insert into utilisateur.invitation (niveau, email, collectivite_id, created_by)
-values (invite.niveau, invite.email, invite.collectivite_id, auth.uid())
-returning id;
-$$ language sql;
-comment on function utilisateur.invite is
-    'Crée une invitation et renvoie son id.';
-
-
--- API exposed RPCs.
-create function add_user(
-    collectivite_id integer,
-    email text,
-    niveau niveau_acces
-) returns json
-as
-$$
-declare
-    existing_user    auth.users;
-    conflicting_user bool;
-    invitation_id    uuid;
-begin
-    if have_edition_acces(collectivite_id) or is_service_role()
-    then
-        select *
-        from auth.users u
-        where u.email = add_user.email
-        into existing_user;
-
-        if FOUND
-        then
-            -- There is an existing user matching the email.
-            select count(*) > 0
-            from private_utilisateur_droit pud
-            where add_user.collectivite_id = pud.collectivite_id
-              and existing_user.id = pud.user_id
-            into conflicting_user;
-
-            if conflicting_user
-            then
-                if (select count(*) > 0
-                    from private_utilisateur_droit pud
-                    where add_user.collectivite_id = pud.collectivite_id
-                      and existing_user.id = pud.user_id
-                      and active = true)
-                then
-                    -- The existing user is already associated with our collectivite.
-                    perform set_config('response.status', '409', true); -- 409: Conflict
-                    return json_build_object(
-                            'error', 'L''utilisateur est déjà associé à cette collectivité.'
-                        );
-                else
-                    -- The existing user's rights to the collectivite had been desactivated.
-                    update private_utilisateur_droit
-                    set active      = true,
-                        modified_at = now(),
-                        niveau_acces=add_user.niveau
-                    where user_id = existing_user.id
-                      and private_utilisateur_droit.collectivite_id = add_user.collectivite_id;
-
-                    return json_build_object(
-                            'added', true,
-                            'message', 'Accès de l''utilisateur ré-activés.'
-                        );
-                end if;
-            else
-                -- Associate the existing user with our collectivite.
-                perform utilisateur.associate(
-                        add_user.collectivite_id,
-                        existing_user.id,
-                        add_user.niveau,
-                        null
-                    );
-                return json_build_object(
-                        'added', true,
-                        'message', 'Utilisateur ajouté.'
-                    );
-            end if;
-
-        else
-            -- No user matching the email was found, we should invite them.
-            select utilisateur.invite(
-                           add_user.collectivite_id,
-                           add_user.email,
-                           add_user.niveau
-                       )
-            into invitation_id;
-            return json_build_object(
-                    'invitation_id', invitation_id,
-                    'message', 'Invitation créée.'
-                );
-        end if;
-    else
-        -- Not admin nor service role.
-        perform set_config('response.status', '403', true); -- 403: Forbidden
-        return json_build_object('error', 'Vous n''êtes pas administrateur de cette collectivité.');
-    end if;
-end;
-$$ language plpgsql security definer;
-comment on function add_user is
-    'Ajoute un utilisateur à une collectivité avec un niveau d''accès.
-        Si l''utilisateur
-        - est déjà associé à la collectivité renvoie une erreur 409.
-        - est dans la base, renvoie un message json {"added": true}.
-        - n''est pas dans la base, renvoie un message json { "invitation_id": uuid }.';
-
-
-create function
+create or replace function
     consume_invitation(id uuid)
     returns void
 as
@@ -219,6 +34,14 @@ begin
                     invitation.niveau,
                     invitation.id
                 );
+
+            -- Ajoute le droit vérifié à l'utilisateur invité
+            -- On vérifie si l'enregistrement existe déjà
+            -- car l'ordre d'exécution entre l'insert dans dcp et consume_invitation peut varier
+            if (select count(*)>0 from dcp where user_id = auth.uid()) then
+                insert into utilisateur_verifie (user_id, verifie) values(auth.uid(), true)
+                on conflict (user_id) do update set verifie = true;
+            end if;
 
             perform set_config('response.status', '201', true); -- 201: Created
         else

--- a/data_layer/sqitch/deploy/utilisateur/invitation_v2@v2.60.0.sql
+++ b/data_layer/sqitch/deploy/utilisateur/invitation_v2@v2.60.0.sql
@@ -1,0 +1,239 @@
+-- Deploy tet:utilisateur/invitation_v2 to pg
+-- requires: utilisateur/niveaux_acces
+
+BEGIN;
+
+-- Drop deprecated invitation flow.
+drop function create_agent_invitation;
+drop function latest_invitation;
+drop function accept_invitation;
+truncate table private_collectivite_invitation;
+drop table private_collectivite_invitation;
+
+
+-- Create the invitation table in utilisateur schema.
+create table utilisateur.invitation
+(
+    id              uuid primary key default gen_random_uuid(),
+    niveau          niveau_acces                               not null,
+    email           text                                       not null,
+    collectivite_id integer references collectivite            not null,
+
+    created_by      uuid references auth.users                 not null,
+    created_at      timestamptz      default CURRENT_TIMESTAMP not null,
+
+    accepted_at     timestamptz,
+    consumed        bool generated always as (accepted_at is not null) stored,
+    pending         bool generated always as (accepted_at is null and active) stored,
+    active          bool             default true
+);
+comment on table utilisateur.invitation is
+    'Permet d''inviter un utilisateur sur une collectivité.';
+
+-- Add a reference to invitation in private_utilisateur_droit.
+alter table private_utilisateur_droit
+    add invitation_id uuid references utilisateur.invitation;
+comment on column private_utilisateur_droit.invitation_id is
+    'L''id de l''invitation utilisée pour obtenir ce droit.';
+
+-- Invitation RLS
+alter table utilisateur.invitation
+    enable row level security;
+
+create policy allow_read -- so we expose the data in views for admin purposes.
+    on utilisateur.invitation
+    using (true);
+
+
+-- Add a new constraint on droits.
+alter table private_utilisateur_droit
+    add constraint unique_user_collectivite unique (user_id, collectivite_id);
+comment on constraint unique_user_collectivite on private_utilisateur_droit is
+    'Un utilisateur ne peut avoir qu''un seul droit par collectivité.';
+
+-- Internal functions.
+create function
+    utilisateur.associate(
+    collectivite_id integer,
+    user_id uuid,
+    niveau niveau_acces,
+    invitation_id uuid
+)
+    returns void
+as
+$$
+insert into private_utilisateur_droit (user_id, collectivite_id, active, niveau_acces, invitation_id)
+values (associate.user_id, associate.collectivite_id, true, associate.niveau, associate.invitation_id)
+on conflict (user_id, collectivite_id)
+    do update set active        = true,
+                  niveau_acces  = associate.niveau,
+                  invitation_id = associate.invitation_id;
+$$ language sql;
+comment on function utilisateur.associate is
+    'Associe un utilisateur à une collectivité avec un niveau d''accès.';
+
+
+create function
+    utilisateur.invite(
+    collectivite_id integer,
+    email text,
+    niveau niveau_acces
+)
+    returns uuid
+as
+$$
+insert into utilisateur.invitation (niveau, email, collectivite_id, created_by)
+values (invite.niveau, invite.email, invite.collectivite_id, auth.uid())
+returning id;
+$$ language sql;
+comment on function utilisateur.invite is
+    'Crée une invitation et renvoie son id.';
+
+
+-- API exposed RPCs.
+create function add_user(
+    collectivite_id integer,
+    email text,
+    niveau niveau_acces
+) returns json
+as
+$$
+declare
+    existing_user    auth.users;
+    conflicting_user bool;
+    invitation_id    uuid;
+begin
+    if have_edition_acces(collectivite_id) or is_service_role()
+    then
+        select *
+        from auth.users u
+        where u.email = add_user.email
+        into existing_user;
+
+        if FOUND
+        then
+            -- There is an existing user matching the email.
+            select count(*) > 0
+            from private_utilisateur_droit pud
+            where add_user.collectivite_id = pud.collectivite_id
+              and existing_user.id = pud.user_id
+            into conflicting_user;
+
+            if conflicting_user
+            then
+                if (select count(*) > 0
+                    from private_utilisateur_droit pud
+                    where add_user.collectivite_id = pud.collectivite_id
+                      and existing_user.id = pud.user_id
+                      and active = true)
+                then
+                    -- The existing user is already associated with our collectivite.
+                    perform set_config('response.status', '409', true); -- 409: Conflict
+                    return json_build_object(
+                            'error', 'L''utilisateur est déjà associé à cette collectivité.'
+                        );
+                else
+                    -- The existing user's rights to the collectivite had been desactivated.
+                    update private_utilisateur_droit
+                    set active      = true,
+                        modified_at = now(),
+                        niveau_acces=add_user.niveau
+                    where user_id = existing_user.id
+                      and private_utilisateur_droit.collectivite_id = add_user.collectivite_id;
+
+                    return json_build_object(
+                            'added', true,
+                            'message', 'Accès de l''utilisateur ré-activés.'
+                        );
+                end if;
+            else
+                -- Associate the existing user with our collectivite.
+                perform utilisateur.associate(
+                        add_user.collectivite_id,
+                        existing_user.id,
+                        add_user.niveau,
+                        null
+                    );
+                return json_build_object(
+                        'added', true,
+                        'message', 'Utilisateur ajouté.'
+                    );
+            end if;
+
+        else
+            -- No user matching the email was found, we should invite them.
+            select utilisateur.invite(
+                           add_user.collectivite_id,
+                           add_user.email,
+                           add_user.niveau
+                       )
+            into invitation_id;
+            return json_build_object(
+                    'invitation_id', invitation_id,
+                    'message', 'Invitation créée.'
+                );
+        end if;
+    else
+        -- Not admin nor service role.
+        perform set_config('response.status', '403', true); -- 403: Forbidden
+        return json_build_object('error', 'Vous n''êtes pas administrateur de cette collectivité.');
+    end if;
+end;
+$$ language plpgsql security definer;
+comment on function add_user is
+    'Ajoute un utilisateur à une collectivité avec un niveau d''accès.
+        Si l''utilisateur
+        - est déjà associé à la collectivité renvoie une erreur 409.
+        - est dans la base, renvoie un message json {"added": true}.
+        - n''est pas dans la base, renvoie un message json { "invitation_id": uuid }.';
+
+
+create function
+    consume_invitation(id uuid)
+    returns void
+as
+$$
+declare
+    invitation utilisateur.invitation;
+begin
+    if is_authenticated()
+    then
+        -- The current user is authenticated.
+        select *
+        from utilisateur.invitation i
+        where i.id = consume_invitation.id
+        into invitation;
+
+        if invitation.pending
+        then
+            -- The invitation is still pending (hasn't been consumed).
+            -- Mark the invitation as consumed.
+            update utilisateur.invitation i
+            set accepted_at = now()
+            where i.id = invitation.id;
+
+            -- Associate the user to the collectivité.
+            perform utilisateur.associate(
+                    invitation.collectivite_id,
+                    auth.uid(),
+                    invitation.niveau,
+                    invitation.id
+                );
+
+            perform set_config('response.status', '201', true); -- 201: Created
+        else
+            -- The invitation is consumed.
+            perform set_config('response.status', '403', true); -- 403: Forbidden
+        end if;
+    else
+        -- Not authenticated.
+        perform set_config('response.status', '401', true); -- 401: Unauthorized
+    end if;
+end;
+$$ language plpgsql security definer;
+comment on function consume_invitation is
+    'Permet à l''utilisateur d''utiliser une invitation pour rejoindre une collectivité.'
+        ' Renvoie un code 201 en cas de succès.'
+        ' L''invitation n''est plus utilisable par la suite.';
+
+COMMIT;

--- a/data_layer/sqitch/revert/utilisateur/dcp@v2.60.0.sql
+++ b/data_layer/sqitch/revert/utilisateur/dcp@v2.60.0.sql
@@ -1,0 +1,14 @@
+-- Deploy tet:dcp to pg
+-- requires: base
+
+BEGIN;
+
+drop trigger after_insert_droit on dcp;
+drop function after_insert_dcp_add_rights;
+drop function est_verifie;
+drop function est_support;
+drop table utilisateur_verifie;
+drop table utilisateur_support;
+
+
+COMMIT;

--- a/data_layer/sqitch/revert/utilisateur/invitation_v2.sql
+++ b/data_layer/sqitch/revert/utilisateur/invitation_v2.sql
@@ -1,103 +1,54 @@
--- Revert tet:utilisateur/invitation_v2 from pg
+-- Deploy tet:utilisateur/invitation_v2 to pg
+-- requires: utilisateur/niveaux_acces
 
 BEGIN;
 
-drop function consume_invitation(id uuid);
-drop function add_user(collectivite_id integer, email text, niveau niveau_acces);
-drop function utilisateur.invite(collectivite_id integer, email text, niveau niveau_acces);
-drop function utilisateur.associate(collectivite_id integer, user_id uuid, niveau niveau_acces, invitation_id uuid);
-alter table private_utilisateur_droit drop constraint unique_user_collectivite;
-alter table private_utilisateur_droit drop column invitation_id;
-drop table utilisateur.invitation;
-
-
--- replay invitation v1
-create table private_collectivite_invitation
-(
-    id              uuid primary key         default gen_random_uuid(),
-    role_name       role_name                                          not null,
-    collectivite_id integer references collectivite                    not null,
-    created_by      uuid references auth.users                         not null,
-    created_at      timestamp with time zone default CURRENT_TIMESTAMP not null
-);
-alter table private_collectivite_invitation
-    enable row level security;
-create policy allow_read
-    on private_collectivite_invitation
-    for select
-    using (is_any_role_on(collectivite_id));
-create policy allow_insert
-    on private_collectivite_invitation
-    for insert
-    with check (is_referent_of(collectivite_id));
-
-
-create or replace function create_agent_invitation(collectivite_id integer)
-    returns json
+create or replace function
+    consume_invitation(id uuid)
+    returns void
 as
 $$
 declare
-    invitation_id uuid;
+    invitation utilisateur.invitation;
 begin
-    if is_referent_of(create_agent_invitation.collectivite_id)
+    if is_authenticated()
     then
-        select gen_random_uuid() into invitation_id;
-        insert into private_collectivite_invitation
-        values (invitation_id, 'agent', create_agent_invitation.collectivite_id, auth.uid());
-        return json_build_object('message', 'L''invitation a été crée.', 'id', invitation_id);
-    else
-        perform set_config('response.status', '401', true);
-        return json_build_object('error', 'Vous n''êtes pas le référent de cette collectivité.');
-    end if;
-end
-$$ language plpgsql security definer;
+        -- The current user is authenticated.
+        select *
+        from utilisateur.invitation i
+        where i.id = consume_invitation.id
+        into invitation;
 
-create function latest_invitation(collectivite_id integer)
-    returns json
-as
-$$
-declare
-    param_collectivite_id integer;
-    invitation_id         uuid;
-begin
-    select collectivite_id into param_collectivite_id;
-    if is_any_role_on(collectivite_id)
-    then
-        select into invitation_id id
-        from private_collectivite_invitation
-        where private_collectivite_invitation.collectivite_id = param_collectivite_id;
-        return json_build_object('id', invitation_id);
+        if invitation.pending
+        then
+            -- The invitation is still pending (hasn't been consumed).
+            -- Mark the invitation as consumed.
+            update utilisateur.invitation i
+            set accepted_at = now()
+            where i.id = invitation.id;
+
+            -- Associate the user to the collectivité.
+            perform utilisateur.associate(
+                    invitation.collectivite_id,
+                    auth.uid(),
+                    invitation.niveau,
+                    invitation.id
+                );
+
+            perform set_config('response.status', '201', true); -- 201: Created
+        else
+            -- The invitation is consumed.
+            perform set_config('response.status', '403', true); -- 403: Forbidden
+        end if;
     else
-        perform set_config('response.status', '401', true);
-        return json_build_object('error', 'Vous n''avez pas rejoint cette collectivité.');
+        -- Not authenticated.
+        perform set_config('response.status', '401', true); -- 401: Unauthorized
     end if;
 end;
-$$ language plpgsql;
-
-create or replace function accept_invitation(invitation_id uuid)
-    returns json
-as
-$$
-declare
-    invitation_collectivite_id integer;
-begin
-    select into invitation_collectivite_id collectivite_id
-    from private_collectivite_invitation
-    where id = invitation_id;
-    if (is_any_role_on(invitation_collectivite_id))
-    then
-        perform set_config('response.status', '401', true);
-        return json_build_object('error', 'Vous avez déjà rejoint cette collectivité.');
-    else
-        insert into private_utilisateur_droit(user_id, collectivite_id, role_name, active)
-        select auth.uid(), collectivite_id, role_name, true
-        from private_collectivite_invitation
-        where id = invitation_id
-        order by created_at
-        limit 1;
-        return json_build_object('message', 'Vous avez rejoint cette collectivité.');
-    end if;
-end
 $$ language plpgsql security definer;
+comment on function consume_invitation is
+    'Permet à l''utilisateur d''utiliser une invitation pour rejoindre une collectivité.'
+        ' Renvoie un code 201 en cas de succès.'
+        ' L''invitation n''est plus utilisable par la suite.';
 
 COMMIT;

--- a/data_layer/sqitch/revert/utilisateur/invitation_v2@v2.60.0.sql
+++ b/data_layer/sqitch/revert/utilisateur/invitation_v2@v2.60.0.sql
@@ -1,0 +1,103 @@
+-- Revert tet:utilisateur/invitation_v2 from pg
+
+BEGIN;
+
+drop function consume_invitation(id uuid);
+drop function add_user(collectivite_id integer, email text, niveau niveau_acces);
+drop function utilisateur.invite(collectivite_id integer, email text, niveau niveau_acces);
+drop function utilisateur.associate(collectivite_id integer, user_id uuid, niveau niveau_acces, invitation_id uuid);
+alter table private_utilisateur_droit drop constraint unique_user_collectivite;
+alter table private_utilisateur_droit drop column invitation_id;
+drop table utilisateur.invitation;
+
+
+-- replay invitation v1
+create table private_collectivite_invitation
+(
+    id              uuid primary key         default gen_random_uuid(),
+    role_name       role_name                                          not null,
+    collectivite_id integer references collectivite                    not null,
+    created_by      uuid references auth.users                         not null,
+    created_at      timestamp with time zone default CURRENT_TIMESTAMP not null
+);
+alter table private_collectivite_invitation
+    enable row level security;
+create policy allow_read
+    on private_collectivite_invitation
+    for select
+    using (is_any_role_on(collectivite_id));
+create policy allow_insert
+    on private_collectivite_invitation
+    for insert
+    with check (is_referent_of(collectivite_id));
+
+
+create or replace function create_agent_invitation(collectivite_id integer)
+    returns json
+as
+$$
+declare
+    invitation_id uuid;
+begin
+    if is_referent_of(create_agent_invitation.collectivite_id)
+    then
+        select gen_random_uuid() into invitation_id;
+        insert into private_collectivite_invitation
+        values (invitation_id, 'agent', create_agent_invitation.collectivite_id, auth.uid());
+        return json_build_object('message', 'L''invitation a été crée.', 'id', invitation_id);
+    else
+        perform set_config('response.status', '401', true);
+        return json_build_object('error', 'Vous n''êtes pas le référent de cette collectivité.');
+    end if;
+end
+$$ language plpgsql security definer;
+
+create function latest_invitation(collectivite_id integer)
+    returns json
+as
+$$
+declare
+    param_collectivite_id integer;
+    invitation_id         uuid;
+begin
+    select collectivite_id into param_collectivite_id;
+    if is_any_role_on(collectivite_id)
+    then
+        select into invitation_id id
+        from private_collectivite_invitation
+        where private_collectivite_invitation.collectivite_id = param_collectivite_id;
+        return json_build_object('id', invitation_id);
+    else
+        perform set_config('response.status', '401', true);
+        return json_build_object('error', 'Vous n''avez pas rejoint cette collectivité.');
+    end if;
+end;
+$$ language plpgsql;
+
+create or replace function accept_invitation(invitation_id uuid)
+    returns json
+as
+$$
+declare
+    invitation_collectivite_id integer;
+begin
+    select into invitation_collectivite_id collectivite_id
+    from private_collectivite_invitation
+    where id = invitation_id;
+    if (is_any_role_on(invitation_collectivite_id))
+    then
+        perform set_config('response.status', '401', true);
+        return json_build_object('error', 'Vous avez déjà rejoint cette collectivité.');
+    else
+        insert into private_utilisateur_droit(user_id, collectivite_id, role_name, active)
+        select auth.uid(), collectivite_id, role_name, true
+        from private_collectivite_invitation
+        where id = invitation_id
+        order by created_at
+        limit 1;
+        return json_build_object('message', 'Vous avez rejoint cette collectivité.');
+    end if;
+end
+$$ language plpgsql security definer;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -485,3 +485,6 @@ site/contact 2023-09-01T12:37:28Z Florian <florian@derfurth.com> # Permet de sto
 utilisateur/usage [utilisateur/usage@v2.59.0] 2023-09-07T07:46:54Z Florian <florian@derfurth.com> # Ajoute le tracking des exports
 plan_action/export [plan_action/export@v2.49.0] 2023-08-25T10:07:37Z Marc Rutkowski <marc@attractive-media.fr> # Ajoute le tri des fiches par titre dans l'export
 @v2.60.0 2023-09-07T09:36:40Z Florian <florian@derfurth.com> # Amélioration des exports plan d'action
+
+utilisateur/dcp [utilisateur/dcp@v2.60.0] 2023-09-18T13:54:20Z Amandine Jacquelin <conta@LanceLibre> # Gère le conflit potentiel avec consume_invitation
+utilisateur/invitation_v2 [utilisateur/invitation_v2@v2.60.0] 2023-09-18T13:56:52Z Amandine Jacquelin <conta@LanceLibre> # Ajoute le droit vérifié dans consume_invitation

--- a/data_layer/sqitch/verify/utilisateur/dcp.sql
+++ b/data_layer/sqitch/verify/utilisateur/dcp.sql
@@ -2,14 +2,6 @@
 
 BEGIN;
 
-select user_id, verifie
-from utilisateur_verifie where false;
-
-select user_id, support
-from utilisateur_support where false;
-
-select has_function_privilege('est_verifie()', 'execute');
-select has_function_privilege('est_support()', 'execute');
 select has_function_privilege('after_insert_dcp_add_rights()', 'execute');
 
 ROLLBACK;

--- a/data_layer/sqitch/verify/utilisateur/dcp@v2.60.0.sql
+++ b/data_layer/sqitch/verify/utilisateur/dcp@v2.60.0.sql
@@ -1,0 +1,15 @@
+-- Verify tet:dcp on pg
+
+BEGIN;
+
+select user_id, verifie
+from utilisateur_verifie where false;
+
+select user_id, support
+from utilisateur_support where false;
+
+select has_function_privilege('est_verifie()', 'execute');
+select has_function_privilege('est_support()', 'execute');
+select has_function_privilege('after_insert_dcp_add_rights()', 'execute');
+
+ROLLBACK;

--- a/data_layer/sqitch/verify/utilisateur/invitation_v2.sql
+++ b/data_layer/sqitch/verify/utilisateur/invitation_v2.sql
@@ -2,26 +2,6 @@
 
 BEGIN;
 
-select id,
-       niveau,
-       email,
-       collectivite_id,
-       created_by,
-       created_at,
-       accepted_at,
-       consumed,
-       pending
-from utilisateur.invitation
-where false;
-
-select invitation_id
-from private_utilisateur_droit
-where false;
-
-select has_function_privilege('utilisateur.associate(integer, uuid, niveau_acces, uuid)', 'execute');
-select has_function_privilege('utilisateur.invite(integer, text,  niveau_acces)', 'execute');
-
-select has_function_privilege('add_user(integer, text, niveau_acces)', 'execute');
 select has_function_privilege('consume_invitation(uuid)', 'execute');
 
 ROLLBACK;

--- a/data_layer/sqitch/verify/utilisateur/invitation_v2@v2.60.0.sql
+++ b/data_layer/sqitch/verify/utilisateur/invitation_v2@v2.60.0.sql
@@ -1,0 +1,27 @@
+-- Verify tet:utilisateur/invitation_v2 on pg
+
+BEGIN;
+
+select id,
+       niveau,
+       email,
+       collectivite_id,
+       created_by,
+       created_at,
+       accepted_at,
+       consumed,
+       pending
+from utilisateur.invitation
+where false;
+
+select invitation_id
+from private_utilisateur_droit
+where false;
+
+select has_function_privilege('utilisateur.associate(integer, uuid, niveau_acces, uuid)', 'execute');
+select has_function_privilege('utilisateur.invite(integer, text,  niveau_acces)', 'execute');
+
+select has_function_privilege('add_user(integer, text, niveau_acces)', 'execute');
+select has_function_privilege('consume_invitation(uuid)', 'execute');
+
+ROLLBACK;


### PR DESCRIPTION
L'ajout du nouvel utilisateur dans la table dcp et l'execution de la fonction consume_invitation ne se fait pas dans le même ordre selon l'environnement.