### PR TITLE
dl: Justification des statuts détaillés

### DIFF
--- a/api_tests/lib/database.types.ts
+++ b/api_tests/lib/database.types.ts
@@ -5271,45 +5271,6 @@ export interface Database {
           }
         ]
       }
-      commune_pop_legale: {
-        Row: {
-          codarr: string | null
-          codcan: string | null
-          codcom: string | null
-          coddep: string | null
-          codreg: string | null
-          com: string | null
-          pcap: number | null
-          pmun: number | null
-          ptot: number | null
-          reg: string | null
-        }
-        Insert: {
-          codarr?: string | null
-          codcan?: string | null
-          codcom?: string | null
-          coddep?: string | null
-          codreg?: string | null
-          com?: string | null
-          pcap?: number | null
-          pmun?: number | null
-          ptot?: number | null
-          reg?: string | null
-        }
-        Update: {
-          codarr?: string | null
-          codcan?: string | null
-          codcom?: string | null
-          coddep?: string | null
-          codreg?: string | null
-          com?: string | null
-          pcap?: number | null
-          pmun?: number | null
-          ptot?: number | null
-          reg?: string | null
-        }
-        Relationships: []
-      }
       confidentialite_crud: {
         Row: {
           c: Database["public"]["Enums"]["confidentialite_option_crud"]
@@ -11134,6 +11095,343 @@ export interface Database {
             foreignKeyName: "justification_question_id_fkey"
             columns: ["question_id"]
             referencedRelation: "report_question"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      justification_ajustement: {
+        Row: {
+          action_id: string
+          collectivite_id: number
+          modified_at: string
+          modified_by: string
+          texte: string
+        }
+        Insert: {
+          action_id: string
+          collectivite_id: number
+          modified_at: string
+          modified_by?: string
+          texte: string
+        }
+        Update: {
+          action_id?: string
+          collectivite_id?: number
+          modified_at?: string
+          modified_by?: string
+          texte?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "justification_ajustement_action_id_fkey"
+            columns: ["action_id"]
+            referencedRelation: "action_relation"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_membre_crm"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_plan_action"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivites_crm"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "late_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "action_snippet"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_plan_action_premier_usage"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "action_statuts"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "active_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "auditeurs"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "audits"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_card"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_carte_identite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_identite"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_niveau_acces"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "comparaison_scores_audit"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "crm_collectivites"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "crm_usages"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "named_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "question_display"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "question_thematique_completude"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_active_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_completude"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_completude_compute"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_plan_action_hebdo"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_plan_action_premier_usage"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_plan_action_usage"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_score"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "site_labellisation"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "stats_active_real_collectivites"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "stats_carte_collectivite_active"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "stats_locales_engagement_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "suivi_audit"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "carte_collectivite_active"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_action_statut"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_labellisation"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_plan_action"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_referentiel"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_utilisateur"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "crm_usages"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "engagement_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "locales_engagement_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "locales_pourcentage_completude"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "rattachement"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_indicateur_resultat"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_reponse_binaire"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_reponse_choix"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_reponse_proportion"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_scores"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_modified_by_fkey"
+            columns: ["modified_by"]
+            referencedRelation: "users"
             referencedColumns: ["id"]
           }
         ]
@@ -23385,7 +23683,6 @@ export interface Database {
       col_is_null:
         | {
             Args: {
-              schema_name: unknown
               table_name: unknown
               column_name: unknown
               description?: string
@@ -23394,6 +23691,7 @@ export interface Database {
           }
         | {
             Args: {
+              schema_name: unknown
               table_name: unknown
               column_name: unknown
               description?: string
@@ -23403,7 +23701,6 @@ export interface Database {
       col_not_null:
         | {
             Args: {
-              schema_name: unknown
               table_name: unknown
               column_name: unknown
               description?: string
@@ -23412,6 +23709,7 @@ export interface Database {
           }
         | {
             Args: {
+              schema_name: unknown
               table_name: unknown
               column_name: unknown
               description?: string
@@ -23589,10 +23887,6 @@ export interface Database {
       }
       diag:
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string
-          }
-        | {
             Args: {
               msg: string
             }
@@ -23602,6 +23896,10 @@ export interface Database {
             Args: {
               msg: unknown
             }
+            Returns: string
+          }
+        | {
+            Args: Record<PropertyKey, never>
             Returns: string
           }
         | {
@@ -23721,7 +24019,19 @@ export interface Database {
             Args: {
               fiche_action_action: unknown
             }
-            Returns: unknown[]
+            Returns: {
+              collectivite_id: number | null
+              date_fin_provisoire: string | null
+              id: number | null
+              modified_at: string | null
+              niveau_priorite:
+                | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
+                | null
+              pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
+              plans: unknown[] | null
+              statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
+              titre: string | null
+            }[]
           }
         | {
             Args: {
@@ -25392,6 +25702,44 @@ export interface Database {
       time_bucket:
         | {
             Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -25473,44 +25821,6 @@ export interface Database {
             Args: {
               bucket_width: number
               ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
             }
             Returns: number
           }

--- a/app.territoiresentransitions.react/src/types/database.types.ts
+++ b/app.territoiresentransitions.react/src/types/database.types.ts
@@ -5271,45 +5271,6 @@ export interface Database {
           }
         ]
       }
-      commune_pop_legale: {
-        Row: {
-          codarr: string | null
-          codcan: string | null
-          codcom: string | null
-          coddep: string | null
-          codreg: string | null
-          com: string | null
-          pcap: number | null
-          pmun: number | null
-          ptot: number | null
-          reg: string | null
-        }
-        Insert: {
-          codarr?: string | null
-          codcan?: string | null
-          codcom?: string | null
-          coddep?: string | null
-          codreg?: string | null
-          com?: string | null
-          pcap?: number | null
-          pmun?: number | null
-          ptot?: number | null
-          reg?: string | null
-        }
-        Update: {
-          codarr?: string | null
-          codcan?: string | null
-          codcom?: string | null
-          coddep?: string | null
-          codreg?: string | null
-          com?: string | null
-          pcap?: number | null
-          pmun?: number | null
-          ptot?: number | null
-          reg?: string | null
-        }
-        Relationships: []
-      }
       confidentialite_crud: {
         Row: {
           c: Database["public"]["Enums"]["confidentialite_option_crud"]
@@ -11134,6 +11095,343 @@ export interface Database {
             foreignKeyName: "justification_question_id_fkey"
             columns: ["question_id"]
             referencedRelation: "report_question"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      justification_ajustement: {
+        Row: {
+          action_id: string
+          collectivite_id: number
+          modified_at: string
+          modified_by: string
+          texte: string
+        }
+        Insert: {
+          action_id: string
+          collectivite_id: number
+          modified_at: string
+          modified_by?: string
+          texte: string
+        }
+        Update: {
+          action_id?: string
+          collectivite_id?: number
+          modified_at?: string
+          modified_by?: string
+          texte?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "justification_ajustement_action_id_fkey"
+            columns: ["action_id"]
+            referencedRelation: "action_relation"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_membre_crm"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_plan_action"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivites_crm"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "late_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "action_snippet"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_plan_action_premier_usage"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "action_statuts"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "active_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "auditeurs"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "audits"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_card"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_carte_identite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_identite"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_niveau_acces"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "comparaison_scores_audit"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "crm_collectivites"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "crm_usages"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "named_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "question_display"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "question_thematique_completude"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_active_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_completude"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_completude_compute"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_plan_action_hebdo"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_plan_action_premier_usage"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_plan_action_usage"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "retool_score"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "site_labellisation"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "stats_active_real_collectivites"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "stats_carte_collectivite_active"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "stats_locales_engagement_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "suivi_audit"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "carte_collectivite_active"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_action_statut"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_labellisation"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_plan_action"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_referentiel"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "collectivite_utilisateur"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "crm_usages"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "engagement_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "locales_engagement_collectivite"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "locales_pourcentage_completude"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "rattachement"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_indicateur_resultat"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_reponse_binaire"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_reponse_choix"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_reponse_proportion"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_collectivite_id_fkey"
+            columns: ["collectivite_id"]
+            referencedRelation: "report_scores"
+            referencedColumns: ["collectivite_id"]
+          },
+          {
+            foreignKeyName: "justification_ajustement_modified_by_fkey"
+            columns: ["modified_by"]
+            referencedRelation: "users"
             referencedColumns: ["id"]
           }
         ]
@@ -23385,7 +23683,6 @@ export interface Database {
       col_is_null:
         | {
             Args: {
-              schema_name: unknown
               table_name: unknown
               column_name: unknown
               description?: string
@@ -23394,6 +23691,7 @@ export interface Database {
           }
         | {
             Args: {
+              schema_name: unknown
               table_name: unknown
               column_name: unknown
               description?: string
@@ -23403,7 +23701,6 @@ export interface Database {
       col_not_null:
         | {
             Args: {
-              schema_name: unknown
               table_name: unknown
               column_name: unknown
               description?: string
@@ -23412,6 +23709,7 @@ export interface Database {
           }
         | {
             Args: {
+              schema_name: unknown
               table_name: unknown
               column_name: unknown
               description?: string
@@ -23589,10 +23887,6 @@ export interface Database {
       }
       diag:
         | {
-            Args: Record<PropertyKey, never>
-            Returns: string
-          }
-        | {
             Args: {
               msg: string
             }
@@ -23602,6 +23896,10 @@ export interface Database {
             Args: {
               msg: unknown
             }
+            Returns: string
+          }
+        | {
+            Args: Record<PropertyKey, never>
             Returns: string
           }
         | {
@@ -23721,7 +24019,19 @@ export interface Database {
             Args: {
               fiche_action_action: unknown
             }
-            Returns: unknown[]
+            Returns: {
+              collectivite_id: number | null
+              date_fin_provisoire: string | null
+              id: number | null
+              modified_at: string | null
+              niveau_priorite:
+                | Database["public"]["Enums"]["fiche_action_niveaux_priorite"]
+                | null
+              pilotes: Database["public"]["CompositeTypes"]["personne"][] | null
+              plans: unknown[] | null
+              statut: Database["public"]["Enums"]["fiche_action_statuts"] | null
+              titre: string | null
+            }[]
           }
         | {
             Args: {
@@ -25392,6 +25702,44 @@ export interface Database {
       time_bucket:
         | {
             Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              bucket_width: number
+              ts: number
+              offset: number
+            }
+            Returns: number
+          }
+        | {
+            Args: {
               bucket_width: unknown
               ts: string
             }
@@ -25473,44 +25821,6 @@ export interface Database {
             Args: {
               bucket_width: number
               ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
-            }
-            Returns: number
-          }
-        | {
-            Args: {
-              bucket_width: number
-              ts: number
-              offset: number
             }
             Returns: number
           }

--- a/data_layer/sqitch/deploy/referentiel/justification_ajustement.sql
+++ b/data_layer/sqitch/deploy/referentiel/justification_ajustement.sql
@@ -1,0 +1,100 @@
+-- Deploy tet:referentiel/justification_ajustement to pg
+
+BEGIN;
+
+create table justification_ajustement
+(
+    collectivite_id integer references collectivite               not null,
+    action_id       action_id references action_relation          not null,
+    texte           text                                          not null,
+    modified_by     uuid references auth.users default auth.uid() not null,
+    modified_at     timestamp with time zone                      not null,
+    primary key (collectivite_id, action_id)
+);
+comment on table justification_ajustement is 'Les justifications pour les scores ajustés.';
+
+select private.add_modified_at_trigger('public', 'justification_ajustement');
+select private.add_modified_by_trigger('public', 'justification_ajustement');
+
+alter table justification_ajustement
+    enable row level security;
+
+create policy allow_read
+    on justification_ajustement
+    for select
+    using (est_verifie() or have_lecture_acces(collectivite_id));
+
+create policy allow_insert
+    on justification_ajustement
+    for insert
+    with check (have_edition_acces(collectivite_id) OR est_auditeur_action(collectivite_id, action_id));
+
+create policy allow_update
+    on justification_ajustement
+    for update
+    using (have_edition_acces(collectivite_id) OR est_auditeur_action(collectivite_id, action_id));
+
+
+create table historique.justification_ajustement
+(
+    id                   serial primary key,
+    collectivite_id      integer   not null,
+    action_id            action_id not null,
+    modified_by          uuid,
+    previous_modified_by uuid,
+    modified_at          timestamp with time zone,
+    previous_modified_at timestamp with time zone,
+    texte                text      not null,
+    previous_texte       text
+);
+
+create function historique.save_justification_ajustement() returns trigger
+as
+$$
+declare
+    updated integer;
+begin
+    -- debounce
+    update historique.justification_ajustement
+    set texte       = new.texte,
+        modified_at = new.modified_at
+    where id in (select id
+                 from historique.justification_ajustement
+                 where collectivite_id = new.collectivite_id
+                   and action_id = new.action_id
+                   and modified_by = new.modified_by
+                   and modified_at > new.modified_at - interval '1 hour'
+                 order by modified_by desc
+                 limit 1)
+    returning id into updated;
+
+    if updated is null
+    then
+        insert into historique.justification_ajustement (collectivite_id,
+                                                         action_id,
+                                                         modified_by,
+                                                         previous_modified_by,
+                                                         modified_at,
+                                                         previous_modified_at,
+                                                         texte,
+                                                         previous_texte)
+        values (new.collectivite_id,
+                new.action_id,
+                auth.uid(),
+                old.modified_by,
+                new.modified_at,
+                old.modified_at,
+                new.texte,
+                old.texte);
+    end if;
+    return new;
+end ;
+$$ language plpgsql security definer;
+
+create trigger save_history
+    after insert or update
+    on justification_ajustement
+    for each row
+execute procedure historique.save_justification_ajustement();
+
+COMMIT;

--- a/data_layer/sqitch/revert/referentiel/justification_ajustement.sql
+++ b/data_layer/sqitch/revert/referentiel/justification_ajustement.sql
@@ -1,0 +1,10 @@
+-- Revert tet:referentiel/justification_ajustement from pg
+
+BEGIN;
+
+drop trigger save_history on justification_ajustement;
+drop function historique.save_justification_ajustement;
+drop table historique.justification_ajustement;
+drop table justification_ajustement;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -512,3 +512,5 @@ evaluation/thematique_completude [evaluation/thematique_completude@v2.64.0] 2023
 
 plan_action/fiches [plan_action/fiches@v2.64.1] 2023-09-28T07:46:21Z Florian <florian@derfurth.com> # Répare la relation calculée entre fiche_resume et fiche_action_action
 @v2.65.0 2023-09-28T12:52:40Z Florian <florian@derfurth.com> # Répare les fiches action dans les référentiels
+
+referentiel/justification_ajustement 2023-10-04T09:01:17Z Florian <florian@derfurth.com> # Ajoute la justification des ajustements des scores détaillés

--- a/data_layer/sqitch/verify/referentiel/justification_ajustement.sql
+++ b/data_layer/sqitch/verify/referentiel/justification_ajustement.sql
@@ -1,0 +1,7 @@
+-- Verify tet:referentiel/justification_ajustement on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;

--- a/data_layer/tests/evaluation/reponse_historique.sql
+++ b/data_layer/tests/evaluation/reponse_historique.sql
@@ -343,7 +343,7 @@ select ok((select count(*) = 2 from historique.reponse_proportion), 'Il devrait 
 select isnt((select modified_by from historique.reponse_proportion limit 1),
             (select modified_by from historique.reponse_proportion limit 1 offset 1),
             'Les deux réponses historisées devraient avoir des `modified_by` différents.');
-select is((select array_agg(modified_by_nom) from historique),
+select is((select array_agg(modified_by_nom order by modified_at desc) from historique),
           (select array ['Yili Didi', 'Yolo Dodo']),
           'La vue client devrait lister une modification par Yili suivie d''une par Yolo');
 
@@ -376,7 +376,7 @@ select ok((select count(*) = 2 from historique.reponse_choix), 'Il devrait y avo
 select isnt((select modified_by from historique.reponse_choix limit 1),
             (select modified_by from historique.reponse_choix limit 1 offset 1),
             'Les deux réponses historisées devraient avoir des `modified_by` différents.');
-select is((select array_agg(modified_by_nom) from historique),
+select is((select array_agg(modified_by_nom order by modified_at desc) from historique),
           (select array ['Yili Didi', 'Yolo Dodo']),
           'La vue client devrait lister une modification par Yili suivie d''une par Yolo');
 
@@ -409,7 +409,7 @@ select ok((select count(*) = 2 from historique.reponse_binaire), 'Il devrait y a
 select isnt((select modified_by from historique.reponse_binaire limit 1),
             (select modified_by from historique.reponse_binaire limit 1 offset 1),
             'Les deux réponses historisées devraient avoir des `modified_by` différents.');
-select is((select array_agg(modified_by_nom) from historique),
+select is((select array_agg(modified_by_nom order by modified_at desc) from historique),
           (select array ['Yili Didi', 'Yolo Dodo']),
           'La vue client devrait lister une modification par Yili suivie d''une par Yolo');
 

--- a/data_layer/tests/referentiel/action_precision_historique.sql
+++ b/data_layer/tests/referentiel/action_precision_historique.sql
@@ -127,7 +127,7 @@ select ok((select count(*) = 2 from historique.action_precision), 'Il devrait y 
 select isnt((select modified_by from historique.action_precision limit 1),
             (select modified_by from historique.action_precision limit 1 offset 1),
             'Les deux statuts historisés devraient avoir des `modified_by` différents.');
-select is((select array_agg(modified_by_nom) from historique),
+select is((select array_agg(modified_by_nom order by modified_at desc) from historique),
           (select array ['Yili Didi', 'Yolo Dodo']),
           'La vue client devrait lister une modification par Yili suivie d''une par Yolo');
 

--- a/data_layer/tests/referentiel/action_statut_historique.sql
+++ b/data_layer/tests/referentiel/action_statut_historique.sql
@@ -146,7 +146,7 @@ select ok((select count(*) = 2 from historique.action_statut), 'Il devrait y avo
 select isnt((select modified_by from historique.action_statut limit 1),
             (select modified_by from historique.action_statut limit 1 offset 1),
             'Les deux statuts historisés devraient avoir des `modified_by` différents.');
-select is((select array_agg(modified_by_nom) from historique),
+select is((select array_agg(modified_by_nom order by modified_at desc) from historique),
           (select array ['Yili Didi', 'Yolo Dodo']),
           'La vue client devrait lister une modification par Yili suivie d''une par Yolo');
 

--- a/data_layer/tests/referentiel/justification_historique.sql
+++ b/data_layer/tests/referentiel/justification_historique.sql
@@ -1,0 +1,139 @@
+begin;
+select plan(6);
+select test.disable_evaluation_api();
+
+-- Enlève le trigger pour tester le debounce - sinon les modified_at sont toujours égaux à now().
+drop trigger if exists modified_at on justification_ajustement;
+
+-- Les séquences des justifications à sauvegarder.
+create table test.sequence_statut
+(
+    action_id   action_id,
+    texte       text,
+    modified_at timestamptz
+);
+
+-- Fonction utilitaire pour upsert un statut.
+create function
+    test.upsert_statut(
+    collectivite_id integer,
+    seq test.sequence_statut
+) returns void
+as
+$$
+insert into justification_ajustement(collectivite_id, action_id, texte, modified_at)
+values (upsert_statut.collectivite_id, seq.action_id, seq.texte, seq.modified_at)
+on conflict (collectivite_id, action_id)
+    do update set texte          = excluded.texte,
+                  modified_by         = excluded.modified_by,
+                  modified_at         = excluded.modified_at;
+$$ language sql;
+
+
+
+-- Supprime les données avant un scénario.
+create function
+    test.clear()
+    returns void
+as
+$$
+truncate test.sequence_statut;
+truncate justification_ajustement;
+truncate historique.justification_ajustement;
+select test_clear_history();
+$$ language sql;
+
+
+-- Scénario Yolo mets à jour un statut
+select test.clear();
+select test.identify_as('yolo@dodo.com');
+
+--- On définit la séquence
+insert into test.sequence_statut (action_id, texte, modified_at)
+values -- un jour à quelques minutes d'intervalle
+       ('cae_1.1.1.1.1', 'pas_fait', '2022-09-10 06:02 +0'),
+       ('cae_1.1.1.1.1', 'non_renseigne', '2022-09-10 06:03 +0'),
+       ('cae_1.1.1.1.1', 'programme', '2022-09-10 06:04 +0'),
+       -- puis le lendemain
+       ('cae_1.1.1.1.1', 'fait', '2022-09-11 08:00 +0');
+
+--- On joue la séquence
+select test.upsert_statut(1, seq)
+from test.sequence_statut seq;
+
+--- On vérifie l'état.
+select results_eq(
+           -- les justifications
+               'select action_id, texte, modified_by, modified_at from justification_ajustement;',
+           -- le statut le plus récent de la séquence
+               'select action_id, texte, auth.uid(), modified_at from test.sequence_statut order by modified_at desc limit 1;',
+               'Les justifications devraient contenir uniquement le statut le plus récent de la séquence.'
+           );
+
+select bag_eq(
+           -- l'historique des justifications
+               'select action_id, texte, modified_by, modified_at from historique.justification_ajustement;',
+           -- les justifications de la séquence
+               'select action_id, texte, auth.uid(), modified_at from test.sequence_statut order by modified_at desc limit 2;',
+               'L''historique devrait contenir uniquement les deux justifications les plus récents de la séquence.'
+           );
+
+-- Scénario Yolo puis Yili mettent à jour des justifications
+select test.clear();
+
+--- On définit la séquence
+insert into test.sequence_statut (action_id, texte, modified_at)
+values -- un jour à quelques minutes d'intervalle
+       ('cae_1.1.1.1.1', 'pas_fait', '2022-09-10 06:02 +0'),
+       ('cae_1.1.1.1.1', 'non_renseigne', '2022-09-10 06:03 +0'),
+       ('cae_1.1.1.1.1', 'programme', '2022-09-10 06:04 +0'),
+       ('cae_1.1.1.1.1', 'fait', '2022-09-10 06:05 +0');
+
+-- Yolo réponds deux fois.
+select test.identify_as('yolo@dodo.com');
+select test.upsert_statut(1, seq)
+from test.sequence_statut seq
+-- les deux premières lignes
+limit 2;
+
+-- Puis Yili réponds deux fois.
+select test.identify_as('yili@didi.com');
+select test.upsert_statut(1, seq)
+from test.sequence_statut seq
+-- les deux dernières lignes
+limit 2 offset 2;
+
+-- On vérifie les résultats.
+select ok((select count(*) = 1 from justification_ajustement), 'Il devrait y avoir un seul statut.');
+select ok((select count(*) = 2 from historique.justification_ajustement),
+          'Il devrait y avoir deux justifications historisés.');
+select isnt((select modified_by from historique.justification_ajustement limit 1),
+            (select modified_by from historique.justification_ajustement limit 1 offset 1),
+            'Les deux justifications historisés devraient avoir des `modified_by` différents.');
+
+
+-- Scénario Yolo modifie des justifications d'actions différentes.
+select test.clear();
+
+--- On définit la séquence
+insert into test.sequence_statut (action_id, texte, modified_at)
+values -- un jour à quelques minutes d'intervalle
+       ('cae_1.1.1.1.1', 'pas_fait', '2022-09-10 06:02 +0'),
+       ('cae_1.1.1.2.1', 'non_renseigne', '2022-09-10 06:03 +0'),
+       ('cae_1.1.1.3.1', 'programme', '2022-09-10 06:04 +0');
+
+--- On joue la séquence.
+select test.identify_as('yolo@dodo.com');
+select test.upsert_statut(1, seq)
+from test.sequence_statut seq;
+
+select bag_eq(
+           -- l'historique des justifications
+               'select action_id, texte, modified_by, modified_at from historique.justification_ajustement;',
+           -- toutes les justifications de la séquence
+               'select action_id, texte, auth.uid(), modified_at from test.sequence_statut;',
+               'L''historique devrait contenir toutes les justifications de la séquence.'
+           );
+
+
+rollback;


### PR DESCRIPTION
Permet d'enregistrer les justification des statuts détaillés dans la table `justification_ajustement` avec les champs suivants:

```typescript
type justification = {
          action_id: string
          collectivite_id: number
          texte: string
          modified_at?: string
          modified_by?: string
 }
```