### PR TITLE
Amélioration justification de l'ajustement manuel du score

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionCard.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionCard.tsx
@@ -128,13 +128,15 @@ const SubActionCard = ({
           {(auditStatus !== 'audit_en_cours' || openSubAction) && (
             <>
               <ActionCommentaire action={subAction} className="mb-10" />
-              {subAction.referentiel === 'cae' && avancement === 'detaille' && (
+              {subAction.referentiel === 'cae' &&
+              avancement === 'detaille' &&
+              subAction.children?.length ? (
                 <ActionJustification
                   action={subAction}
                   className="mb-10"
                   title="Justification de l’ajustement manuel du score"
                 />
-              )}
+              ) : null}
             </>
           )}
 


### PR DESCRIPTION
N'affiche pas le champ de justification de l'ajustement manuel du score lorsque la sous-action n'a pas de tâches