### PR TITLE
dl: PostHog 🦔

### DIFF
--- a/data_layer/sqitch/deploy/stats/posthog.sql
+++ b/data_layer/sqitch/deploy/stats/posthog.sql
@@ -1,0 +1,253 @@
+-- Deploy tet:stats/posthog to pg
+
+BEGIN;
+
+create function stats.posthog_properties(dcp) returns jsonb
+    language sql
+    stable security definer
+begin
+    atomic
+    return json_build_object(
+            'email', $1.email,
+            'name', $1.prenom || ' ' || $1.nom,
+            'fonctions',
+            (select array_agg(distinct m.fonction)
+             from private_collectivite_membre m
+                      join private_utilisateur_droit pud
+                           on m.user_id = pud.user_id and m.collectivite_id = pud.collectivite_id
+             where m.user_id = $1.user_id
+               and m.fonction is not null
+               and pud.active),
+            'auditeur', ($1.user_id in (table auditeurs))
+           );
+end;
+
+create function
+    stats.posthog_event(visite)
+    returns table
+            (
+                event       text,
+                timestamp   text,
+                distinct_id text,
+                properties  jsonb
+            )
+    language sql
+    stable
+    security definer
+    rows 1
+begin
+    atomic
+    select '$pageview'     as event,
+           v.user_id       as distinct_id,
+           to_json(v.time) as timestamp,
+           json_build_object(
+                   '$current_url',
+                   'app/' || (case when v.collectivite_id is null then '' else 'collectivite/' end) || v.page,
+                   'page', v.page,
+                   'tag', v.tag,
+                   'onglet', v.onglet,
+                   'collectivite_id', v.collectivite_id::text,
+                   'niveau_acces', d.niveau_acces,
+                   '$set', stats.posthog_properties(p),
+                   '$groups', json_build_object('collectivite', c.collectivite_id::text)
+           )               as properties
+
+    from $1 v
+             join collectivite c using (collectivite_id)
+             join private_utilisateur_droit d using (user_id, collectivite_id)
+             join dcp p using (user_id);
+end;
+
+
+create function
+    stats.posthog_event(usage)
+    returns table
+            (
+                event       text,
+                timestamp   text,
+                distinct_id text,
+                properties  jsonb
+            )
+    language sql
+    stable
+    security definer
+    rows 1
+begin
+    atomic
+    select u.fonction || '_' || u.action as event,
+           u.user_id                     as distinct_id,
+           to_json(u.time)               as timestamp,
+           json_build_object(
+                   '$current_url',
+                   'app/' || (case when u.collectivite_id is null then '' else 'collectivite/' end) || u.page,
+                   'page', u.page,
+                   'collectivite_id', u.collectivite_id::text,
+                   'niveau_acces', d.niveau_acces,
+                   '$set', stats.posthog_properties(p),
+                   '$groups', json_build_object('collectivite', c.collectivite_id::text)
+           )                             as properties
+
+    from $1 u
+             join collectivite c using (collectivite_id)
+             join private_utilisateur_droit d using (user_id, collectivite_id)
+             join dcp p using (user_id);
+end;
+
+
+create function
+    stats.posthog_event(collectivite)
+    returns table
+            (
+                event       text,
+                distinct_id text,
+                properties  jsonb
+            )
+    language sql
+    stable
+    security definer
+    rows 1
+begin
+    atomic
+    select '$groupidentify'        as event,
+           c.collectivite_id::text as distinct_id,
+           json_build_object(
+                   '$group_type', 'collectivite',
+                   '$group_key', c.collectivite_id::text,
+                   '$group_set', to_jsonb(c) || to_jsonb(scu)
+           )                       as properties
+    from $1 c
+             join stats.crm_usages scu on c.id = scu.collectivite_id
+             join stats.collectivite sc using (collectivite_id);
+end;
+
+
+create view stats.modification_event
+as
+select 'reponse'       as type,
+       modified_at     as time,
+       modified_by     as user_id,
+       collectivite_id as collectivite_id
+from historique.reponse_binaire
+where modified_by is not null
+union all
+select 'reponse', modified_at, modified_by, collectivite_id
+from historique.reponse_choix
+where modified_by is not null
+union all
+select 'reponse', modified_at, modified_by, collectivite_id
+from historique.reponse_proportion
+where modified_by is not null
+union all
+select 'justification', modified_at, modified_by, collectivite_id
+from historique.justification
+where modified_by is not null;
+
+create view stats.creation_event
+as
+select 'fiche'         as type,
+       created_at      as time,
+       modified_by     as user_id,
+       collectivite_id as collectivite_id
+from fiche_action
+where modified_by is not null
+union all
+select 'plan', created_at, modified_by, collectivite_id
+from axe
+where parent is null
+  and modified_by is not null
+union all
+select 'discussion', created_at, created_by, collectivite_id
+from action_discussion;
+
+create function
+    stats.posthog_event(stats.creation_event)
+    returns table
+            (
+                event       text,
+                timestamp   text,
+                distinct_id text,
+                properties  jsonb
+            )
+    language sql
+    stable
+    security definer
+    rows 1
+begin
+    atomic
+    select ev.type || '_' || 'creation' as event,
+           ev.user_id                   as distinct_id,
+           to_json(ev.time)             as timestamp,
+           json_object(
+                   'collectivite_id', ev.collectivite_id::text,
+                   'niveau_acces', d.niveau_acces,
+                   '$set', json_object('email', p.email, 'name', p.prenom || ' ' || p.nom),
+                   '$groups', json_object('collectivite', c.collectivite_id::text)
+           )                            as properties
+
+    from $1 ev
+             join collectivite c using (collectivite_id)
+             join private_utilisateur_droit d using (user_id, collectivite_id)
+             join dcp p using (user_id)
+    order by ev.time;
+end;
+
+create function
+    stats.posthog_event(stats.modification_event)
+    returns table
+            (
+                event       text,
+                timestamp   text,
+                distinct_id text,
+                properties  jsonb
+            )
+    language sql
+    stable
+    security definer
+    rows 1
+begin
+    atomic
+    select ev.type || '_' || 'modification' as event,
+           ev.user_id                       as distinct_id,
+           to_json(ev.time)                 as timestamp,
+           json_object(
+                   'collectivite_id', ev.collectivite_id::text,
+                   'niveau_acces', d.niveau_acces,
+                   '$set', json_object('email', p.email, 'name', p.prenom || ' ' || p.nom),
+                   '$groups', json_object('collectivite', c.collectivite_id::text)
+           )                                as properties
+
+    from $1 ev
+             join collectivite c using (collectivite_id)
+             join private_utilisateur_droit d using (user_id, collectivite_id)
+             join dcp p using (user_id)
+    order by ev.time;
+end;
+
+
+create table stats.posthog_configuration
+(
+    id      serial primary key,
+    api_url text not null,
+    api_key text not null
+);
+
+create function
+    stats.send_posthog_events(events jsonb[])
+    returns bigint
+begin
+    atomic
+
+    select net.http_post(
+                   url := conf.api_url,
+                   body := jsonb_build_object(
+                           'api_key', conf.api_key,
+                           'batch', $1
+                           )
+           )
+    from stats.posthog_configuration conf
+    order by id desc
+    limit 1;
+end;
+
+
+COMMIT;

--- a/data_layer/sqitch/deploy/stats/posthog.sql
+++ b/data_layer/sqitch/deploy/stats/posthog.sql
@@ -28,6 +28,7 @@ begin
            )
     from f;
 end;
+comment on function posthog.properties(dcp) is 'Les user properties pour PostHog.';
 
 create function
     posthog.event(visite)
@@ -64,6 +65,7 @@ begin
     from dcp p
     where p.user_id = $1.user_id;
 end;
+comment on function posthog.event(visite) is 'Un event de type pageview.';
 
 create function
     posthog.event(usage)
@@ -98,6 +100,7 @@ begin
     from dcp p
     where p.user_id = $1.user_id;
 end;
+comment on function posthog.event(usage) is 'Un event de type pageview.';
 
 
 create function
@@ -125,6 +128,7 @@ begin
              join stats.crm_usages scu using (collectivite_id)
     where $1.id = scu.collectivite_id;
 end;
+comment on function posthog.event(visite) is 'Un event de type $groupidentify pour mettre à jour les données sur PostHog.';
 
 
 create view posthog.modification
@@ -151,6 +155,7 @@ select 'justification', modified_at, modified_by, collectivite_id
 from historique.justification
          join stats.collectivite_active using (collectivite_id)
 where modified_by is not null;
+comment on view posthog.modification is 'Les actions de modification destinées à être transformées en events.';
 
 create view posthog.creation
 as
@@ -170,6 +175,7 @@ where parent is null
 union all
 select 'discussion', created_at, created_by, collectivite_id
 from action_discussion;
+comment on view posthog.creation is 'Les actions de creation destinées à être transformées en events.';
 
 create function
     posthog.event(posthog.creation)
@@ -201,6 +207,7 @@ begin
     where $1.collectivite_id = d.collectivite_id
       and $1.user_id = d.user_id;
 end;
+comment on function posthog.event(posthog.creation) is 'Événement de creation.';
 
 create function
     posthog.event(posthog.modification)
@@ -232,9 +239,10 @@ begin
     where $1.collectivite_id = d.collectivite_id
       and $1.user_id = d.user_id;
 end;
+comment on function posthog.event(posthog.modification) is 'Événement de modification.';
 
 create function
-    posthog.event(range tstzrange)
+    posthog.event(tstzrange)
     returns setof jsonb
     language sql
     stable
@@ -257,6 +265,8 @@ begin
     from posthog.creation e
     where $1 @> time;
 end;
+comment on function posthog.event(tstzrange) is 'Événement(s) en jsonb pour une plage de temps.';
+
 
 create table posthog.configuration
 (
@@ -264,6 +274,7 @@ create table posthog.configuration
     api_url text not null,
     api_key text not null
 );
+comment on table posthog.configuration is 'La configuration de PostHog.';
 
 create function
     posthog.send_events(events jsonb[])
@@ -281,5 +292,6 @@ begin
     order by id desc
     limit 1;
 end;
+comment on function posthog.send_events is 'Envoie un lot d''événements à PostHog.';
 
 COMMIT;

--- a/data_layer/sqitch/deploy/stats/posthog.sql
+++ b/data_layer/sqitch/deploy/stats/posthog.sql
@@ -151,7 +151,7 @@ begin
              join stats.crm_usages scu using (collectivite_id)
     where $1.id = scu.collectivite_id;
 end;
-comment on function posthog.event(visite) is 'Un event de type $groupidentify pour mettre à jour les données sur PostHog.';
+comment on function posthog.event(public.collectivite) is 'Un event de type $groupidentify pour mettre à jour les données sur PostHog.';
 
 
 create view posthog.modification

--- a/data_layer/sqitch/deploy/stats/posthog.sql
+++ b/data_layer/sqitch/deploy/stats/posthog.sql
@@ -31,6 +31,29 @@ end;
 comment on function posthog.properties(dcp) is 'Les user properties pour PostHog.';
 
 create function
+    posthog.event(dcp)
+    returns table
+            (
+                event       text,
+                "timestamp" text,
+                distinct_id text,
+                properties  jsonb
+            )
+    language sql
+    stable
+    security definer
+    rows 1
+begin
+    atomic
+    select '$identify'                                       as event,
+           to_json($1.modified_at)                           as timestamp,
+           $1.user_id                                        as distinct_id,
+           json_build_object('$set', posthog.properties($1)) as properties;
+end;
+comment on function posthog.event(dcp) is 'Un event de type identify pour mettre à jour les données sur PostHog.';
+
+
+create function
     posthog.event(visite)
     returns table
             (

--- a/data_layer/sqitch/deploy/stats/posthog.sql
+++ b/data_layer/sqitch/deploy/stats/posthog.sql
@@ -128,18 +128,22 @@ select 'reponse'       as type,
        modified_by     as user_id,
        collectivite_id as collectivite_id
 from historique.reponse_binaire
+         join stats.collectivite_active using (collectivite_id)
 where modified_by is not null
 union all
 select 'reponse', modified_at, modified_by, collectivite_id
 from historique.reponse_choix
+         join stats.collectivite_active using (collectivite_id)
 where modified_by is not null
 union all
 select 'reponse', modified_at, modified_by, collectivite_id
 from historique.reponse_proportion
+         join stats.collectivite_active using (collectivite_id)
 where modified_by is not null
 union all
 select 'justification', modified_at, modified_by, collectivite_id
 from historique.justification
+         join stats.collectivite_active using (collectivite_id)
 where modified_by is not null;
 
 create view stats.creation_event
@@ -149,10 +153,12 @@ select 'fiche'         as type,
        modified_by     as user_id,
        collectivite_id as collectivite_id
 from fiche_action
+         join stats.collectivite_active using (collectivite_id)
 where modified_by is not null
 union all
 select 'plan', created_at, modified_by, collectivite_id
 from axe
+         join stats.collectivite_active using (collectivite_id)
 where parent is null
   and modified_by is not null
 union all

--- a/data_layer/sqitch/deploy/stats/posthog.sql
+++ b/data_layer/sqitch/deploy/stats/posthog.sql
@@ -256,5 +256,29 @@ begin
     limit 1;
 end;
 
+create function
+    stats.posthog_event(range tstzrange)
+    returns setof jsonb
+    language sql
+    stable
+    security definer
+begin
+    atomic
+    select to_jsonb(stats.posthog_event(v))
+    from visite v
+    where $1 @> time
+    union all
+    select to_jsonb(stats.posthog_event(u))
+    from usage u
+    where $1 @> time
+    union all
+    select to_jsonb(stats.posthog_event(e))
+    from stats.modification_event e
+    where $1 @> time
+    union all
+    select to_jsonb(stats.posthog_event(e))
+    from stats.creation_event e
+    where $1 @> time;
+end;
 
 COMMIT;

--- a/data_layer/sqitch/deploy/stats/posthog.sql
+++ b/data_layer/sqitch/deploy/stats/posthog.sql
@@ -300,7 +300,7 @@ create table posthog.configuration
 comment on table posthog.configuration is 'La configuration de PostHog.';
 
 create function
-    posthog.send_events(events jsonb[])
+    posthog.send_events(events jsonb)
     returns bigint
 begin
     atomic

--- a/data_layer/sqitch/revert/stats/posthog.sql
+++ b/data_layer/sqitch/revert/stats/posthog.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
--- XXX Add DDLs here.
+drop schema posthog cascade;
 
 COMMIT;

--- a/data_layer/sqitch/revert/stats/posthog.sql
+++ b/data_layer/sqitch/revert/stats/posthog.sql
@@ -1,0 +1,7 @@
+-- Revert tet:stats/posthog from pg
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -565,3 +565,5 @@ stats/amplitude [stats/amplitude@v2.83.0] 2023-11-27T14:52:26Z Florian <florian@
 
 plan_action/type 2023-12-04T16:57:09Z Florian <florian@derfurth.com> # La relation entre un plan et son type
 @v2.86.0 2023-12-07T16:49:24Z Florian <florian@derfurth.com> # Permet de typer les plans
+
+stats/posthog 2023-12-06T14:08:54Z Florian <florian@derfurth.com> # Ajoute PostHog pour le suivi de l'utilisation de notre produit

--- a/data_layer/sqitch/verify/stats/posthog.sql
+++ b/data_layer/sqitch/verify/stats/posthog.sql
@@ -1,0 +1,7 @@
+-- Verify tet:stats/posthog on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
Intégration PostHog, exemple d'utilisation pour envoyer les événements de la veille :

```sql
with events as (
-- événements creation, modification, visite et usage
                select posthog.event(tstzrange(current_date::date - interval '1 day', current_date::date)) as event
                union all
-- les données des collectivités telles que dans le CRM
                select to_jsonb(posthog.event(collectivite))
                from collectivite)
-- call à l'API
select posthog.send_events(jsonb_agg(events.event))
from events;
```