### PR TITLE
Surcharge les styles pour la zone de prévisualisation du storybook

### DIFF
--- a/packages/ui/.storybook/preview.css
+++ b/packages/ui/.storybook/preview.css
@@ -1,0 +1,4 @@
+/** retire le souligné dsfr sous les liens dans la doc générée par le sb */
+.sbdocs [href] {
+    background-image: none;
+}

--- a/packages/ui/.storybook/preview.js
+++ b/packages/ui/.storybook/preview.js
@@ -1,2 +1,5 @@
 // charge les styles globaux
 import '../src/global.css';
+
+// surcharge les styles pour la zone de prévisualisation
+import './preview.css';


### PR DESCRIPTION
Evite que les liens devant les stories soient soulignés