### PR TITLE
Ajoute les alias d'import dans le package `ui`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35851,6 +35851,95 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz",
+      "integrity": "sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.2",
       "license": "MIT",
@@ -39248,6 +39337,7 @@
         "storybook": "^7.6.1",
         "tailwindcss": "^3.3.5",
         "ts-loader": "^9.5.0",
+        "tsconfig-paths-webpack-plugin": "^4.1.0",
         "typescript": "^5.2.2",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4"

--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -1,6 +1,10 @@
 /**
  * Configuration générale du storybook
  */
+
+const path = require('path');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
 module.exports = {
   // pattern de recherche des stories
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.tsx'],
@@ -20,7 +24,7 @@ module.exports = {
               require.resolve('style-loader'),
               {
                 loader: require.resolve('css-loader'),
-                options: { importLoaders: 1 },
+                options: {importLoaders: 1},
               },
               require.resolve('postcss-loader'),
             ],
@@ -29,6 +33,18 @@ module.exports = {
       },
     },
   ],
+
+  // ajoute les alias de chemins d'import définis dans la config TS
+  webpackFinal: config => {
+    config.resolve.plugins = config.resolve.plugins || [];
+    config.resolve.plugins.push(
+      new TsconfigPathsPlugin({
+        configFile: path.resolve(__dirname, '../tsconfig.json'),
+      })
+    );
+
+    return config;
+  },
 
   framework: '@storybook/react-webpack5',
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,6 +53,7 @@
     "storybook": "^7.6.1",
     "tailwindcss": "^3.3.5",
     "ts-loader": "^9.5.0",
+    "tsconfig-paths-webpack-plugin": "^4.1.0",
     "typescript": "^5.2.2",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4"

--- a/packages/ui/src/design-system/buttons/button/Button.stories.tsx
+++ b/packages/ui/src/design-system/buttons/button/Button.stories.tsx
@@ -1,8 +1,8 @@
 import {useRef} from 'react';
 import {Meta, StoryObj} from '@storybook/react';
 
-import {Button} from './Button';
-import DoubleCheckIcon from '../../../assets/DoubleCheckIcon';
+import {Button} from '@design-system/buttons/button/Button';
+import DoubleCheckIcon from '@assets/DoubleCheckIcon';
 
 const meta: Meta<typeof Button> = {
   title: 'Design System/Button',

--- a/packages/ui/src/design-system/buttons/button/ButtonContent.tsx
+++ b/packages/ui/src/design-system/buttons/button/ButtonContent.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 
-import {Icon, IconSize} from '../../icons/Icon';
+import {Icon, IconSize} from '@design-system/icons/Icon';
 import {buttonThemeClassnames} from '../theme';
 import {ButtonContentProps, ButtonSize} from '../types';
 

--- a/packages/ui/src/design-system/modal/Modal.stories.tsx
+++ b/packages/ui/src/design-system/modal/Modal.stories.tsx
@@ -2,7 +2,7 @@ import {Meta, StoryObj} from '@storybook/react';
 import {forwardRef} from 'react';
 
 import {Modal} from './Modal';
-import {Button} from '../buttons/button/Button';
+import {Button} from '@design-system/buttons/button/Button';
 
 const meta: Meta<typeof Modal> = {
   title: 'Design System/Modale',

--- a/packages/ui/src/design-system/modal/Modal.tsx
+++ b/packages/ui/src/design-system/modal/Modal.tsx
@@ -12,8 +12,8 @@ import {
 } from '@floating-ui/react';
 import classNames from 'classnames';
 
-import {Button} from '../buttons/button/Button';
-import {preset} from '../../tailwind-preset';
+import {preset} from '@tailwind-preset';
+import {Button} from '@design-system/buttons/button/Button';
 
 type Size = 'sm' | 'md' | 'lg' | 'xl';
 

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -12,7 +12,13 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": "./src/",
+    "paths": {
+      "@tailwind-preset": ["tailwind-preset.ts"],
+      "@design-system/*": ["design-system/*"],
+      "@assets/*": ["assets/*"]
+    }
   },
   "include": ["src/*.ts", "src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 /** Configuration Webpack */
 module.exports = function (env, argv) {
@@ -32,9 +33,11 @@ module.exports = function (env, argv) {
       }),
     ],
 
-    // ordre de résolution des modules js par extension
     resolve: {
+      // ordre de résolution des modules js par extension
       extensions: ['.tsx', '.ts', '.js'],
+      // ajoute les alias de chemins d'import définis dans la config TS
+      plugins: [new TsconfigPathsPlugin()],
     },
 
     // exclut du bundle les bibliothèques externes


### PR DESCRIPTION
Permet d'utiliser des alias d'import plutôt que des chemins relatifs.

Ajouter l'option `  "typescript.preferences.importModuleSpecifier": "non-relative",` dans le fichier `settings.json` de VSCode pour que l'autocomplétion (Intellisense) favorise les alias.